### PR TITLE
DashScope: Support deep customization of wanx model request parameters

### DIFF
--- a/models/langchain4j-community-dashscope/src/main/java/dev/langchain4j/community/model/dashscope/WanxHelper.java
+++ b/models/langchain4j-community-dashscope/src/main/java/dev/langchain4j/community/model/dashscope/WanxHelper.java
@@ -6,14 +6,18 @@ import com.alibaba.dashscope.exception.NoApiKeyException;
 import com.alibaba.dashscope.utils.OSSUtils;
 import dev.langchain4j.data.image.Image;
 import dev.langchain4j.internal.Utils;
-
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
-import java.util.*;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
 public class WanxHelper {
 
@@ -25,7 +29,7 @@ public class WanxHelper {
                 .stream()
                 .map(resultMap -> resultMap.get("url"))
                 .map(url -> Image.builder().url(url).build())
-                .toList();
+                .collect(Collectors.toList());
     }
 
     static String imageUrl(Image image, String model, String apiKey) {

--- a/models/langchain4j-community-dashscope/src/main/java/dev/langchain4j/community/model/dashscope/WanxHelper.java
+++ b/models/langchain4j-community-dashscope/src/main/java/dev/langchain4j/community/model/dashscope/WanxHelper.java
@@ -13,12 +13,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
-import java.util.Base64;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.stream.Collectors;
+import java.util.*;
 
 public class WanxHelper {
 
@@ -30,7 +25,7 @@ public class WanxHelper {
                 .stream()
                 .map(resultMap -> resultMap.get("url"))
                 .map(url -> Image.builder().url(url).build())
-                .collect(Collectors.toList());
+                .toList();
     }
 
     static String imageUrl(Image image, String model, String apiKey) {
@@ -43,7 +38,7 @@ public class WanxHelper {
             try {
                 imageUrl = OSSUtils.upload(model, filePath, apiKey);
             } catch (NoApiKeyException e) {
-                throw new RuntimeException(e);
+                throw new IllegalArgumentException(e);
             }
         } else {
             throw new IllegalArgumentException("Failed to get image url from " + image);
@@ -69,7 +64,7 @@ public class WanxHelper {
         try {
             Files.copy(new ByteArrayInputStream(data), tmpFilePath, StandardCopyOption.REPLACE_EXISTING);
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new IllegalStateException(e);
         }
         return tmpFilePath.toAbsolutePath().toString();
     }

--- a/models/langchain4j-community-dashscope/src/main/java/dev/langchain4j/community/model/dashscope/WanxImageModel.java
+++ b/models/langchain4j-community-dashscope/src/main/java/dev/langchain4j/community/model/dashscope/WanxImageModel.java
@@ -172,7 +172,7 @@ public class WanxImageModel implements ImageModel {
         private WanxImageStyle style;
 
         public WanxImageModelBuilder() {
-            // This is public so it can be extended
+            // This is public, so it can be extended
             // By default with Lombok it becomes package private
         }
 

--- a/models/langchain4j-community-dashscope/src/main/java/dev/langchain4j/community/model/dashscope/WanxImageModel.java
+++ b/models/langchain4j-community-dashscope/src/main/java/dev/langchain4j/community/model/dashscope/WanxImageModel.java
@@ -43,16 +43,18 @@ public class WanxImageModel implements ImageModel {
     private final ImageSynthesis imageSynthesis;
     private Consumer<ImageSynthesisParam.ImageSynthesisParamBuilder<?, ?>> imageSynthesisParamCustomizer = p -> {};
 
-    public WanxImageModel(String baseUrl,
-                          String apiKey,
-                          String modelName,
-                          WanxImageRefMode refMode,
-                          Float refStrength,
-                          Integer seed,
-                          WanxImageSize size,
-                          WanxImageStyle style) {
+    public WanxImageModel(
+            String baseUrl,
+            String apiKey,
+            String modelName,
+            WanxImageRefMode refMode,
+            Float refStrength,
+            Integer seed,
+            WanxImageSize size,
+            WanxImageStyle style) {
         if (Utils.isNullOrBlank(apiKey)) {
-            throw new IllegalArgumentException("DashScope api key must be defined. It can be generated here: https://dashscope.console.aliyun.com/apiKey");
+            throw new IllegalArgumentException(
+                    "DashScope api key must be defined. It can be generated here: https://dashscope.console.aliyun.com/apiKey");
         }
         this.modelName = Utils.isNullOrBlank(modelName) ? WanxModelName.WANX_V1 : modelName;
         this.apiKey = apiKey;
@@ -61,12 +63,14 @@ public class WanxImageModel implements ImageModel {
         this.seed = seed;
         this.size = size;
         this.style = style;
-        this.imageSynthesis = Utils.isNullOrBlank(baseUrl) ? new ImageSynthesis() : new ImageSynthesis("text2image", baseUrl);
+        this.imageSynthesis =
+                Utils.isNullOrBlank(baseUrl) ? new ImageSynthesis() : new ImageSynthesis("text2image", baseUrl);
     }
 
     @Override
     public Response<Image> generate(String prompt) {
-        ImageSynthesisParam.ImageSynthesisParamBuilder<?, ?> builder = requestBuilder(prompt).n(1);
+        ImageSynthesisParam.ImageSynthesisParamBuilder<?, ?> builder =
+                requestBuilder(prompt).n(1);
 
         try {
             imageSynthesisParamCustomizer.accept(builder);
@@ -79,7 +83,8 @@ public class WanxImageModel implements ImageModel {
 
     @Override
     public Response<List<Image>> generate(String prompt, int n) {
-        ImageSynthesisParam.ImageSynthesisParamBuilder<?, ?> builder = requestBuilder(prompt).n(n);
+        ImageSynthesisParam.ImageSynthesisParamBuilder<?, ?> builder =
+                requestBuilder(prompt).n(n);
 
         try {
             imageSynthesisParamCustomizer.accept(builder);
@@ -94,9 +99,8 @@ public class WanxImageModel implements ImageModel {
     public Response<Image> edit(Image image, String prompt) {
         String imageUrl = imageUrl(image, modelName, apiKey);
 
-        ImageSynthesisParam.ImageSynthesisParamBuilder<?, ?> builder = requestBuilder(prompt)
-                .refImage(imageUrl)
-                .n(1);
+        ImageSynthesisParam.ImageSynthesisParamBuilder<?, ?> builder =
+                requestBuilder(prompt).refImage(imageUrl).n(1);
 
         if (imageUrl.startsWith("oss://")) {
             builder.header("X-DashScope-OssResourceResolve", "enable");
@@ -108,8 +112,8 @@ public class WanxImageModel implements ImageModel {
             List<Image> images = imagesFrom(result);
             if (images.isEmpty()) {
                 ImageSynthesisOutput output = result.getOutput();
-                String errorMessage = String.format("[%s] %s: %s",
-                        output.getTaskStatus(), output.getCode(), output.getMessage());
+                String errorMessage =
+                        String.format("[%s] %s: %s", output.getTaskStatus(), output.getCode(), output.getMessage());
                 throw new IllegalStateException(errorMessage);
             }
             return Response.from(images.get(0));
@@ -120,15 +124,13 @@ public class WanxImageModel implements ImageModel {
 
     public void setImageSynthesisParamCustomizer(
             Consumer<ImageSynthesisParam.ImageSynthesisParamBuilder<?, ?>> imageSynthesisParamCustomizer) {
-        ensureNotNull(imageSynthesisParamCustomizer, "imageSynthesisParamCustomizer");
-        this.imageSynthesisParamCustomizer = imageSynthesisParamCustomizer;
+        this.imageSynthesisParamCustomizer =
+                ensureNotNull(imageSynthesisParamCustomizer, "imageSynthesisParamCustomizer");
     }
 
     private ImageSynthesisParam.ImageSynthesisParamBuilder<?, ?> requestBuilder(String prompt) {
-        ImageSynthesisParam.ImageSynthesisParamBuilder<?, ?> builder = ImageSynthesisParam.builder()
-                .apiKey(apiKey)
-                .model(modelName)
-                .prompt(prompt);
+        ImageSynthesisParam.ImageSynthesisParamBuilder<?, ?> builder =
+                ImageSynthesisParam.builder().apiKey(apiKey).model(modelName).prompt(prompt);
 
         if (seed != null) {
             builder.seed(seed);
@@ -217,16 +219,7 @@ public class WanxImageModel implements ImageModel {
         }
 
         public WanxImageModel build() {
-            return new WanxImageModel(
-                    baseUrl,
-                    apiKey,
-                    modelName,
-                    refMode,
-                    refStrength,
-                    seed,
-                    size,
-                    style
-            );
+            return new WanxImageModel(baseUrl, apiKey, modelName, refMode, refStrength, seed, size, style);
         }
     }
 }

--- a/models/langchain4j-community-dashscope/src/main/java/dev/langchain4j/community/model/dashscope/WanxImageSize.java
+++ b/models/langchain4j-community-dashscope/src/main/java/dev/langchain4j/community/model/dashscope/WanxImageSize.java
@@ -1,5 +1,7 @@
 package dev.langchain4j.community.model.dashscope;
 
+import static dev.langchain4j.internal.Utils.isNullOrBlank;
+
 public enum WanxImageSize {
 
     SIZE_1024_1024("1024*1024"),
@@ -15,5 +17,23 @@ public enum WanxImageSize {
     @Override
     public String toString() {
         return size;
+    }
+
+    public String getSize() {
+        return size;
+    }
+
+    public static WanxImageSize of(String size) {
+        if (isNullOrBlank(size)) {
+            return null;
+        }
+
+        for (WanxImageSize imageSize : values()) {
+            if (imageSize.size.equalsIgnoreCase(size)) {
+                return imageSize;
+            }
+        }
+
+        return null;
     }
 }

--- a/models/langchain4j-community-dashscope/src/main/java/dev/langchain4j/community/model/dashscope/WanxImageSize.java
+++ b/models/langchain4j-community-dashscope/src/main/java/dev/langchain4j/community/model/dashscope/WanxImageSize.java
@@ -3,7 +3,6 @@ package dev.langchain4j.community.model.dashscope;
 import static dev.langchain4j.internal.Utils.isNullOrBlank;
 
 public enum WanxImageSize {
-
     SIZE_1024_1024("1024*1024"),
     SIZE_720_1280("720*1280"),
     SIZE_1280_720("1280*720");

--- a/models/langchain4j-community-dashscope/src/main/java/dev/langchain4j/community/model/dashscope/WanxImageStyle.java
+++ b/models/langchain4j-community-dashscope/src/main/java/dev/langchain4j/community/model/dashscope/WanxImageStyle.java
@@ -3,7 +3,6 @@ package dev.langchain4j.community.model.dashscope;
 import static dev.langchain4j.internal.Utils.isNullOrBlank;
 
 public enum WanxImageStyle {
-
     PHOTOGRAPHY("<photography>"),
     PORTRAIT("<portrait>"),
     CARTOON_3D("<3d cartoon>"),

--- a/models/langchain4j-community-dashscope/src/main/java/dev/langchain4j/community/model/dashscope/WanxImageStyle.java
+++ b/models/langchain4j-community-dashscope/src/main/java/dev/langchain4j/community/model/dashscope/WanxImageStyle.java
@@ -1,5 +1,7 @@
 package dev.langchain4j.community.model.dashscope;
 
+import static dev.langchain4j.internal.Utils.isNullOrBlank;
+
 public enum WanxImageStyle {
 
     PHOTOGRAPHY("<photography>"),
@@ -22,5 +24,23 @@ public enum WanxImageStyle {
     @Override
     public String toString() {
         return style;
+    }
+
+    public String getStyle() {
+        return style;
+    }
+
+    public static WanxImageStyle of(String style) {
+        if (isNullOrBlank(style)) {
+            return null;
+        }
+
+        for (WanxImageStyle imageStyle : values()) {
+            if (imageStyle.toString().equalsIgnoreCase(style)) {
+                return imageStyle;
+            }
+        }
+
+        return null;
     }
 }

--- a/models/langchain4j-community-dashscope/src/test/java/dev/langchain4j/community/model/dashscope/WanxImageModelIT.java
+++ b/models/langchain4j-community-dashscope/src/test/java/dev/langchain4j/community/model/dashscope/WanxImageModelIT.java
@@ -36,6 +36,26 @@ class WanxImageModelIT {
 
     @ParameterizedTest
     @MethodSource("dev.langchain4j.community.model.dashscope.WanxTestHelper#imageModelNameProvider")
+    void simple_image_generation_works_by_customize_request(String modelName) {
+        WanxImageModel model = WanxImageModel.builder()
+                .apiKey(apiKey())
+                .modelName(modelName)
+                .build();
+
+        model.setImageSynthesisParamCustomizer(builder -> {
+            builder.extraInput("lora_index", "wanx1.4.6_textlora_jianzhi1_20240816");
+            builder.extraInput("trigger_word", "papercut");
+        });
+
+        Response<Image> response = model.generate("Beautiful house on country side");
+
+        URI remoteImage = response.content().url();
+        log.info("Your remote image is here: {}", remoteImage);
+        assertThat(remoteImage).isNotNull();
+    }
+
+    @ParameterizedTest
+    @MethodSource("dev.langchain4j.community.model.dashscope.WanxTestHelper#imageModelNameProvider")
     void simple_image_edition_works_by_url(String modelName) {
         WanxImageModel model = WanxImageModel.builder()
                 .apiKey(apiKey())

--- a/models/langchain4j-community-dashscope/src/test/java/dev/langchain4j/community/model/dashscope/WanxImageModelIT.java
+++ b/models/langchain4j-community-dashscope/src/test/java/dev/langchain4j/community/model/dashscope/WanxImageModelIT.java
@@ -1,18 +1,17 @@
 package dev.langchain4j.community.model.dashscope;
 
+import static dev.langchain4j.community.model.dashscope.QwenTestHelper.apiKey;
+import static dev.langchain4j.community.model.dashscope.QwenTestHelper.multimodalImageData;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import dev.langchain4j.data.image.Image;
 import dev.langchain4j.model.output.Response;
+import java.net.URI;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.net.URI;
-
-import static dev.langchain4j.community.model.dashscope.QwenTestHelper.apiKey;
-import static dev.langchain4j.community.model.dashscope.QwenTestHelper.multimodalImageData;
-import static org.assertj.core.api.Assertions.assertThat;
 
 @EnabledIfEnvironmentVariable(named = "DASHSCOPE_API_KEY", matches = ".+")
 class WanxImageModelIT {
@@ -22,10 +21,8 @@ class WanxImageModelIT {
     @ParameterizedTest
     @MethodSource("dev.langchain4j.community.model.dashscope.WanxTestHelper#imageModelNameProvider")
     void simple_image_generation_works(String modelName) {
-        WanxImageModel model = WanxImageModel.builder()
-                .apiKey(apiKey())
-                .modelName(modelName)
-                .build();
+        WanxImageModel model =
+                WanxImageModel.builder().apiKey(apiKey()).modelName(modelName).build();
 
         Response<Image> response = model.generate("Beautiful house on country side");
 
@@ -37,10 +34,8 @@ class WanxImageModelIT {
     @ParameterizedTest
     @MethodSource("dev.langchain4j.community.model.dashscope.WanxTestHelper#imageModelNameProvider")
     void simple_image_generation_works_by_customize_request(String modelName) {
-        WanxImageModel model = WanxImageModel.builder()
-                .apiKey(apiKey())
-                .modelName(modelName)
-                .build();
+        WanxImageModel model =
+                WanxImageModel.builder().apiKey(apiKey()).modelName(modelName).build();
 
         model.setImageSynthesisParamCustomizer(builder -> {
             builder.extraInput("lora_index", "wanx1.4.6_textlora_jianzhi1_20240816");
@@ -57,10 +52,8 @@ class WanxImageModelIT {
     @ParameterizedTest
     @MethodSource("dev.langchain4j.community.model.dashscope.WanxTestHelper#imageModelNameProvider")
     void simple_image_edition_works_by_url(String modelName) {
-        WanxImageModel model = WanxImageModel.builder()
-                .apiKey(apiKey())
-                .modelName(modelName)
-                .build();
+        WanxImageModel model =
+                WanxImageModel.builder().apiKey(apiKey()).modelName(modelName).build();
 
         Image image = Image.builder()
                 .url("https://help-static-aliyun-doc.aliyuncs.com/assets/img/zh-CN/2476628361/p335710.png")
@@ -76,10 +69,8 @@ class WanxImageModelIT {
     @ParameterizedTest
     @MethodSource("dev.langchain4j.community.model.dashscope.WanxTestHelper#imageModelNameProvider")
     void simple_image_edition_works_by_data(String modelName) {
-        WanxImageModel model = WanxImageModel.builder()
-                .apiKey(apiKey())
-                .modelName(modelName)
-                .build();
+        WanxImageModel model =
+                WanxImageModel.builder().apiKey(apiKey()).modelName(modelName).build();
 
         Image image = Image.builder()
                 .base64Data(multimodalImageData())


### PR DESCRIPTION
## Change
The wanx model supports many deeply customized parameters, such as combining the customer's lora model to generate images. Here is a way to intervene in the request parameters of the wanx model.


## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [X] There are no breaking changes
- [X] I have added unit and integration tests for my change
- [X] I have manually run all the unit tests in _all_ modules, and they are all green
- [ ] I have manually run all integration tests in the module I have added/changed, and they are all green