### PR TITLE
DashScope: Support data-url

### DIFF
--- a/models/langchain4j-community-dashscope/pom.xml
+++ b/models/langchain4j-community-dashscope/pom.xml
@@ -21,7 +21,7 @@
     </licenses>
 
     <properties>
-        <dashscope.version>2.18.3</dashscope.version>
+        <dashscope.version>2.18.4</dashscope.version>
     </properties>
 
     <dependencies>

--- a/models/langchain4j-community-dashscope/src/main/java/dev/langchain4j/community/model/dashscope/QwenHelper.java
+++ b/models/langchain4j-community-dashscope/src/main/java/dev/langchain4j/community/model/dashscope/QwenHelper.java
@@ -1,5 +1,22 @@
 package dev.langchain4j.community.model.dashscope;
 
+import static com.alibaba.dashscope.aigc.conversation.ConversationParam.ResultFormat.MESSAGE;
+import static dev.langchain4j.data.message.ChatMessageType.AI;
+import static dev.langchain4j.data.message.ChatMessageType.SYSTEM;
+import static dev.langchain4j.data.message.ChatMessageType.TOOL_EXECUTION_RESULT;
+import static dev.langchain4j.data.message.ChatMessageType.USER;
+import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.Utils.isNullOrBlank;
+import static dev.langchain4j.internal.Utils.isNullOrEmpty;
+import static dev.langchain4j.model.chat.request.ToolChoice.REQUIRED;
+import static dev.langchain4j.model.chat.request.json.JsonSchemaElementHelper.toMap;
+import static dev.langchain4j.model.output.FinishReason.LENGTH;
+import static dev.langchain4j.model.output.FinishReason.STOP;
+import static dev.langchain4j.model.output.FinishReason.TOOL_EXECUTION;
+import static java.util.Objects.isNull;
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toList;
+
 import com.alibaba.dashscope.aigc.generation.GenerationOutput;
 import com.alibaba.dashscope.aigc.generation.GenerationOutput.Choice;
 import com.alibaba.dashscope.aigc.generation.GenerationParam;
@@ -42,9 +59,6 @@ import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import dev.langchain4j.model.output.FinishReason;
 import dev.langchain4j.model.output.Response;
 import dev.langchain4j.model.output.TokenUsage;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -55,23 +69,8 @@ import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.BinaryOperator;
 import java.util.function.Consumer;
