### PR TITLE
DashScope: Bump dashscope-sdk-java version from 2.16.9 to 2.18.0

### DIFF
--- a/models/langchain4j-community-dashscope/pom.xml
+++ b/models/langchain4j-community-dashscope/pom.xml
@@ -21,7 +21,7 @@
     </licenses>
 
     <properties>
-        <dashscope.version>2.16.9</dashscope.version>
+        <dashscope.version>2.18.0</dashscope.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
## Change
Bump dashscope-sdk-java version from 2.16.9 to 2.18.0


## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [X] There are no breaking changes
- [ ] I have added unit and integration tests for my change
- [X] I have manually run all the unit tests in _all_ modules, and they are all green
- [ ] I have manually run all integration tests in the module I have added/changed, and they are all green

