### PR TITLE
DashScope: Add qwen reasoning models. (qwq)

### DIFF
--- a/models/langchain4j-community-dashscope/src/main/java/dev/langchain4j/community/model/dashscope/QwenModelName.java
+++ b/models/langchain4j-community-dashscope/src/main/java/dev/langchain4j/community/model/dashscope/QwenModelName.java
@@ -5,13 +5,13 @@ package dev.langchain4j.community.model.dashscope;
  */
 public class QwenModelName {
     // Use with QwenChatModel and QwenLanguageModel
-    public static final String QWEN_TURBO = "qwen-turbo"; // Qwen base model, stable version.
-    public static final String QWEN_TURBO_LATEST = "qwen-turbo-latest"; // Qwen base model, latest version.
+    public static final String QWEN_TURBO = "qwen-turbo"; // Qwen base model, stable version
+    public static final String QWEN_TURBO_LATEST = "qwen-turbo-latest"; // Qwen base model, latest version
     public static final String QWEN_PLUS = "qwen-plus"; // Qwen plus model, stable version.
-    public static final String QWEN_PLUS_LATEST = "qwen-plus-latest"; // Qwen plus model, latest version.
-    public static final String QWEN_MAX = "qwen-max"; // Qwen max model, stable version.
-    public static final String QWEN_MAX_LATEST = "qwen-max-latest"; // Qwen max model, latest version.
-    public static final String QWEN_LONG = "qwen-long"; // Qwen long model, 10m context.
+    public static final String QWEN_PLUS_LATEST = "qwen-plus-latest"; // Qwen plus model, latest version
+    public static final String QWEN_MAX = "qwen-max"; // Qwen max model, stable version
+    public static final String QWEN_MAX_LATEST = "qwen-max-latest"; // Qwen max model, latest version
+    public static final String QWEN_LONG = "qwen-long"; // Qwen long model, 10m context
     public static final String QWEN_7B_CHAT = "qwen-7b-chat"; // Qwen open sourced 7-billion-parameters model
     public static final String QWEN_14B_CHAT = "qwen-14b-chat"; // Qwen open sourced 14-billion-parameters model
     public static final String QWEN_72B_CHAT = "qwen-72b-chat"; // Qwen open sourced 72-billion-parameters model
@@ -49,20 +49,20 @@ public class QwenModelName {
     public static final String QWEN2_5_72B_INSTRUCT =
             "qwen2.5-72b-instruct"; // Qwen open sourced 72-billion-parameters model (v2.5)
     public static final String QWEN_VL_PLUS =
-            "qwen-vl-plus"; // Qwen multi-modal model, supports image and text information, stable version.
+            "qwen-vl-plus"; // Qwen multi-modal model, supports image and text information, stable version
     public static final String QWEN_VL_PLUS_LATEST =
-            "qwen-vl-plus-latest"; // Qwen multi-modal model, supports image and text information, latest version.
+            "qwen-vl-plus-latest"; // Qwen multi-modal model, supports image and text information, latest version
     public static final String QWEN_VL_MAX =
-            "qwen-vl-max"; // Qwen multi-modal model, offers optimal performance on a wider range of complex tasks,
-    // stable version.
+            "qwen-vl-max"; // Qwen multi-modal model, offers optimal performance, stable version
     public static final String QWEN_VL_MAX_LATEST =
-            "qwen-vl-max-latest"; // Qwen multi-modal model, offers optimal performance on a wider range of complex
-    // tasks, stable version.
+            "qwen-vl-max-latest"; // Qwen multi-modal model, offers optimal performance, stable version
     public static final String QWEN_AUDIO_TURBO = "qwen-audio-turbo"; // Qwen audio understanding model, stable version
     public static final String QWEN_AUDIO_TURBO_LATEST =
             "qwen-audio-turbo-latest"; // Qwen audio understanding model, latest version
-    public static final String QWEN_MT_TURBO = "qwen-mt-turbo"; // Qwen turbo model for translation.
-    public static final String QWEN_MT_PLUS = "qwen-mt-plus"; // Qwen plus model for translation.
+    public static final String QWEN_MT_TURBO = "qwen-mt-turbo"; // Qwen turbo model for translation
+    public static final String QWEN_MT_PLUS = "qwen-mt-plus"; // Qwen plus model for translation
+    public static final String QWQ_PLUS = "qwq-plus"; // Qwen reasoning model, stable version
+    public static final String QWQ_PLUS_LATEST = "qwq-plus-latest"; // Qwen reasoning model, latest version
 
     // Use with QwenEmbeddingModel
     public static final String TEXT_EMBEDDING_V1 = "text-embedding-v1"; // Support: en, zh, es, fr, pt, id

--- a/models/langchain4j-community-dashscope/src/test/java/dev/langchain4j/community/model/dashscope/QwenStreamingChatModelIT.java
+++ b/models/langchain4j-community-dashscope/src/test/java/dev/langchain4j/community/model/dashscope/QwenStreamingChatModelIT.java
@@ -1,5 +1,29 @@
 package dev.langchain4j.community.model.dashscope;
 
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.chat.StreamingChatLanguageModel;
+import dev.langchain4j.model.chat.TestStreamingChatResponseHandler;
+import dev.langchain4j.model.chat.TestStreamingResponseHandler;
+import dev.langchain4j.model.chat.common.AbstractStreamingChatModelIT;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.output.Response;
+import dev.langchain4j.model.output.TokenUsage;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
 import static dev.langchain4j.community.model.dashscope.QwenHelper.convertHandler;
 import static dev.langchain4j.community.model.dashscope.QwenModelName.QWEN_MAX;
 import static dev.langchain4j.community.model.dashscope.QwenTestHelper.apiKey;
@@ -20,34 +44,12 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import dev.langchain4j.agent.tool.ToolExecutionRequest;
-import dev.langchain4j.agent.tool.ToolSpecification;
-import dev.langchain4j.data.message.AiMessage;
-import dev.langchain4j.data.message.ChatMessage;
-import dev.langchain4j.data.message.ToolExecutionResultMessage;
-import dev.langchain4j.data.message.UserMessage;
-import dev.langchain4j.model.chat.StreamingChatLanguageModel;
-import dev.langchain4j.model.chat.TestStreamingChatResponseHandler;
-import dev.langchain4j.model.chat.TestStreamingResponseHandler;
-import dev.langchain4j.model.chat.common.AbstractStreamingChatModelIT;
-import dev.langchain4j.model.chat.request.ChatRequest;
-import dev.langchain4j.model.chat.request.ChatRequestParameters;
-import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
-import dev.langchain4j.model.chat.response.ChatResponse;
-import dev.langchain4j.model.output.Response;
-import dev.langchain4j.model.output.TokenUsage;
-import java.util.List;
-import java.util.stream.Collectors;
-import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
-
 @EnabledIfEnvironmentVariable(named = "DASHSCOPE_API_KEY", matches = ".+")
 class QwenStreamingChatModelIT extends AbstractStreamingChatModelIT {
 
     @ParameterizedTest
     @MethodSource("dev.langchain4j.community.model.dashscope.QwenTestHelper#nonMultimodalChatModelNameProvider")
+    @MethodSource("dev.langchain4j.community.model.dashscope.QwenTestHelper#reasoningChatModelNameProvider")
     void should_send_non_multimodal_messages_and_receive_response(String modelName) {
         StreamingChatLanguageModel model = QwenStreamingChatModel.builder()
                 .apiKey(apiKey())
@@ -63,6 +65,7 @@ class QwenStreamingChatModelIT extends AbstractStreamingChatModelIT {
 
     @ParameterizedTest
     @MethodSource("dev.langchain4j.community.model.dashscope.QwenTestHelper#nonMultimodalChatModelNameProvider")
+    @MethodSource("dev.langchain4j.community.model.dashscope.QwenTestHelper#reasoningChatModelNameProvider")
     void should_send_non_multimodal_messages_and_receive_response_by_customized_request(String modelName) {
         QwenStreamingChatModel model = QwenStreamingChatModel.builder()
                 .apiKey(apiKey())

--- a/models/langchain4j-community-dashscope/src/test/java/dev/langchain4j/community/model/dashscope/QwenStreamingChatModelIT.java
+++ b/models/langchain4j-community-dashscope/src/test/java/dev/langchain4j/community/model/dashscope/QwenStreamingChatModelIT.java
@@ -1,29 +1,5 @@
 package dev.langchain4j.community.model.dashscope;
 
-import dev.langchain4j.agent.tool.ToolExecutionRequest;
-import dev.langchain4j.agent.tool.ToolSpecification;
-import dev.langchain4j.data.message.AiMessage;
-import dev.langchain4j.data.message.ChatMessage;
-import dev.langchain4j.data.message.ToolExecutionResultMessage;
-import dev.langchain4j.data.message.UserMessage;
-import dev.langchain4j.model.chat.StreamingChatLanguageModel;
-import dev.langchain4j.model.chat.TestStreamingChatResponseHandler;
-import dev.langchain4j.model.chat.TestStreamingResponseHandler;
-import dev.langchain4j.model.chat.common.AbstractStreamingChatModelIT;
-import dev.langchain4j.model.chat.request.ChatRequest;
-import dev.langchain4j.model.chat.request.ChatRequestParameters;
-import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
-import dev.langchain4j.model.chat.response.ChatResponse;
-import dev.langchain4j.model.output.Response;
-import dev.langchain4j.model.output.TokenUsage;
-import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
-
-import java.util.List;
-import java.util.stream.Collectors;
-
 import static dev.langchain4j.community.model.dashscope.QwenHelper.convertHandler;
 import static dev.langchain4j.community.model.dashscope.QwenModelName.QWEN_MAX;
 import static dev.langchain4j.community.model.dashscope.QwenTestHelper.apiKey;
@@ -43,6 +19,29 @@ import static dev.langchain4j.model.output.FinishReason.TOOL_EXECUTION;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.chat.StreamingChatLanguageModel;
+import dev.langchain4j.model.chat.TestStreamingChatResponseHandler;
+import dev.langchain4j.model.chat.TestStreamingResponseHandler;
+import dev.langchain4j.model.chat.common.AbstractStreamingChatModelIT;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.output.Response;
+import dev.langchain4j.model.output.TokenUsage;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 @EnabledIfEnvironmentVariable(named = "DASHSCOPE_API_KEY", matches = ".+")
 class QwenStreamingChatModelIT extends AbstractStreamingChatModelIT {

--- a/models/langchain4j-community-dashscope/src/test/java/dev/langchain4j/community/model/dashscope/QwenTestHelper.java
+++ b/models/langchain4j-community-dashscope/src/test/java/dev/langchain4j/community/model/dashscope/QwenTestHelper.java
@@ -1,8 +1,5 @@
 package dev.langchain4j.community.model.dashscope;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
-
 import dev.langchain4j.data.audio.Audio;
 import dev.langchain4j.data.image.Image;
 import dev.langchain4j.data.message.AiMessage;
@@ -12,6 +9,8 @@ import dev.langchain4j.data.message.ImageContent;
 import dev.langchain4j.data.message.SystemMessage;
 import dev.langchain4j.data.message.TextContent;
 import dev.langchain4j.data.message.UserMessage;
+import org.junit.jupiter.params.provider.Arguments;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -20,7 +19,9 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Stream;
-import org.junit.jupiter.params.provider.Arguments;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 class QwenTestHelper {
 
@@ -54,6 +55,14 @@ class QwenTestHelper {
                 Arguments.of(QwenModelName.QWEN2_5_14B_INSTRUCT),
                 Arguments.of(QwenModelName.QWEN2_5_32B_INSTRUCT),
                 Arguments.of(QwenModelName.QWEN2_5_72B_INSTRUCT));
+    }
+
+    public static Stream<Arguments> reasoningChatModelNameProvider() {
+        // Only streaming output is supported.
+        // Function Call and structured output (JSON Mode) are not supported.
+        return Stream.of(
+                Arguments.of(QwenModelName.QWQ_PLUS),
+                Arguments.of(QwenModelName.QWQ_PLUS_LATEST));
     }
 
     public static Stream<Arguments> functionCallChatModelNameProvider() {

--- a/models/langchain4j-community-dashscope/src/test/java/dev/langchain4j/community/model/dashscope/QwenTestHelper.java
+++ b/models/langchain4j-community-dashscope/src/test/java/dev/langchain4j/community/model/dashscope/QwenTestHelper.java
@@ -1,5 +1,8 @@
 package dev.langchain4j.community.model.dashscope;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
 import dev.langchain4j.data.audio.Audio;
 import dev.langchain4j.data.image.Image;
 import dev.langchain4j.data.message.AiMessage;
@@ -9,8 +12,6 @@ import dev.langchain4j.data.message.ImageContent;
 import dev.langchain4j.data.message.SystemMessage;
 import dev.langchain4j.data.message.TextContent;
 import dev.langchain4j.data.message.UserMessage;
-import org.junit.jupiter.params.provider.Arguments;
-
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -19,9 +20,7 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Stream;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import org.junit.jupiter.params.provider.Arguments;
 
 class QwenTestHelper {
 
@@ -60,9 +59,7 @@ class QwenTestHelper {
     public static Stream<Arguments> reasoningChatModelNameProvider() {
         // Only streaming output is supported.
         // Function Call and structured output (JSON Mode) are not supported.
-        return Stream.of(
-                Arguments.of(QwenModelName.QWQ_PLUS),
-                Arguments.of(QwenModelName.QWQ_PLUS_LATEST));
+        return Stream.of(Arguments.of(QwenModelName.QWQ_PLUS), Arguments.of(QwenModelName.QWQ_PLUS_LATEST));
     }
 
     public static Stream<Arguments> functionCallChatModelNameProvider() {


### PR DESCRIPTION
## Change
Add qwen reasoning models.

Note: for qwq models, only streaming output is supported. Function Call and structured output (JSON Mode) are not supported.

Reference: https://help.aliyun.com/zh/model-studio/user-guide/qwq



## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [X] There are no breaking changes
- [X] I have added unit and integration tests for my change
- [X] I have manually run all the unit tests in _all_ modules, and they are all green
- [X] I have manually run all integration tests in the module I have added/changed, and they are all green