-
-import static com.alibaba.dashscope.aigc.conversation.ConversationParam.ResultFormat.MESSAGE;
-import static dev.langchain4j.data.message.ChatMessageType.AI;
-import static dev.langchain4j.data.message.ChatMessageType.SYSTEM;
-import static dev.langchain4j.data.message.ChatMessageType.TOOL_EXECUTION_RESULT;
-import static dev.langchain4j.data.message.ChatMessageType.USER;
-import static dev.langchain4j.internal.Utils.getOrDefault;
-import static dev.langchain4j.internal.Utils.isNullOrBlank;
-import static dev.langchain4j.internal.Utils.isNullOrEmpty;
-import static dev.langchain4j.model.chat.request.ToolChoice.REQUIRED;
-import static dev.langchain4j.model.chat.request.json.JsonSchemaElementHelper.toMap;
-import static dev.langchain4j.model.output.FinishReason.LENGTH;
-import static dev.langchain4j.model.output.FinishReason.STOP;
-import static dev.langchain4j.model.output.FinishReason.TOOL_EXECUTION;
-import static java.util.Objects.isNull;
-import static java.util.stream.Collectors.joining;
-import static java.util.stream.Collectors.toList;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class QwenHelper {
 
@@ -169,7 +168,8 @@ class QwenHelper {
                     imageContent = image.url().toString();
                     return Collections.singletonMap("image", imageContent);
                 } else if (Utils.isNotNullOrBlank(image.base64Data())) {
-                    return Collections.singletonMap("image", "data:%s;base64,%s".formatted(image.mimeType(), image.base64Data()));
+                    return Collections.singletonMap(
+                            "image", "data:%s;base64,%s".formatted(image.mimeType(), image.base64Data()));
                 } else {
                     return Collections.emptyMap();
                 }
@@ -180,7 +180,8 @@ class QwenHelper {
                     audioContent = audio.url().toString();
                     return Collections.singletonMap("audio", audioContent);
                 } else if (Utils.isNotNullOrBlank(audio.base64Data())) {
-                    return Collections.singletonMap("audio", "data:%s;base64,%s".formatted(audio.mimeType(), audio.base64Data()));
+                    return Collections.singletonMap(
+                            "audio", "data:%s;base64,%s".formatted(audio.mimeType(), audio.base64Data()));
                 } else {
                     return Collections.emptyMap();
                 }

--- a/models/langchain4j-community-dashscope/src/main/java/dev/langchain4j/community/model/dashscope/QwenHelper.java
+++ b/models/langchain4j-community-dashscope/src/main/java/dev/langchain4j/community/model/dashscope/QwenHelper.java
@@ -1,22 +1,5 @@
 package dev.langchain4j.community.model.dashscope;
 
-import static com.alibaba.dashscope.aigc.conversation.ConversationParam.ResultFormat.MESSAGE;
-import static dev.langchain4j.data.message.ChatMessageType.AI;
-import static dev.langchain4j.data.message.ChatMessageType.SYSTEM;
-import static dev.langchain4j.data.message.ChatMessageType.TOOL_EXECUTION_RESULT;
-import static dev.langchain4j.data.message.ChatMessageType.USER;
-import static dev.langchain4j.internal.Utils.getOrDefault;
-import static dev.langchain4j.internal.Utils.isNullOrBlank;
-import static dev.langchain4j.internal.Utils.isNullOrEmpty;
-import static dev.langchain4j.model.chat.request.ToolChoice.REQUIRED;
-import static dev.langchain4j.model.chat.request.json.JsonSchemaElementHelper.toMap;
-import static dev.langchain4j.model.output.FinishReason.LENGTH;
-import static dev.langchain4j.model.output.FinishReason.STOP;
-import static dev.langchain4j.model.output.FinishReason.TOOL_EXECUTION;
-import static java.util.Objects.isNull;
-import static java.util.stream.Collectors.joining;
-import static java.util.stream.Collectors.toList;
-
 import com.alibaba.dashscope.aigc.generation.GenerationOutput;
 import com.alibaba.dashscope.aigc.generation.GenerationOutput.Choice;
 import com.alibaba.dashscope.aigc.generation.GenerationParam;
@@ -59,6 +42,9 @@ import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import dev.langchain4j.model.output.FinishReason;
 import dev.langchain4j.model.output.Response;
 import dev.langchain4j.model.output.TokenUsage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -77,8 +63,23 @@ import java.util.UUID;
 import java.util.function.BiFunction;
 import java.util.function.BinaryOperator;
 import java.util.function.Consumer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
+import static com.alibaba.dashscope.aigc.conversation.ConversationParam.ResultFormat.MESSAGE;
+import static dev.langchain4j.data.message.ChatMessageType.AI;
+import static dev.langchain4j.data.message.ChatMessageType.SYSTEM;
+import static dev.langchain4j.data.message.ChatMessageType.TOOL_EXECUTION_RESULT;
+import static dev.langchain4j.data.message.ChatMessageType.USER;
+import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.Utils.isNullOrBlank;
+import static dev.langchain4j.internal.Utils.isNullOrEmpty;
+import static dev.langchain4j.model.chat.request.ToolChoice.REQUIRED;
+import static dev.langchain4j.model.chat.request.json.JsonSchemaElementHelper.toMap;
+import static dev.langchain4j.model.output.FinishReason.LENGTH;
+import static dev.langchain4j.model.output.FinishReason.STOP;
+import static dev.langchain4j.model.output.FinishReason.TOOL_EXECUTION;
+import static java.util.Objects.isNull;
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toList;
 
 class QwenHelper {
 
@@ -715,7 +716,7 @@ class QwenHelper {
                         .topK(parameters.topK())
                         .enableSearch(getOrDefault(parameters.enableSearch(), false))
                         .seed(parameters.seed())
-                        .maxLength(parameters.maxOutputTokens())
+                        .maxTokens(parameters.maxOutputTokens())
                         .messages(toQwenMultiModalMessages(chatRequest.messages()))
                         .incrementalOutput(incrementalOutput);
 

--- a/models/langchain4j-community-dashscope/src/main/java/dev/langchain4j/community/model/dashscope/QwenHelper.java
+++ b/models/langchain4j-community-dashscope/src/main/java/dev/langchain4j/community/model/dashscope/QwenHelper.java
@@ -45,13 +45,6 @@ import dev.langchain4j.model.output.TokenUsage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.StandardCopyOption;
-import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -59,7 +52,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.UUID;
 import java.util.function.BiFunction;
 import java.util.function.BinaryOperator;
 import java.util.function.Consumer;
@@ -177,16 +169,7 @@ class QwenHelper {
                     imageContent = image.url().toString();
                     return Collections.singletonMap("image", imageContent);
                 } else if (Utils.isNotNullOrBlank(image.base64Data())) {
-                    // The dashscope sdk supports local file url: file://...
-                    // Using the temporary directory for storing temporary files is a safe practice,
-                    // as most operating systems will periodically clean up the contents of this directory
-                    // or do so upon system reboot.
-                    imageContent = saveDataAsTemporaryFile(image.base64Data(), image.mimeType());
-
-                    // In this case, the dashscope sdk requires a mutable map.
-                    HashMap<String, Object> contentMap = new HashMap<>(1);
-                    contentMap.put("image", imageContent);
-                    return contentMap;
+                    return Collections.singletonMap("image", "data:%s;base64,%s".formatted(image.mimeType(), image.base64Data()));
                 } else {
                     return Collections.emptyMap();
                 }
@@ -197,16 +180,7 @@ class QwenHelper {
                     audioContent = audio.url().toString();
                     return Collections.singletonMap("audio", audioContent);
                 } else if (Utils.isNotNullOrBlank(audio.base64Data())) {
-                    // The dashscope sdk supports local file url: file://...
-                    // Using the temporary directory for storing temporary files is a safe practice,
-                    // as most operating systems will periodically clean up the contents of this directory
-                    // or do so upon system reboot.
-                    audioContent = saveDataAsTemporaryFile(audio.base64Data(), audio.mimeType());
-
-                    // In this case, the dashscope sdk requires a mutable map.
-                    HashMap<String, Object> contentMap = new HashMap<>(1);
-                    contentMap.put("audio", audioContent);
-                    return contentMap;
+                    return Collections.singletonMap("audio", "data:%s;base64,%s".formatted(audio.mimeType(), audio.base64Data()));
                 } else {
                     return Collections.emptyMap();
                 }
@@ -215,28 +189,6 @@ class QwenHelper {
             default:
                 return Collections.emptyMap();
         }
-    }
-
-    static String saveDataAsTemporaryFile(String base64Data, String mimeType) {
-        String tmpDir = System.getProperty("java.io.tmpdir", "/tmp");
-        String tmpFileName = UUID.randomUUID().toString();
-        if (Utils.isNotNullOrBlank(mimeType)) {
-            // e.g. "image/png", "image/jpeg"...
-            int lastSlashIndex = mimeType.lastIndexOf("/");
-            if (lastSlashIndex >= 0 && lastSlashIndex < mimeType.length() - 1) {
-                String fileSuffix = mimeType.substring(lastSlashIndex + 1);
-                tmpFileName = tmpFileName + "." + fileSuffix;
-            }
-        }
-
-        Path tmpFilePath = Paths.get(tmpDir, tmpFileName);
-        byte[] data = Base64.getDecoder().decode(base64Data);
-        try {
-            Files.copy(new ByteArrayInputStream(data), tmpFilePath, StandardCopyOption.REPLACE_EXISTING);
-        } catch (IOException e) {
-            throw new IllegalStateException(e);
-        }
-        return tmpFilePath.toAbsolutePath().toUri().toString();
     }
 
     static String roleFrom(ChatMessage message) {

--- a/models/langchain4j-community-dashscope/src/main/java/dev/langchain4j/community/model/dashscope/QwenModelName.java
+++ b/models/langchain4j-community-dashscope/src/main/java/dev/langchain4j/community/model/dashscope/QwenModelName.java
@@ -11,8 +11,7 @@ public class QwenModelName {
     public static final String QWEN_PLUS_LATEST = "qwen-plus-latest"; // Qwen plus model, latest version.
     public static final String QWEN_MAX = "qwen-max"; // Qwen max model, stable version.
     public static final String QWEN_MAX_LATEST = "qwen-max-latest"; // Qwen max model, latest version.
-    public static final String QWEN_LONG =
-            "qwen-long"; // Qwen long model, 10m context.
+    public static final String QWEN_LONG = "qwen-long"; // Qwen long model, 10m context.
     public static final String QWEN_7B_CHAT = "qwen-7b-chat"; // Qwen open sourced 7-billion-parameters model
     public static final String QWEN_14B_CHAT = "qwen-14b-chat"; // Qwen open sourced 14-billion-parameters model
     public static final String QWEN_72B_CHAT = "qwen-72b-chat"; // Qwen open sourced 72-billion-parameters model
@@ -54,11 +53,14 @@ public class QwenModelName {
     public static final String QWEN_VL_PLUS_LATEST =
             "qwen-vl-plus-latest"; // Qwen multi-modal model, supports image and text information, latest version.
     public static final String QWEN_VL_MAX =
-            "qwen-vl-max"; // Qwen multi-modal model, offers optimal performance on a wider range of complex tasks, stable version.
+            "qwen-vl-max"; // Qwen multi-modal model, offers optimal performance on a wider range of complex tasks,
+    // stable version.
     public static final String QWEN_VL_MAX_LATEST =
-            "qwen-vl-max-latest"; // Qwen multi-modal model, offers optimal performance on a wider range of complex tasks, stable version.
+            "qwen-vl-max-latest"; // Qwen multi-modal model, offers optimal performance on a wider range of complex
+    // tasks, stable version.
     public static final String QWEN_AUDIO_TURBO = "qwen-audio-turbo"; // Qwen audio understanding model, stable version
-    public static final String QWEN_AUDIO_TURBO_LATEST = "qwen-audio-turbo-latest"; // Qwen audio understanding model, latest version
+    public static final String QWEN_AUDIO_TURBO_LATEST =
+            "qwen-audio-turbo-latest"; // Qwen audio understanding model, latest version
     public static final String QWEN_MT_TURBO = "qwen-mt-turbo"; // Qwen turbo model for translation.
     public static final String QWEN_MT_PLUS = "qwen-mt-plus"; // Qwen plus model for translation.
 

--- a/models/langchain4j-community-dashscope/src/main/java/dev/langchain4j/community/model/dashscope/QwenModelName.java
+++ b/models/langchain4j-community-dashscope/src/main/java/dev/langchain4j/community/model/dashscope/QwenModelName.java
@@ -5,11 +5,14 @@ package dev.langchain4j.community.model.dashscope;
  */
 public class QwenModelName {
     // Use with QwenChatModel and QwenLanguageModel
-    public static final String QWEN_TURBO = "qwen-turbo"; // Qwen base model, 4k context.
-    public static final String QWEN_PLUS = "qwen-plus"; // Qwen plus model, 8k context.
-    public static final String QWEN_MAX = "qwen-max"; // Qwen max model, 200-billion-parameters, 8k context.
-    public static final String QWEN_MAX_LONGCONTEXT =
-            "qwen-max-longcontext"; // Qwen max model, 200-billion-parameters, 30k context.
+    public static final String QWEN_TURBO = "qwen-turbo"; // Qwen base model, stable version.
+    public static final String QWEN_TURBO_LATEST = "qwen-turbo-latest"; // Qwen base model, latest version.
+    public static final String QWEN_PLUS = "qwen-plus"; // Qwen plus model, stable version.
+    public static final String QWEN_PLUS_LATEST = "qwen-plus-latest"; // Qwen plus model, latest version.
+    public static final String QWEN_MAX = "qwen-max"; // Qwen max model, stable version.
+    public static final String QWEN_MAX_LATEST = "qwen-max-latest"; // Qwen max model, latest version.
+    public static final String QWEN_LONG =
+            "qwen-long"; // Qwen long model, 10m context.
     public static final String QWEN_7B_CHAT = "qwen-7b-chat"; // Qwen open sourced 7-billion-parameters model
     public static final String QWEN_14B_CHAT = "qwen-14b-chat"; // Qwen open sourced 14-billion-parameters model
     public static final String QWEN_72B_CHAT = "qwen-72b-chat"; // Qwen open sourced 72-billion-parameters model
@@ -47,11 +50,15 @@ public class QwenModelName {
     public static final String QWEN2_5_72B_INSTRUCT =
             "qwen2.5-72b-instruct"; // Qwen open sourced 72-billion-parameters model (v2.5)
     public static final String QWEN_VL_PLUS =
-            "qwen-vl-plus"; // Qwen multi-modal model, supports image and text information.
+            "qwen-vl-plus"; // Qwen multi-modal model, supports image and text information, stable version.
+    public static final String QWEN_VL_PLUS_LATEST =
+            "qwen-vl-plus-latest"; // Qwen multi-modal model, supports image and text information, latest version.
     public static final String QWEN_VL_MAX =
-            "qwen-vl-max"; // Qwen multi-modal model, offers optimal performance on a wider range of complex tasks.
-    public static final String QWEN_AUDIO_CHAT = "qwen-audio-chat"; // Qwen open sourced speech model, sft for chatting.
-    public static final String QWEN2_AUDIO_INSTRUCT = "qwen2-audio-instruct"; // Qwen open sourced speech model (v2)
+            "qwen-vl-max"; // Qwen multi-modal model, offers optimal performance on a wider range of complex tasks, stable version.
+    public static final String QWEN_VL_MAX_LATEST =
+            "qwen-vl-max-latest"; // Qwen multi-modal model, offers optimal performance on a wider range of complex tasks, stable version.
+    public static final String QWEN_AUDIO_TURBO = "qwen-audio-turbo"; // Qwen audio understanding model, stable version
+    public static final String QWEN_AUDIO_TURBO_LATEST = "qwen-audio-turbo-latest"; // Qwen audio understanding model, latest version
     public static final String QWEN_MT_TURBO = "qwen-mt-turbo"; // Qwen turbo model for translation.
     public static final String QWEN_MT_PLUS = "qwen-mt-plus"; // Qwen plus model for translation.
 

--- a/models/langchain4j-community-dashscope/src/test/java/dev/langchain4j/community/model/dashscope/QwenTestHelper.java
+++ b/models/langchain4j-community-dashscope/src/test/java/dev/langchain4j/community/model/dashscope/QwenTestHelper.java
@@ -1,5 +1,8 @@
 package dev.langchain4j.community.model.dashscope;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
 import dev.langchain4j.data.audio.Audio;
 import dev.langchain4j.data.image.Image;
 import dev.langchain4j.data.message.AiMessage;
@@ -9,8 +12,6 @@ import dev.langchain4j.data.message.ImageContent;
 import dev.langchain4j.data.message.SystemMessage;
 import dev.langchain4j.data.message.TextContent;
 import dev.langchain4j.data.message.UserMessage;
-import org.junit.jupiter.params.provider.Arguments;
-
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -19,9 +20,7 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Stream;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import org.junit.jupiter.params.provider.Arguments;
 
 class QwenTestHelper {
 
@@ -62,8 +61,7 @@ class QwenTestHelper {
     }
 
     public static Stream<Arguments> vlChatModelNameProvider() {
-        return Stream.of(Arguments.of(QwenModelName.QWEN_VL_MAX),
-                Arguments.of(QwenModelName.QWEN_VL_MAX_LATEST));
+        return Stream.of(Arguments.of(QwenModelName.QWEN_VL_MAX), Arguments.of(QwenModelName.QWEN_VL_MAX_LATEST));
     }
 
     public static Stream<Arguments> mtChatModelNameProvider() {
@@ -71,8 +69,8 @@ class QwenTestHelper {
     }
 
     public static Stream<Arguments> audioChatModelNameProvider() {
-        return Stream.of(Arguments.of(QwenModelName.QWEN_AUDIO_TURBO),
-                Arguments.of(QwenModelName.QWEN_AUDIO_TURBO_LATEST));
+        return Stream.of(
+                Arguments.of(QwenModelName.QWEN_AUDIO_TURBO), Arguments.of(QwenModelName.QWEN_AUDIO_TURBO_LATEST));
     }
 
     public static Stream<Arguments> embeddingModelNameProvider() {

--- a/models/langchain4j-community-dashscope/src/test/java/dev/langchain4j/community/model/dashscope/QwenTestHelper.java
+++ b/models/langchain4j-community-dashscope/src/test/java/dev/langchain4j/community/model/dashscope/QwenTestHelper.java
@@ -1,8 +1,5 @@
 package dev.langchain4j.community.model.dashscope;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
-
 import dev.langchain4j.data.audio.Audio;
 import dev.langchain4j.data.image.Image;
 import dev.langchain4j.data.message.AiMessage;
@@ -12,6 +9,8 @@ import dev.langchain4j.data.message.ImageContent;
 import dev.langchain4j.data.message.SystemMessage;
 import dev.langchain4j.data.message.TextContent;
 import dev.langchain4j.data.message.UserMessage;
+import org.junit.jupiter.params.provider.Arguments;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -20,16 +19,21 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Stream;
-import org.junit.jupiter.params.provider.Arguments;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 class QwenTestHelper {
 
     public static Stream<Arguments> languageModelNameProvider() {
         return Stream.of(
                 Arguments.of(QwenModelName.QWEN_TURBO),
+                Arguments.of(QwenModelName.QWEN_TURBO_LATEST),
                 Arguments.of(QwenModelName.QWEN_PLUS),
+                Arguments.of(QwenModelName.QWEN_PLUS_LATEST),
                 Arguments.of(QwenModelName.QWEN_MAX),
-                Arguments.of(QwenModelName.QWEN_MAX_LONGCONTEXT),
+                Arguments.of(QwenModelName.QWEN_MAX_LATEST),
+                Arguments.of(QwenModelName.QWEN_LONG),
                 Arguments.of(QwenModelName.QWEN2_5_3B_INSTRUCT),
                 Arguments.of(QwenModelName.QWEN2_5_7B_INSTRUCT),
                 Arguments.of(QwenModelName.QWEN2_5_14B_INSTRUCT),
@@ -40,9 +44,12 @@ class QwenTestHelper {
     public static Stream<Arguments> nonMultimodalChatModelNameProvider() {
         return Stream.of(
                 Arguments.of(QwenModelName.QWEN_TURBO),
+                Arguments.of(QwenModelName.QWEN_TURBO_LATEST),
                 Arguments.of(QwenModelName.QWEN_PLUS),
+                Arguments.of(QwenModelName.QWEN_PLUS_LATEST),
                 Arguments.of(QwenModelName.QWEN_MAX),
-                Arguments.of(QwenModelName.QWEN_MAX_LONGCONTEXT),
+                Arguments.of(QwenModelName.QWEN_MAX_LATEST),
+                Arguments.of(QwenModelName.QWEN_LONG),
                 Arguments.of(QwenModelName.QWEN2_5_3B_INSTRUCT),
                 Arguments.of(QwenModelName.QWEN2_5_7B_INSTRUCT),
                 Arguments.of(QwenModelName.QWEN2_5_14B_INSTRUCT),
@@ -55,7 +62,8 @@ class QwenTestHelper {
     }
 
     public static Stream<Arguments> vlChatModelNameProvider() {
-        return Stream.of(Arguments.of(QwenModelName.QWEN_VL_MAX));
+        return Stream.of(Arguments.of(QwenModelName.QWEN_VL_MAX),
+                Arguments.of(QwenModelName.QWEN_VL_MAX_LATEST));
     }
 
     public static Stream<Arguments> mtChatModelNameProvider() {
@@ -63,7 +71,8 @@ class QwenTestHelper {
     }
 
     public static Stream<Arguments> audioChatModelNameProvider() {
-        return Stream.of(Arguments.of(QwenModelName.QWEN2_AUDIO_INSTRUCT));
+        return Stream.of(Arguments.of(QwenModelName.QWEN_AUDIO_TURBO),
+                Arguments.of(QwenModelName.QWEN_AUDIO_TURBO_LATEST));
     }
 
     public static Stream<Arguments> embeddingModelNameProvider() {


### PR DESCRIPTION
## Change
Qwen models add data-url support. Simplify the transmission of base64 data.
In addition, adjust the model name according to the latest model list. Reference: https://help.aliyun.com/zh/model-studio/getting-started/models

## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [X] There are no breaking changes
- [ ] I have added unit and integration tests for my change
- [X] I have manually run all the unit tests in _all_ modules, and they are all green
- [X] I have manually run all integration tests in the module I have added/changed, and they are all green

Note: All test cases that reference files from "upload.wikimedia.org" will fail, as the dashscope platform cannot access certain websites. Usually there will be replacement tests in Qwen's own ITs.
And, some tests in ChatModelListenerIT/StreamingChatModelListenerIT do not allow model provider value to be OTHER. Don't understand the reason for this restriction, but DashScope does belong to ModelProvider.OTHER.
