### PR TITLE
[FEATURE] Add Lucene full-text content retriever

### DIFF
--- a/content-retrievers/langchain4j-community-lucene/README.md
+++ b/content-retrievers/langchain4j-community-lucene/README.md
@@ -1,0 +1,7 @@
+# LangChain4J Full-text Content Retriever Using Apache Lucene
+
+## About
+
+[LangChain4j](https://docs.langchain4j.dev/) full-text content retriever using [Apache Lucene](https://lucene.apache.org/). See [RAG (Retrieval-Augmented Generation)](https://docs.langchain4j.dev/tutorials/rag/).
+
+Retrieves content from Apache Lucene based on a full-text search, preserving `TextSegment` metadata. Includes CL100K token counts and similarity scores.

--- a/content-retrievers/langchain4j-community-lucene/pom.xml
+++ b/content-retrievers/langchain4j-community-lucene/pom.xml
@@ -42,9 +42,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest</artifactId>
-            <version>3.0</version>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/content-retrievers/langchain4j-community-lucene/pom.xml
+++ b/content-retrievers/langchain4j-community-lucene/pom.xml
@@ -32,6 +32,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.knuddels</groupId>
             <artifactId>jtokkit</artifactId>
         </dependency>

--- a/content-retrievers/langchain4j-community-lucene/pom.xml
+++ b/content-retrievers/langchain4j-community-lucene/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>dev.langchain4j</groupId>
+        <artifactId>langchain4j-community</artifactId>
+        <version>1.0.0-alpha2-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>langchain4j-community-lucene</artifactId>
+    <packaging>jar</packaging>
+    <name>LangChain4j :: Community :: Content Retriever :: Lucene</name>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.lucene</groupId>
+            <artifactId>lucene-core</artifactId>
+            <version>9.12.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.lucene</groupId>
+            <artifactId>lucene-queryparser</artifactId>
+            <version>9.12.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.knuddels</groupId>
+            <artifactId>jtokkit</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <version>3.0</version>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+</project>

--- a/content-retrievers/langchain4j-community-lucene/src/main/java/dev/langchain4j/rag/content/retriever/lucene/DirectoryFactory.java
+++ b/content-retrievers/langchain4j-community-lucene/src/main/java/dev/langchain4j/rag/content/retriever/lucene/DirectoryFactory.java
@@ -1,0 +1,51 @@
+package dev.langchain4j.rag.content.retriever.lucene;
+
+import static java.util.Objects.requireNonNull;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.MMapDirectory;
+
+/**
+ * Static factory for create Lucene directories.
+ */
+public class DirectoryFactory {
+
+    /**
+     * Create a memory mapped file-system based directory.
+     *
+     * @param directoryPath Path for the directory.
+     *
+     * @return Lucene directory
+     */
+    public static Directory fsDirectory(final Path directoryPath) {
+        requireNonNull(directoryPath, "No file system directory path provided");
+        try {
+            final Directory directory = new MMapDirectory(directoryPath);
+            return directory;
+        } catch (final Exception e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Create a memory mapped file-system based directory, in a temporary directory.
+     *
+     * @return Lucene directory
+     */
+    public static Directory tempDirectory() {
+        try {
+            final Path directoryPath = Files.createTempDirectory(Directory.class.getCanonicalName());
+            final Path newSubDirectory = Paths.get(directoryPath.toString(), Directory.class.getCanonicalName());
+            return fsDirectory(newSubDirectory);
+        } catch (final Exception e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+    private DirectoryFactory() {
+        // Prevent instantiation
+    }
+}

--- a/content-retrievers/langchain4j-community-lucene/src/main/java/dev/langchain4j/rag/content/retriever/lucene/DirectoryFactory.java
+++ b/content-retrievers/langchain4j-community-lucene/src/main/java/dev/langchain4j/rag/content/retriever/lucene/DirectoryFactory.java
@@ -1,6 +1,6 @@
 package dev.langchain4j.rag.content.retriever.lucene;
 
-import static java.util.Objects.requireNonNull;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -21,7 +21,7 @@ public class DirectoryFactory {
      * @return Lucene directory
      */
     public static Directory fsDirectory(final Path directoryPath) {
-        requireNonNull(directoryPath, "No file system directory path provided");
+        ensureNotNull(directoryPath, "directoryPath");
         try {
             final Directory directory = new MMapDirectory(directoryPath);
             return directory;

--- a/content-retrievers/langchain4j-community-lucene/src/main/java/dev/langchain4j/rag/content/retriever/lucene/DirectoryFactory.java
+++ b/content-retrievers/langchain4j-community-lucene/src/main/java/dev/langchain4j/rag/content/retriever/lucene/DirectoryFactory.java
@@ -20,12 +20,12 @@ public class DirectoryFactory {
      *
      * @return Lucene directory
      */
-    public static Directory fsDirectory(final Path directoryPath) {
+    public static Directory fsDirectory(Path directoryPath) {
         ensureNotNull(directoryPath, "directoryPath");
         try {
-            final Directory directory = new MMapDirectory(directoryPath);
+            Directory directory = new MMapDirectory(directoryPath);
             return directory;
-        } catch (final Exception e) {
+        } catch (Exception e) {
             throw new RuntimeException(e.getMessage(), e);
         }
     }
@@ -37,10 +37,10 @@ public class DirectoryFactory {
      */
     public static Directory tempDirectory() {
         try {
-            final Path directoryPath = Files.createTempDirectory(Directory.class.getCanonicalName());
-            final Path newSubDirectory = Paths.get(directoryPath.toString(), Directory.class.getCanonicalName());
+            Path directoryPath = Files.createTempDirectory(Directory.class.getCanonicalName());
+            Path newSubDirectory = Paths.get(directoryPath.toString(), Directory.class.getCanonicalName());
             return fsDirectory(newSubDirectory);
-        } catch (final Exception e) {
+        } catch (Exception e) {
             throw new RuntimeException(e.getMessage(), e);
         }
     }

--- a/content-retrievers/langchain4j-community-lucene/src/main/java/dev/langchain4j/rag/content/retriever/lucene/LuceneContentRetriever.java
+++ b/content-retrievers/langchain4j-community-lucene/src/main/java/dev/langchain4j/rag/content/retriever/lucene/LuceneContentRetriever.java
@@ -83,8 +83,9 @@ public final class LuceneContentRetriever implements ContentRetriever {
         public LuceneContentRetrieverBuilder contentFieldName(String contentFieldName) {
             if (contentFieldName == null || contentFieldName.isBlank()) {
                 this.contentFieldName = LuceneIndexer.CONTENT_FIELD_NAME;
+            } else {
+                this.contentFieldName = contentFieldName;
             }
-            this.contentFieldName = contentFieldName;
 
             return this;
         }
@@ -143,8 +144,9 @@ public final class LuceneContentRetriever implements ContentRetriever {
         public LuceneContentRetrieverBuilder tokenCountFieldName(String tokenCountFieldName) {
             if (tokenCountFieldName == null || tokenCountFieldName.isBlank()) {
                 this.tokenCountFieldName = LuceneIndexer.TOKEN_COUNT_FIELD_NAME;
+            } else {
+                this.tokenCountFieldName = tokenCountFieldName;
             }
-            this.tokenCountFieldName = tokenCountFieldName;
 
             return this;
         }

--- a/content-retrievers/langchain4j-community-lucene/src/main/java/dev/langchain4j/rag/content/retriever/lucene/LuceneContentRetriever.java
+++ b/content-retrievers/langchain4j-community-lucene/src/main/java/dev/langchain4j/rag/content/retriever/lucene/LuceneContentRetriever.java
@@ -13,8 +13,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.StoredValue;
@@ -34,6 +32,8 @@ import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.store.Directory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Full-text content retrieval using Apache Lucene for LangChain4J RAG.
@@ -163,7 +163,7 @@ public final class LuceneContentRetriever implements ContentRetriever {
         }
     }
 
-    private static final Logger LOGGER = Logger.getLogger(LuceneContentRetriever.class.getCanonicalName());
+    private static final Logger log = LoggerFactory.getLogger(LuceneContentRetriever.class);
 
     /**
      * Instantiate a builder for `LuceneContentRetriever`.
@@ -259,7 +259,7 @@ public final class LuceneContentRetriever implements ContentRetriever {
             return hits;
         } catch (final Throwable e) {
             // Catch Throwable, since Lucene can throw AssertionError
-            LOGGER.log(Level.INFO, String.format("Could not query <%s>", query), e);
+            log.info(String.format("Could not query <%s>", query), e);
             return Collections.emptyList();
         }
     }
@@ -281,7 +281,7 @@ public final class LuceneContentRetriever implements ContentRetriever {
             final QueryParser parser = new QueryParser(contentFieldName, new StandardAnalyzer());
             fullTextQuery = parser.parse(query);
         } catch (final ParseException e) {
-            LOGGER.log(Level.INFO, String.format("Could not create query <%s>", query), e);
+            log.info(String.format("Could not create query <%s>", query), e);
             return new MatchAllDocsQuery();
         }
 

--- a/content-retrievers/langchain4j-community-lucene/src/main/java/dev/langchain4j/rag/content/retriever/lucene/LuceneContentRetriever.java
+++ b/content-retrievers/langchain4j-community-lucene/src/main/java/dev/langchain4j/rag/content/retriever/lucene/LuceneContentRetriever.java
@@ -1,0 +1,348 @@
+package dev.langchain4j.rag.content.retriever.lucene;
+
+import static java.util.Objects.requireNonNull;
+
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.rag.content.Content;
+import dev.langchain4j.rag.content.ContentMetadata;
+import dev.langchain4j.rag.content.retriever.ContentRetriever;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.StoredValue;
+import org.apache.lucene.document.StoredValue.Type;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.index.StoredFields;
+import org.apache.lucene.queryparser.classic.ParseException;
+import org.apache.lucene.queryparser.classic.QueryParser;
+import org.apache.lucene.search.BooleanClause.Occur;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.FieldDoc;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.Sort;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.store.Directory;
+
+/**
+ * Full-text content retrieval using Apache Lucene for LangChain4J RAG.
+ */
+public final class LuceneContentRetriever implements ContentRetriever {
+
+    /**
+     * Builder for `LuceneContentRetriever`.
+     */
+    public static class LuceneContentRetrieverBuilder {
+
+        private Directory directory;
+        private boolean onlyMatches;
+        private int topNMatches;
+        private int maxTokenCount;
+        private String contentFieldName;
+        private String tokenCountFieldName;
+
+        private LuceneContentRetrieverBuilder() {
+            // Set defaults
+            onlyMatches = true;
+            topNMatches = 10;
+            maxTokenCount = Integer.MAX_VALUE;
+            contentFieldName = LuceneIndexer.CONTENT_FIELD_NAME;
+            tokenCountFieldName = LuceneIndexer.TOKEN_COUNT_FIELD_NAME;
+        }
+
+        /**
+         * Build an instance of `LuceneContentRetriever` using internal builder field values.
+         *
+         * @return New instance of `LuceneContentRetriever`
+         */
+        public LuceneContentRetriever build() {
+            if (directory == null) {
+                directory = DirectoryFactory.tempDirectory();
+            }
+            return new LuceneContentRetriever(
+                    directory, onlyMatches, topNMatches, maxTokenCount, contentFieldName, tokenCountFieldName);
+        }
+
+        public LuceneContentRetrieverBuilder contentFieldName(final String contentFieldName) {
+            if (contentFieldName == null || contentFieldName.isBlank()) {
+                this.contentFieldName = LuceneIndexer.CONTENT_FIELD_NAME;
+            }
+            this.contentFieldName = contentFieldName;
+
+            return this;
+        }
+
+        /**
+         * Sets the Lucene directory. If null, a temporary file-based directory is used.
+         *
+         * @param directory Lucene directory
+         * @return Builder
+         */
+        public LuceneContentRetrieverBuilder directory(final Directory directory) {
+            // Can be null
+            this.directory = directory;
+            return this;
+        }
+
+        /**
+         * Provides documents until the top N, even if there is no good match.
+         *
+         * @return Builder
+         */
+        public LuceneContentRetrieverBuilder matchUntilTopN() {
+            onlyMatches = false;
+            return this;
+        }
+
+        /**
+         * Returns documents until the maximum token limit is reached.
+         *
+         * @param maxTokenCount Maximum number of tokens
+         * @return Builder
+         */
+        public LuceneContentRetrieverBuilder maxTokenCount(final int maxTokenCount) {
+            if (maxTokenCount >= 0) {
+                this.maxTokenCount = maxTokenCount;
+            }
+            return this;
+        }
+
+        /**
+         * Provides only documents matched to the query using full text search.
+         *
+         * @return Builder
+         */
+        public LuceneContentRetrieverBuilder onlyMatches() {
+            onlyMatches = true;
+            return this;
+        }
+
+        public LuceneContentRetrieverBuilder tokenCountFieldName(final String tokenCountFieldName) {
+            if (tokenCountFieldName == null || tokenCountFieldName.isBlank()) {
+                this.tokenCountFieldName = LuceneIndexer.TOKEN_COUNT_FIELD_NAME;
+            }
+            this.tokenCountFieldName = tokenCountFieldName;
+
+            return this;
+        }
+
+        /**
+         * Returns only a certain number of documents.
+         *
+         * @param topNMatches Number of documents to return
+         * @return Builder
+         */
+        public LuceneContentRetrieverBuilder topNMatches(final int topNMatches) {
+            if (topNMatches >= 0) {
+                this.topNMatches = topNMatches;
+            }
+            return this;
+        }
+    }
+
+    private static final Logger LOGGER = Logger.getLogger(LuceneContentRetriever.class.getCanonicalName());
+
+    /**
+     * Instantiate a builder for `LuceneContentRetriever`.
+     *
+     * @return Builder for `LuceneContentRetriever`
+     */
+    public static LuceneContentRetrieverBuilder builder() {
+        return new LuceneContentRetrieverBuilder();
+    }
+
+    private final Directory directory;
+    private final boolean onlyMatches;
+    private final int topNMatches;
+    private final int maxTokenCount;
+    private final String contentFieldName;
+    private final String tokenCountFieldName;
+
+    /**
+     * Initialize all fields, and do one more round of validation (even though the builder has
+     * validated the fields).
+     *
+     * @param directory Lucene directory
+     * @param onlyMatches Whether to only consider matching documents
+     * @param topNMatches Return only the first n matches
+     * @param maxTokenCount Return until a maximum token count
+     * @param contentFieldName Name of the Lucene field with the text
+     * @param tokenCountFieldName Name of the Lucene field with token counts
+     */
+    private LuceneContentRetriever(
+            final Directory directory,
+            final boolean onlyMatches,
+            final int topNMatches,
+            final int maxTokenCount,
+            final String contentFieldName,
+            final String tokenCountFieldName) {
+        this.directory = requireNonNull(directory, "No directory provided");
+        this.onlyMatches = onlyMatches;
+        this.topNMatches = Math.max(0, topNMatches);
+        this.maxTokenCount = Math.max(0, maxTokenCount);
+        this.contentFieldName = requireNonNull(contentFieldName, "No content field name provided");
+        if (this.contentFieldName.isBlank()) {
+            throw new IllegalArgumentException("Content field name cannot be blank");
+        }
+        this.tokenCountFieldName = requireNonNull(tokenCountFieldName, "No token count field name provided");
+        if (this.tokenCountFieldName.isBlank()) {
+            throw new IllegalArgumentException("Token count field name cannot be blank");
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public List<Content> retrieve(final dev.langchain4j.rag.query.Query query) {
+        if (query == null) {
+            return Collections.emptyList();
+        }
+
+        int docCount = 0;
+        int tokenCount = 0;
+        try (final DirectoryReader reader = DirectoryReader.open(directory)) {
+
+            final Query luceneQuery = buildQuery(query.text());
+
+            final IndexSearcher searcher = new IndexSearcher(reader);
+            final TopDocs topDocs = searcher.search(luceneQuery, topNMatches, Sort.RELEVANCE);
+            final List<Content> hits = new ArrayList<>();
+            final StoredFields storedFields = reader.storedFields();
+            for (final ScoreDoc scoreDoc : topDocs.scoreDocs) {
+                // Retrieve document contents
+                final Document document = storedFields.document(scoreDoc.doc);
+                final String content = document.get(contentFieldName);
+                if (content == null || content.isBlank()) {
+                    continue;
+                }
+
+                // Check if number of documents is exceeded
+                docCount = docCount + 1;
+                if (docCount > topNMatches) {
+                    break;
+                }
+
+                // Check token count
+                final IndexableField tokenCountField = document.getField(tokenCountFieldName);
+                if (tokenCountField != null) {
+                    final int docTokens = tokenCountField.numericValue().intValue();
+                    if (tokenCount + docTokens > maxTokenCount) {
+                        continue;
+                        // There may be smaller documents to come after this that we can accommodate
+                    }
+                    tokenCount = tokenCount + docTokens;
+                }
+
+                // Add all other document fields to metadata
+                final Metadata metadata = createTextSegmentMetadata(document);
+
+                // Finally, add text segment to the list
+                final TextSegment textSegment = TextSegment.from(content, metadata);
+                hits.add(Content.from(textSegment, withScore(scoreDoc)));
+            }
+            return hits;
+        } catch (final Throwable e) {
+            // Catch Throwable, since Lucene can throw AssertionError
+            LOGGER.log(Level.INFO, String.format("Could not query <%s>", query), e);
+            return Collections.emptyList();
+        }
+    }
+
+    /**
+     * Build a Lucene query. <br />
+     * TODO: This may be extended in the future to allow for hybrid full text
+     * and embedding vector search.
+     *
+     * @param query User prompt
+     *
+     * @return Lucene query
+     *
+     * @throws ParseException When the query cannot be parsed into terms
+     */
+    private Query buildQuery(final String query) {
+        final Query fullTextQuery;
+        try {
+            final QueryParser parser = new QueryParser(contentFieldName, new StandardAnalyzer());
+            fullTextQuery = parser.parse(query);
+        } catch (final ParseException e) {
+            LOGGER.log(Level.INFO, String.format("Could not create query <%s>", query), e);
+            return new MatchAllDocsQuery();
+        }
+
+        if (onlyMatches) {
+            return fullTextQuery;
+        }
+
+        final BooleanQuery combinedQuery = new BooleanQuery.Builder()
+                .add(fullTextQuery, Occur.SHOULD)
+                .add(new MatchAllDocsQuery(), Occur.SHOULD)
+                .build();
+        return combinedQuery;
+    }
+
+    /**
+     * Map Lucene document fields as metadata, preserving types as much as possible.
+     *
+     * @param document Lucene document
+     *
+     * @return Text segment metadata
+     */
+    private Metadata createTextSegmentMetadata(final Document document) {
+        final Metadata metadata = new Metadata();
+        for (final IndexableField field : document) {
+            final String fieldName = field.name();
+            if (contentFieldName.equals(fieldName)) {
+                continue;
+            }
+
+            final StoredValue storedValue = field.storedValue();
+            final Type type = storedValue.getType();
+            switch (type) {
+                case INTEGER:
+                    metadata.put(fieldName, storedValue.getIntValue());
+                    break;
+                case LONG:
+                    metadata.put(fieldName, storedValue.getLongValue());
+                    break;
+                case FLOAT:
+                    metadata.put(fieldName, storedValue.getFloatValue());
+                    break;
+                case DOUBLE:
+                    metadata.put(fieldName, storedValue.getDoubleValue());
+                    break;
+                case STRING:
+                    metadata.put(fieldName, storedValue.getStringValue());
+                    break;
+                default:
+                    // No-op
+            }
+        }
+        return metadata;
+    }
+
+    /**
+     * Obtaining the hit score is poorly defined in Lucene, so protect it with a try block.
+     *
+     * @param scoreDoc Lucene score doc
+     *
+     * @return Metadata map with score
+     */
+    private Map<ContentMetadata, Object> withScore(final ScoreDoc scoreDoc) {
+        final Map<ContentMetadata, Object> contentMetadata = new HashMap<>();
+        try {
+            contentMetadata.put(ContentMetadata.SCORE, (float) ((FieldDoc) scoreDoc).fields[0] - 1f);
+        } catch (final Exception e) {
+            // Ignore = No score will be added to content metadata
+        }
+        return contentMetadata;
+    }
+}

--- a/content-retrievers/langchain4j-community-lucene/src/main/java/dev/langchain4j/rag/content/retriever/lucene/LuceneContentRetriever.java
+++ b/content-retrievers/langchain4j-community-lucene/src/main/java/dev/langchain4j/rag/content/retriever/lucene/LuceneContentRetriever.java
@@ -73,6 +73,12 @@ public final class LuceneContentRetriever implements ContentRetriever {
                     directory, onlyMatches, topNMatches, maxTokenCount, contentFieldName, tokenCountFieldName);
         }
 
+        /**
+         * Sets the name of the content field.
+         *
+         * @param contentFieldName Content field name
+         * @return Builder
+         */
         public LuceneContentRetrieverBuilder contentFieldName(final String contentFieldName) {
             if (contentFieldName == null || contentFieldName.isBlank()) {
                 this.contentFieldName = LuceneIndexer.CONTENT_FIELD_NAME;
@@ -127,6 +133,12 @@ public final class LuceneContentRetriever implements ContentRetriever {
             return this;
         }
 
+        /**
+         * Sets the name of the token count field.
+         *
+         * @param tokenCountFieldName Token count field name
+         * @return Builder
+         */
         public LuceneContentRetrieverBuilder tokenCountFieldName(final String tokenCountFieldName) {
             if (tokenCountFieldName == null || tokenCountFieldName.isBlank()) {
                 this.tokenCountFieldName = LuceneIndexer.TOKEN_COUNT_FIELD_NAME;

--- a/content-retrievers/langchain4j-community-lucene/src/main/java/dev/langchain4j/rag/content/retriever/lucene/LuceneContentRetriever.java
+++ b/content-retrievers/langchain4j-community-lucene/src/main/java/dev/langchain4j/rag/content/retriever/lucene/LuceneContentRetriever.java
@@ -1,6 +1,7 @@
 package dev.langchain4j.rag.content.retriever.lucene;
 
-import static java.util.Objects.requireNonNull;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 
 import dev.langchain4j.data.document.Metadata;
 import dev.langchain4j.data.segment.TextSegment;
@@ -198,18 +199,12 @@ public final class LuceneContentRetriever implements ContentRetriever {
             final int maxTokenCount,
             final String contentFieldName,
             final String tokenCountFieldName) {
-        this.directory = requireNonNull(directory, "No directory provided");
+        this.directory = ensureNotNull(directory, "directory");
         this.onlyMatches = onlyMatches;
         this.topNMatches = Math.max(0, topNMatches);
         this.maxTokenCount = Math.max(0, maxTokenCount);
-        this.contentFieldName = requireNonNull(contentFieldName, "No content field name provided");
-        if (this.contentFieldName.isBlank()) {
-            throw new IllegalArgumentException("Content field name cannot be blank");
-        }
-        this.tokenCountFieldName = requireNonNull(tokenCountFieldName, "No token count field name provided");
-        if (this.tokenCountFieldName.isBlank()) {
-            throw new IllegalArgumentException("Token count field name cannot be blank");
-        }
+        this.contentFieldName = ensureNotBlank(contentFieldName, "contentFieldName");
+        this.tokenCountFieldName = ensureNotBlank(tokenCountFieldName, "tokenCountFieldName");
     }
 
     /** {@inheritDoc} */

--- a/content-retrievers/langchain4j-community-lucene/src/main/java/dev/langchain4j/rag/content/retriever/lucene/LuceneContentRetriever.java
+++ b/content-retrievers/langchain4j-community-lucene/src/main/java/dev/langchain4j/rag/content/retriever/lucene/LuceneContentRetriever.java
@@ -259,7 +259,7 @@ public final class LuceneContentRetriever implements ContentRetriever {
             return hits;
         } catch (Throwable e) {
             // Catch Throwable, since Lucene can throw AssertionError
-            log.info(String.format("Could not query <%s>", query), e);
+            log.error(String.format("Could not query <%s>", query), e);
             return Collections.emptyList();
         }
     }
@@ -281,7 +281,7 @@ public final class LuceneContentRetriever implements ContentRetriever {
             QueryParser parser = new QueryParser(contentFieldName, new StandardAnalyzer());
             fullTextQuery = parser.parse(query);
         } catch (ParseException e) {
-            log.info(String.format("Could not create query <%s>", query), e);
+            log.warn(String.format("Could not create query <%s>", query), e);
             return new MatchAllDocsQuery();
         }
 

--- a/content-retrievers/langchain4j-community-lucene/src/main/java/dev/langchain4j/rag/content/retriever/lucene/LuceneIndexer.java
+++ b/content-retrievers/langchain4j-community-lucene/src/main/java/dev/langchain4j/rag/content/retriever/lucene/LuceneIndexer.java
@@ -44,9 +44,9 @@ public final class LuceneIndexer {
      *
      * @param directory Lucene directory
      */
-    public LuceneIndexer(final Directory directory) {
+    public LuceneIndexer(Directory directory) {
         this.directory = ensureNotNull(directory, "directory");
-        final EncodingRegistry registry = Encodings.newDefaultEncodingRegistry();
+        EncodingRegistry registry = Encodings.newDefaultEncodingRegistry();
         encoding = registry.getEncoding(EncodingType.CL100K_BASE);
     }
 
@@ -56,43 +56,43 @@ public final class LuceneIndexer {
      *
      * @param content Text segment including metadata
      */
-    public void addContent(final TextSegment content) {
+    public void addContent(TextSegment content) {
         if (content == null) {
             return;
         }
 
-        final IndexWriterConfig config = new IndexWriterConfig(new StandardAnalyzer());
-        try (final IndexWriter writer = new IndexWriter(directory, config); ) {
-            final String text = content.text();
-            final int tokens = encoding.countTokens(text);
-            final Document doc = new Document();
+        IndexWriterConfig config = new IndexWriterConfig(new StandardAnalyzer());
+        try (IndexWriter writer = new IndexWriter(directory, config); ) {
+            String text = content.text();
+            int tokens = encoding.countTokens(text);
+            Document doc = new Document();
             doc.add(new TextField(CONTENT_FIELD_NAME, text, Field.Store.YES));
             doc.add(new IntField(TOKEN_COUNT_FIELD_NAME, tokens, Field.Store.YES));
-            final Map<String, Object> metadataMap = content.metadata().toMap();
+            Map<String, Object> metadataMap = content.metadata().toMap();
             if (metadataMap != null) {
-                for (final Entry<String, Object> entry : metadataMap.entrySet()) {
+                for (Entry<String, Object> entry : metadataMap.entrySet()) {
                     doc.add(toField(entry));
                 }
             }
             writer.addDocument(doc);
-        } catch (final IOException e) {
+        } catch (IOException e) {
             log.info(String.format("Could not write content%n%s", content), e);
         }
     }
 
-    private Field toField(final Entry<String, Object> entry) {
-        final String fieldName = entry.getKey();
-        final var fieldValue = entry.getValue();
-        final Field field;
-        if (fieldValue instanceof final String string) {
+    private Field toField(Entry<String, Object> entry) {
+        String fieldName = entry.getKey();
+        var fieldValue = entry.getValue();
+        Field field;
+        if (fieldValue instanceof String string) {
             field = new StringField(fieldName, string, Store.YES);
-        } else if (fieldValue instanceof final Integer number) {
+        } else if (fieldValue instanceof Integer number) {
             field = new IntField(fieldName, number, Store.YES);
-        } else if (fieldValue instanceof final Long number) {
+        } else if (fieldValue instanceof Long number) {
             field = new LongField(fieldName, number, Store.YES);
-        } else if (fieldValue instanceof final Float number) {
+        } else if (fieldValue instanceof Float number) {
             field = new FloatField(fieldName, number, Store.YES);
-        } else if (fieldValue instanceof final Double number) {
+        } else if (fieldValue instanceof Double number) {
             field = new DoubleField(fieldName, number, Store.YES);
         } else {
             field = new StringField(fieldName, String.valueOf(fieldValue), Store.YES);

--- a/content-retrievers/langchain4j-community-lucene/src/main/java/dev/langchain4j/rag/content/retriever/lucene/LuceneIndexer.java
+++ b/content-retrievers/langchain4j-community-lucene/src/main/java/dev/langchain4j/rag/content/retriever/lucene/LuceneIndexer.java
@@ -1,0 +1,102 @@
+package dev.langchain4j.rag.content.retriever.lucene;
+
+import static java.util.Objects.requireNonNull;
+
+import com.knuddels.jtokkit.Encodings;
+import com.knuddels.jtokkit.api.Encoding;
+import com.knuddels.jtokkit.api.EncodingRegistry;
+import com.knuddels.jtokkit.api.EncodingType;
+import dev.langchain4j.data.segment.TextSegment;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.DoubleField;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.Field.Store;
+import org.apache.lucene.document.FloatField;
+import org.apache.lucene.document.IntField;
+import org.apache.lucene.document.LongField;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.document.TextField;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.store.Directory;
+
+/**
+ * Lucene indexer for LangChain4J content (in the form of `TextSegment`).
+ */
+public final class LuceneIndexer {
+
+    static final String CONTENT_FIELD_NAME = "content";
+    static final String TOKEN_COUNT_FIELD_NAME = "token-count";
+
+    private static final Logger LOGGER = Logger.getLogger(LuceneIndexer.class.getCanonicalName());
+
+    private final Directory directory;
+    private final Encoding encoding;
+
+    /**
+     * Instantiate a new indexer to add content to an index based on a Lucene directory.
+     *
+     * @param directory Lucene directory
+     */
+    public LuceneIndexer(final Directory directory) {
+        this.directory = requireNonNull(directory, "No directory provided");
+        final EncodingRegistry registry = Encodings.newDefaultEncodingRegistry();
+        encoding = registry.getEncoding(EncodingType.CL100K_BASE);
+    }
+
+    /**
+     * Add content to a Lucene index, including segment including metadata and token count. <br/>
+     * IMPORTANT: Token counts are approximate, and do not include metadata.
+     *
+     * @param content Text segment including metadata
+     */
+    public void addContent(final TextSegment content) {
+        if (content == null) {
+            return;
+        }
+
+        final IndexWriterConfig config = new IndexWriterConfig(new StandardAnalyzer());
+        try (final IndexWriter writer = new IndexWriter(directory, config); ) {
+            final String text = content.text();
+            final int tokens = encoding.countTokens(text);
+            final Document doc = new Document();
+            doc.add(new TextField(CONTENT_FIELD_NAME, text, Field.Store.YES));
+            doc.add(new IntField(TOKEN_COUNT_FIELD_NAME, tokens, Field.Store.YES));
+            final Map<String, Object> metadataMap = content.metadata().toMap();
+            if (metadataMap != null) {
+                for (final Entry<String, Object> entry : metadataMap.entrySet()) {
+                    doc.add(toField(entry));
+                }
+            }
+            writer.addDocument(doc);
+        } catch (final IOException e) {
+            LOGGER.log(Level.INFO, String.format("Could not write content%n%s", content), e);
+        }
+    }
+
+    private Field toField(final Entry<String, Object> entry) {
+        final String fieldName = entry.getKey();
+        final var fieldValue = entry.getValue();
+        final Field field;
+        if (fieldValue instanceof final String string) {
+            field = new StringField(fieldName, string, Store.YES);
+        } else if (fieldValue instanceof final Integer number) {
+            field = new IntField(fieldName, number, Store.YES);
+        } else if (fieldValue instanceof final Long number) {
+            field = new LongField(fieldName, number, Store.YES);
+        } else if (fieldValue instanceof final Float number) {
+            field = new FloatField(fieldName, number, Store.YES);
+        } else if (fieldValue instanceof final Double number) {
+            field = new DoubleField(fieldName, number, Store.YES);
+        } else {
+            field = new StringField(fieldName, String.valueOf(fieldValue), Store.YES);
+        }
+        return field;
+    }
+}

--- a/content-retrievers/langchain4j-community-lucene/src/main/java/dev/langchain4j/rag/content/retriever/lucene/LuceneIndexer.java
+++ b/content-retrievers/langchain4j-community-lucene/src/main/java/dev/langchain4j/rag/content/retriever/lucene/LuceneIndexer.java
@@ -1,6 +1,6 @@
 package dev.langchain4j.rag.content.retriever.lucene;
 
-import static java.util.Objects.requireNonNull;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 
 import com.knuddels.jtokkit.Encodings;
 import com.knuddels.jtokkit.api.Encoding;
@@ -45,7 +45,7 @@ public final class LuceneIndexer {
      * @param directory Lucene directory
      */
     public LuceneIndexer(final Directory directory) {
-        this.directory = requireNonNull(directory, "No directory provided");
+        this.directory = ensureNotNull(directory, "directory");
         final EncodingRegistry registry = Encodings.newDefaultEncodingRegistry();
         encoding = registry.getEncoding(EncodingType.CL100K_BASE);
     }

--- a/content-retrievers/langchain4j-community-lucene/src/main/java/dev/langchain4j/rag/content/retriever/lucene/LuceneIndexer.java
+++ b/content-retrievers/langchain4j-community-lucene/src/main/java/dev/langchain4j/rag/content/retriever/lucene/LuceneIndexer.java
@@ -76,7 +76,7 @@ public final class LuceneIndexer {
             }
             writer.addDocument(doc);
         } catch (IOException e) {
-            log.info(String.format("Could not write content%n%s", content), e);
+            log.error(String.format("Could not write content%n%s", content), e);
         }
     }
 

--- a/content-retrievers/langchain4j-community-lucene/src/main/java/dev/langchain4j/rag/content/retriever/lucene/LuceneIndexer.java
+++ b/content-retrievers/langchain4j-community-lucene/src/main/java/dev/langchain4j/rag/content/retriever/lucene/LuceneIndexer.java
@@ -10,8 +10,6 @@ import dev.langchain4j.data.segment.TextSegment;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.DoubleField;
@@ -25,6 +23,8 @@ import org.apache.lucene.document.TextField;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.store.Directory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Lucene indexer for LangChain4J content (in the form of `TextSegment`).
@@ -34,7 +34,7 @@ public final class LuceneIndexer {
     static final String CONTENT_FIELD_NAME = "content";
     static final String TOKEN_COUNT_FIELD_NAME = "token-count";
 
-    private static final Logger LOGGER = Logger.getLogger(LuceneIndexer.class.getCanonicalName());
+    private static final Logger log = LoggerFactory.getLogger(LuceneIndexer.class);
 
     private final Directory directory;
     private final Encoding encoding;
@@ -76,7 +76,7 @@ public final class LuceneIndexer {
             }
             writer.addDocument(doc);
         } catch (final IOException e) {
-            LOGGER.log(Level.INFO, String.format("Could not write content%n%s", content), e);
+            log.info(String.format("Could not write content%n%s", content), e);
         }
     }
 

--- a/content-retrievers/langchain4j-community-lucene/src/test/java/test/dev/langchain4j/rag/content/retriever/FullTextSearchTest.java
+++ b/content-retrievers/langchain4j-community-lucene/src/test/java/test/dev/langchain4j/rag/content/retriever/FullTextSearchTest.java
@@ -1,9 +1,6 @@
 package test.dev.langchain4j.rag.content.retriever;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.collection.IsEmptyCollection.empty;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.langchain4j.data.document.Metadata;
 import dev.langchain4j.data.segment.TextSegment;
@@ -59,8 +56,8 @@ public class FullTextSearchTest {
                 results.stream().map(content -> content.textSegment().text()).collect(Collectors.toList());
         Collections.sort(actualTextSegments);
 
-        assertThat(results, hasSize(1));
-        assertThat(actualTextSegments, is(expectedTextSegments));
+        assertThat(results).hasSize(1);
+        assertThat(actualTextSegments).isEqualTo(expectedTextSegments);
     }
 
     @Test
@@ -86,8 +83,8 @@ public class FullTextSearchTest {
                 results.stream().map(content -> content.textSegment().text()).collect(Collectors.toList());
         Collections.sort(actualTextSegments);
 
-        assertThat(results, hasSize(hitTextSegments.length + missTextSegments.length));
-        assertThat(actualTextSegments, is(expectedTextSegments));
+        assertThat(results).hasSize(hitTextSegments.length + missTextSegments.length);
+        assertThat(actualTextSegments).isEqualTo(expectedTextSegments);
     }
 
     @Test
@@ -109,8 +106,8 @@ public class FullTextSearchTest {
                 results.stream().map(content -> content.textSegment().text()).collect(Collectors.toList());
         Collections.sort(actualTextSegments);
 
-        assertThat(results, hasSize(hitTextSegments.length));
-        assertThat(actualTextSegments, is(expectedTextSegments));
+        assertThat(results).hasSize(hitTextSegments.length);
+        assertThat(actualTextSegments).isEqualTo(expectedTextSegments);
     }
 
     @Test
@@ -129,8 +126,8 @@ public class FullTextSearchTest {
                 results.stream().map(content -> content.textSegment().text()).collect(Collectors.toList());
         Collections.sort(actualTextSegments);
 
-        assertThat(results, hasSize(1));
-        assertThat(actualTextSegments, is(expectedTextSegments));
+        assertThat(results).hasSize(1);
+        assertThat(actualTextSegments).isEqualTo(expectedTextSegments);
     }
 
     @Test
@@ -145,7 +142,7 @@ public class FullTextSearchTest {
         final List<Content> results = contentRetriever.retrieve(query);
 
         // No limiting by token count, since wrong field is used
-        assertThat(results, hasSize(hitTextSegments.length));
+        assertThat(results).hasSize(hitTextSegments.length);
     }
 
     @Test
@@ -158,7 +155,7 @@ public class FullTextSearchTest {
 
         final List<Content> results = contentRetriever.retrieve(query);
 
-        assertThat(results, is(empty()));
+        assertThat(results).isEmpty();
     }
 
     @BeforeEach

--- a/content-retrievers/langchain4j-community-lucene/src/test/java/test/dev/langchain4j/rag/content/retriever/FullTextSearchTest.java
+++ b/content-retrievers/langchain4j-community-lucene/src/test/java/test/dev/langchain4j/rag/content/retriever/FullTextSearchTest.java
@@ -1,0 +1,177 @@
+package test.dev.langchain4j.rag.content.retriever;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.collection.IsEmptyCollection.empty;
+
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.rag.content.Content;
+import dev.langchain4j.rag.content.retriever.lucene.DirectoryFactory;
+import dev.langchain4j.rag.content.retriever.lucene.LuceneContentRetriever;
+import dev.langchain4j.rag.content.retriever.lucene.LuceneIndexer;
+import dev.langchain4j.rag.query.Query;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.lucene.store.Directory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class FullTextSearchTest {
+
+    private static final TextSegment[] hitTextSegments = {
+        TextSegment.from("Lucene is a powerful search library.", metadataName("doc1")),
+        TextSegment.from("Is Lucinity is not a library?", metadataName("doc2")),
+        TextSegment.from("BM25Similarity is the default search term similarity algorithm.", metadataName("doc3")),
+    };
+    private static final TextSegment[] missTextSegments = {
+        TextSegment.from("Aaaaah - some random text here.", metadataName("miss1"))
+    };
+    private static final Query query = Query.from("Give me information on the lucine search library");
+
+    private static Metadata metadataName(final String name) {
+        final Metadata metadata = new Metadata();
+        metadata.put("name", name);
+        return metadata;
+    }
+
+    private Directory directory;
+    private LuceneIndexer indexer;
+    private LuceneContentRetriever contentRetriever;
+
+    @Test
+    public void query1() {
+
+        contentRetriever = LuceneContentRetriever.builder()
+                .topNMatches(1)
+                .directory(directory)
+                .build();
+
+        final List<String> expectedTextSegments = new ArrayList<>();
+        expectedTextSegments.add(hitTextSegments[2].text());
+
+        final List<Content> results = contentRetriever.retrieve(query);
+        final List<String> actualTextSegments =
+                results.stream().map(content -> content.textSegment().text()).collect(Collectors.toList());
+        Collections.sort(actualTextSegments);
+
+        assertThat(results, hasSize(1));
+        assertThat(actualTextSegments, is(expectedTextSegments));
+    }
+
+    @Test
+    public void queryAll() {
+
+        contentRetriever = LuceneContentRetriever.builder()
+                .matchUntilTopN()
+                .directory(directory)
+                .build();
+
+        final List<String> expectedTextSegments = new ArrayList<>();
+        for (final TextSegment textSegment : hitTextSegments) {
+            expectedTextSegments.add(textSegment.text());
+        }
+        for (final TextSegment textSegment : missTextSegments) {
+            indexer.addContent(textSegment);
+            expectedTextSegments.add(textSegment.text());
+        }
+        Collections.sort(expectedTextSegments);
+
+        final List<Content> results = contentRetriever.retrieve(query);
+        final List<String> actualTextSegments =
+                results.stream().map(content -> content.textSegment().text()).collect(Collectors.toList());
+        Collections.sort(actualTextSegments);
+
+        assertThat(results, hasSize(hitTextSegments.length + missTextSegments.length));
+        assertThat(actualTextSegments, is(expectedTextSegments));
+    }
+
+    @Test
+    public void queryContent() {
+
+        contentRetriever = LuceneContentRetriever.builder().directory(directory).build();
+
+        final List<String> expectedTextSegments = new ArrayList<>();
+        for (final TextSegment textSegment : hitTextSegments) {
+            expectedTextSegments.add(textSegment.text());
+        }
+        for (final TextSegment textSegment : missTextSegments) {
+            indexer.addContent(textSegment);
+        }
+        Collections.sort(expectedTextSegments);
+
+        final List<Content> results = contentRetriever.retrieve(query);
+        final List<String> actualTextSegments =
+                results.stream().map(content -> content.textSegment().text()).collect(Collectors.toList());
+        Collections.sort(actualTextSegments);
+
+        assertThat(results, hasSize(hitTextSegments.length));
+        assertThat(actualTextSegments, is(expectedTextSegments));
+    }
+
+    @Test
+    public void queryWithMaxTokens() {
+
+        contentRetriever = LuceneContentRetriever.builder()
+                .maxTokenCount(8)
+                .directory(directory)
+                .build();
+
+        final List<String> expectedTextSegments = new ArrayList<>();
+        expectedTextSegments.add(hitTextSegments[0].text());
+
+        final List<Content> results = contentRetriever.retrieve(query);
+        final List<String> actualTextSegments =
+                results.stream().map(content -> content.textSegment().text()).collect(Collectors.toList());
+        Collections.sort(actualTextSegments);
+
+        assertThat(results, hasSize(1));
+        assertThat(actualTextSegments, is(expectedTextSegments));
+    }
+
+    @Test
+    public void retrieverWithBadTokenCountField() {
+
+        contentRetriever = LuceneContentRetriever.builder()
+                .maxTokenCount(8)
+                .tokenCountFieldName("BAD_TOKEN_COUNT_FIELD_NAME")
+                .directory(directory)
+                .build();
+
+        final List<Content> results = contentRetriever.retrieve(query);
+
+        // No limiting by token count, since wrong field is used
+        assertThat(results, hasSize(hitTextSegments.length));
+    }
+
+    @Test
+    public void retrieverWithWrongContentField() {
+
+        contentRetriever = LuceneContentRetriever.builder()
+                .contentFieldName("MY_CONTENT")
+                .directory(directory)
+                .build();
+
+        final List<Content> results = contentRetriever.retrieve(query);
+
+        assertThat(results, is(empty()));
+    }
+
+    @BeforeEach
+    public void setUp() {
+        directory = DirectoryFactory.tempDirectory();
+        indexer = new LuceneIndexer(directory);
+        for (final TextSegment textSegment : hitTextSegments) {
+            indexer.addContent(textSegment);
+        }
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        directory.close();
+    }
+}

--- a/content-retrievers/langchain4j-community-lucene/src/test/java/test/dev/langchain4j/rag/content/retriever/FullTextSearchTest.java
+++ b/content-retrievers/langchain4j-community-lucene/src/test/java/test/dev/langchain4j/rag/content/retriever/FullTextSearchTest.java
@@ -30,8 +30,8 @@ public class FullTextSearchTest {
     };
     private static final Query query = Query.from("Give me information on the lucine search library");
 
-    private static Metadata metadataName(final String name) {
-        final Metadata metadata = new Metadata();
+    private static Metadata metadataName(String name) {
+        Metadata metadata = new Metadata();
         metadata.put("name", name);
         return metadata;
     }
@@ -48,11 +48,11 @@ public class FullTextSearchTest {
                 .directory(directory)
                 .build();
 
-        final List<String> expectedTextSegments = new ArrayList<>();
+        List<String> expectedTextSegments = new ArrayList<>();
         expectedTextSegments.add(hitTextSegments[2].text());
 
-        final List<Content> results = contentRetriever.retrieve(query);
-        final List<String> actualTextSegments =
+        List<Content> results = contentRetriever.retrieve(query);
+        List<String> actualTextSegments =
                 results.stream().map(content -> content.textSegment().text()).collect(Collectors.toList());
         Collections.sort(actualTextSegments);
 
@@ -68,18 +68,18 @@ public class FullTextSearchTest {
                 .directory(directory)
                 .build();
 
-        final List<String> expectedTextSegments = new ArrayList<>();
-        for (final TextSegment textSegment : hitTextSegments) {
+        List<String> expectedTextSegments = new ArrayList<>();
+        for (TextSegment textSegment : hitTextSegments) {
             expectedTextSegments.add(textSegment.text());
         }
-        for (final TextSegment textSegment : missTextSegments) {
+        for (TextSegment textSegment : missTextSegments) {
             indexer.addContent(textSegment);
             expectedTextSegments.add(textSegment.text());
         }
         Collections.sort(expectedTextSegments);
 
-        final List<Content> results = contentRetriever.retrieve(query);
-        final List<String> actualTextSegments =
+        List<Content> results = contentRetriever.retrieve(query);
+        List<String> actualTextSegments =
                 results.stream().map(content -> content.textSegment().text()).collect(Collectors.toList());
         Collections.sort(actualTextSegments);
 
@@ -92,17 +92,17 @@ public class FullTextSearchTest {
 
         contentRetriever = LuceneContentRetriever.builder().directory(directory).build();
 
-        final List<String> expectedTextSegments = new ArrayList<>();
-        for (final TextSegment textSegment : hitTextSegments) {
+        List<String> expectedTextSegments = new ArrayList<>();
+        for (TextSegment textSegment : hitTextSegments) {
             expectedTextSegments.add(textSegment.text());
         }
-        for (final TextSegment textSegment : missTextSegments) {
+        for (TextSegment textSegment : missTextSegments) {
             indexer.addContent(textSegment);
         }
         Collections.sort(expectedTextSegments);
 
-        final List<Content> results = contentRetriever.retrieve(query);
-        final List<String> actualTextSegments =
+        List<Content> results = contentRetriever.retrieve(query);
+        List<String> actualTextSegments =
                 results.stream().map(content -> content.textSegment().text()).collect(Collectors.toList());
         Collections.sort(actualTextSegments);
 
@@ -118,11 +118,11 @@ public class FullTextSearchTest {
                 .directory(directory)
                 .build();
 
-        final List<String> expectedTextSegments = new ArrayList<>();
+        List<String> expectedTextSegments = new ArrayList<>();
         expectedTextSegments.add(hitTextSegments[0].text());
 
-        final List<Content> results = contentRetriever.retrieve(query);
-        final List<String> actualTextSegments =
+        List<Content> results = contentRetriever.retrieve(query);
+        List<String> actualTextSegments =
                 results.stream().map(content -> content.textSegment().text()).collect(Collectors.toList());
         Collections.sort(actualTextSegments);
 
@@ -139,7 +139,7 @@ public class FullTextSearchTest {
                 .directory(directory)
                 .build();
 
-        final List<Content> results = contentRetriever.retrieve(query);
+        List<Content> results = contentRetriever.retrieve(query);
 
         // No limiting by token count, since wrong field is used
         assertThat(results).hasSize(hitTextSegments.length);
@@ -153,7 +153,7 @@ public class FullTextSearchTest {
                 .directory(directory)
                 .build();
 
-        final List<Content> results = contentRetriever.retrieve(query);
+        List<Content> results = contentRetriever.retrieve(query);
 
         assertThat(results).isEmpty();
     }
@@ -162,7 +162,7 @@ public class FullTextSearchTest {
     public void setUp() {
         directory = DirectoryFactory.tempDirectory();
         indexer = new LuceneIndexer(directory);
-        for (final TextSegment textSegment : hitTextSegments) {
+        for (TextSegment textSegment : hitTextSegments) {
             indexer.addContent(textSegment);
         }
     }

--- a/langchain4j-community-bom/pom.xml
+++ b/langchain4j-community-bom/pom.xml
@@ -67,6 +67,13 @@
                 <version>${project.version}</version>
             </dependency>
 
+            <!-- content retrievers -->
+            <dependency>
+                <groupId>dev.langchain4j</groupId>
+                <artifactId>langchain4j-community-lucene</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
             <!-- web search engines -->
             <dependency>
                 <groupId>dev.langchain4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,9 @@
         <module>embedding-stores/langchain4j-community-duckdb</module>
         <module>embedding-stores/langchain4j-community-vearch</module>
 
+        <!-- Integration of content retrievers -->
+        <module>content-retrievers/langchain4j-community-lucene</module>
+
         <!-- Integration of web search engine -->
         <module>web-search-engines/langchain4j-community-web-search-engine-searxng</module>
 


### PR DESCRIPTION
## Issue
Closes #52

## Change
Create a new LangChain4J full-text ContentRetriever using Apache Lucene. This would retrieve content from Apache Lucene based on a full-text search, preserving TextSegment metadata, and include CL100K token counts and similarity scores.


## General checklist
- [x] There are no breaking changes
- [x] I have added unit and integration tests for my change
- [x] I have manually run all the unit tests in _all_ modules, and they are all green
- [x] I have manually run all integration tests in the module I have added/changed, and they are all green


- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)


## Checklist for adding new maven module
- [x] I have added my new module in the root `pom.xml` and `langchain4j-community-bom/pom.xml`


## Checklist for adding new embedding store integration
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration\
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
