### PR TITLE
issue-125_neo4j-fix-constraint-creation

### DIFF
--- a/embedding-stores/langchain4j-community-neo4j/src/main/java/dev/langchain4j/community/store/embedding/neo4j/Neo4jEmbeddingStore.java
+++ b/embedding-stores/langchain4j-community-neo4j/src/main/java/dev/langchain4j/community/store/embedding/neo4j/Neo4jEmbeddingStore.java
@@ -398,9 +398,9 @@ public class Neo4jEmbeddingStore implements EmbeddingStore<TextSegment> {
     private boolean constraintExist() {
         try (var session = session()) {
             var query = """
-                    SHOW CONSTRAINTS\s
-                    WHERE $label IN labelsOrTypes\s
-                    AND $property IN properties\s
+                    SHOW CONSTRAINTS
+                    WHERE $label IN labelsOrTypes
+                    AND $property IN properties
                     AND type IN ['NODE_KEY', 'UNIQUENESS']
                     """;
             var result = session.run(query, Map.of("label", sanitizedLabel, "property", sanitizedIdProperty));

--- a/embedding-stores/langchain4j-community-neo4j/src/main/java/dev/langchain4j/community/store/embedding/neo4j/Neo4jEmbeddingStore.java
+++ b/embedding-stores/langchain4j-community-neo4j/src/main/java/dev/langchain4j/community/store/embedding/neo4j/Neo4jEmbeddingStore.java
@@ -403,7 +403,7 @@ public class Neo4jEmbeddingStore implements EmbeddingStore<TextSegment> {
                     AND $property IN properties
                     AND type IN ['NODE_KEY', 'UNIQUENESS']
                     """;
-            var result = session.run(query, Map.of("label", sanitizedLabel, "property", sanitizedIdProperty));
+            var result = session.run(query, Map.of("label", this.label, "property", this.idProperty));
 
             return !result.list().isEmpty();
         }

--- a/embedding-stores/langchain4j-community-neo4j/src/main/java/dev/langchain4j/community/store/embedding/neo4j/Neo4jEmbeddingStore.java
+++ b/embedding-stores/langchain4j-community-neo4j/src/main/java/dev/langchain4j/community/store/embedding/neo4j/Neo4jEmbeddingStore.java
@@ -391,13 +391,14 @@ public class Neo4jEmbeddingStore implements EmbeddingStore<TextSegment> {
         }
         createFullTextIndex();
         if (!constraintExist()) {
-            createUniqueConstraint();   
+            createUniqueConstraint();
         }
     }
 
     private boolean constraintExist() {
         try (var session = session()) {
-            var query = """
+            var query =
+                    """
                     SHOW CONSTRAINTS
                     WHERE $label IN labelsOrTypes
                     AND $property IN properties

--- a/embedding-stores/langchain4j-community-neo4j/src/test/java/dev/langchain4j/community/store/embedding/neo4j/Neo4jEmbeddingStoreBaseTest.java
+++ b/embedding-stores/langchain4j-community-neo4j/src/test/java/dev/langchain4j/community/store/embedding/neo4j/Neo4jEmbeddingStoreBaseTest.java
@@ -24,11 +24,13 @@ public abstract class Neo4jEmbeddingStoreBaseTest extends EmbeddingStoreIT {
     protected static final String USERNAME = "neo4j";
     protected static final String ADMIN_PASSWORD = "adminPass";
     protected static final String LABEL_TO_SANITIZE = "Label ` to \\ sanitize";
-    protected static final String NEO4J_VERSION = System.getProperty("neo4jVersion", "5.26");
+    protected static final String NEO4J_VERSION = System.getProperty("neo4jVersion", "5.26-enterprise");
 
     @Container
     protected static Neo4jContainer<?> neo4jContainer =
-            new Neo4jContainer<>(DockerImageName.parse("neo4j:" + NEO4J_VERSION)).withAdminPassword(ADMIN_PASSWORD);
+            new Neo4jContainer<>(DockerImageName.parse("neo4j:" + NEO4J_VERSION))
+                    .withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
+                    .withAdminPassword(ADMIN_PASSWORD);
 
     protected static final String METADATA_KEY = "test-key";
 

--- a/embedding-stores/langchain4j-community-neo4j/src/test/java/dev/langchain4j/community/store/embedding/neo4j/Neo4jEmbeddingStoreBaseTest.java
+++ b/embedding-stores/langchain4j-community-neo4j/src/test/java/dev/langchain4j/community/store/embedding/neo4j/Neo4jEmbeddingStoreBaseTest.java
@@ -27,10 +27,10 @@ public abstract class Neo4jEmbeddingStoreBaseTest extends EmbeddingStoreIT {
     protected static final String NEO4J_VERSION = System.getProperty("neo4jVersion", "5.26-enterprise");
 
     @Container
-    protected static Neo4jContainer<?> neo4jContainer =
-            new Neo4jContainer<>(DockerImageName.parse("neo4j:" + NEO4J_VERSION))
-                    .withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
-                    .withAdminPassword(ADMIN_PASSWORD);
+    protected static Neo4jContainer<?> neo4jContainer = new Neo4jContainer<>(
+                    DockerImageName.parse("neo4j:" + NEO4J_VERSION))
+            .withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
+            .withAdminPassword(ADMIN_PASSWORD);
 
     protected static final String METADATA_KEY = "test-key";
 

--- a/embedding-stores/langchain4j-community-neo4j/src/test/java/dev/langchain4j/community/store/embedding/neo4j/Neo4jEmbeddingStoreSchemaCreationTest.java
+++ b/embedding-stores/langchain4j-community-neo4j/src/test/java/dev/langchain4j/community/store/embedding/neo4j/Neo4jEmbeddingStoreSchemaCreationTest.java
@@ -1,0 +1,119 @@
+package dev.langchain4j.community.store.embedding.neo4j;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.neo4j.driver.Values.ofString;
+
+class Neo4jEmbeddingStoreSchemaCreationTest extends Neo4jEmbeddingStoreBaseTest {
+
+    @Test
+    void should_create_vector_index_if_not_existing() {
+        Neo4jEmbeddingStore.builder()
+                .label("Document0")
+                .embeddingProperty("embedding")
+                .indexName("vector0")
+                .dimension(384)
+                .withBasicAuth(neo4jContainer.getBoltUrl(), USERNAME, ADMIN_PASSWORD)
+                .build();
+
+        var index = session.run("SHOW VECTOR INDEX WHERE 'Document0' IN labelsOrTypes").single().get("name").asString();
+        assertThat(index).isEqualTo("vector0");
+    }
+
+    @Test
+    void should_not_fail_if_vector_index_exist() {
+        var createVectorIndexQuery = """
+                    CREATE VECTOR INDEX vector1
+                    FOR (n:Document1) ON n.embedding
+                    OPTIONS {
+                        indexConfig: {
+                            `vector.dimensions`: 384
+                        }
+                    }
+                    """;
+        session.run(createVectorIndexQuery);
+
+        Neo4jEmbeddingStore.builder()
+                .label("Document1")
+                .embeddingProperty("embedding")
+                .indexName("vector1")
+                .dimension(384)
+                .withBasicAuth(neo4jContainer.getBoltUrl(), USERNAME, ADMIN_PASSWORD)
+                .build();
+    }
+
+    @Test
+    void should_create_unique_index_on_id_if_not_existing() {
+        Neo4jEmbeddingStore.builder()
+                .label("Document2")
+                .embeddingProperty("embedding")
+                .indexName("vector2")
+                .dimension(384)
+                .withBasicAuth(neo4jContainer.getBoltUrl(), USERNAME, ADMIN_PASSWORD)
+                .build();
+
+        var uniqueConstraint = session.run("SHOW CONSTRAINT WHERE 'Document2' IN labelsOrTypes").single();
+        var properties = uniqueConstraint.get("properties").asList(ofString());
+        var type = uniqueConstraint.get("type").asString();
+        assertThat(properties).containsExactly("id");
+        assertThat(type).isEqualTo("UNIQUENESS");
+    }
+
+    @Test
+    void should_not_create_unique_index_if_already_existing() {
+        var createUniqueConstraintQuery = """
+                CREATE CONSTRAINT uidx3
+                FOR (n:Document3)
+                REQUIRE n.id IS UNIQUE;
+                """;
+        session.run(createUniqueConstraintQuery);
+
+        Neo4jEmbeddingStore.builder()
+                .label("Document3")
+                .embeddingProperty("embedding")
+                .indexName("vector3")
+                .dimension(384)
+                .withBasicAuth(neo4jContainer.getBoltUrl(), USERNAME, ADMIN_PASSWORD)
+                .build();
+
+        var constraintName = session.run("SHOW CONSTRAINT WHERE 'Document3' IN labelsOrTypes").single().get("name").asString();
+        assertThat(constraintName).isEqualTo("uidx3");
+    }
+
+    @Test
+    void should_not_fail_if_node_key_constraint_exist() {
+        var createNodeKeyConstraintQuery = """
+                CREATE CONSTRAINT nk4
+                FOR (n:Document4)
+                REQUIRE n.id IS NODE KEY;
+                """;
+        session.run(createNodeKeyConstraintQuery);
+
+        Neo4jEmbeddingStore.builder()
+                .label("Document4")
+                .embeddingProperty("embedding")
+                .indexName("vector4")
+                .dimension(384)
+                .withBasicAuth(neo4jContainer.getBoltUrl(), USERNAME, ADMIN_PASSWORD)
+                .build();
+
+        var constraintName = session.run("SHOW CONSTRAINT WHERE 'Document4' IN labelsOrTypes").single().get("name").asString();
+        assertThat(constraintName).isEqualTo("nk4");
+    }
+
+    @Test
+    void should_create_constraint_on_given_id_property() {
+        Neo4jEmbeddingStore.builder()
+                .label("Document5")
+                .embeddingProperty("embedding")
+                .indexName("vector5")
+                .idProperty("docId")
+                .dimension(384)
+                .withBasicAuth(neo4jContainer.getBoltUrl(), USERNAME, ADMIN_PASSWORD)
+                .build();
+
+        var constraintProperties = session.run("SHOW CONSTRAINT WHERE 'Document5' IN labelsOrTypes").single().get("properties").asList(ofString());
+        assertThat(constraintProperties).containsExactly("docId");
+    }
+}

--- a/embedding-stores/langchain4j-community-neo4j/src/test/java/dev/langchain4j/community/store/embedding/neo4j/Neo4jEmbeddingStoreSchemaCreationTest.java
+++ b/embedding-stores/langchain4j-community-neo4j/src/test/java/dev/langchain4j/community/store/embedding/neo4j/Neo4jEmbeddingStoreSchemaCreationTest.java
@@ -1,9 +1,9 @@
 package dev.langchain4j.community.store.embedding.neo4j;
 
-import org.junit.jupiter.api.Test;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.neo4j.driver.Values.ofString;
+
+import org.junit.jupiter.api.Test;
 
 class Neo4jEmbeddingStoreSchemaCreationTest extends Neo4jEmbeddingStoreBaseTest {
 
@@ -17,13 +17,17 @@ class Neo4jEmbeddingStoreSchemaCreationTest extends Neo4jEmbeddingStoreBaseTest 
                 .withBasicAuth(neo4jContainer.getBoltUrl(), USERNAME, ADMIN_PASSWORD)
                 .build();
 
-        var index = session.run("SHOW VECTOR INDEX WHERE 'Document0' IN labelsOrTypes").single().get("name").asString();
+        var index = session.run("SHOW VECTOR INDEX WHERE 'Document0' IN labelsOrTypes")
+                .single()
+                .get("name")
+                .asString();
         assertThat(index).isEqualTo("vector0");
     }
 
     @Test
     void should_not_fail_if_vector_index_exist() {
-        var createVectorIndexQuery = """
+        var createVectorIndexQuery =
+                """
                     CREATE VECTOR INDEX vector1
                     FOR (n:Document1) ON n.embedding
                     OPTIONS {
@@ -53,7 +57,8 @@ class Neo4jEmbeddingStoreSchemaCreationTest extends Neo4jEmbeddingStoreBaseTest 
                 .withBasicAuth(neo4jContainer.getBoltUrl(), USERNAME, ADMIN_PASSWORD)
                 .build();
 
-        var uniqueConstraint = session.run("SHOW CONSTRAINT WHERE 'Document2' IN labelsOrTypes").single();
+        var uniqueConstraint = session.run("SHOW CONSTRAINT WHERE 'Document2' IN labelsOrTypes")
+                .single();
         var properties = uniqueConstraint.get("properties").asList(ofString());
         var type = uniqueConstraint.get("type").asString();
         assertThat(properties).containsExactly("id");
@@ -62,7 +67,8 @@ class Neo4jEmbeddingStoreSchemaCreationTest extends Neo4jEmbeddingStoreBaseTest 
 
     @Test
     void should_not_create_unique_index_if_already_existing() {
-        var createUniqueConstraintQuery = """
+        var createUniqueConstraintQuery =
+                """
                 CREATE CONSTRAINT uidx3
                 FOR (n:Document3)
                 REQUIRE n.id IS UNIQUE;
@@ -77,13 +83,17 @@ class Neo4jEmbeddingStoreSchemaCreationTest extends Neo4jEmbeddingStoreBaseTest 
                 .withBasicAuth(neo4jContainer.getBoltUrl(), USERNAME, ADMIN_PASSWORD)
                 .build();
 
-        var constraintName = session.run("SHOW CONSTRAINT WHERE 'Document3' IN labelsOrTypes").single().get("name").asString();
+        var constraintName = session.run("SHOW CONSTRAINT WHERE 'Document3' IN labelsOrTypes")
+                .single()
+                .get("name")
+                .asString();
         assertThat(constraintName).isEqualTo("uidx3");
     }
 
     @Test
     void should_not_fail_if_node_key_constraint_exist() {
-        var createNodeKeyConstraintQuery = """
+        var createNodeKeyConstraintQuery =
+                """
                 CREATE CONSTRAINT nk4
                 FOR (n:Document4)
                 REQUIRE n.id IS NODE KEY;
@@ -98,7 +108,10 @@ class Neo4jEmbeddingStoreSchemaCreationTest extends Neo4jEmbeddingStoreBaseTest 
                 .withBasicAuth(neo4jContainer.getBoltUrl(), USERNAME, ADMIN_PASSWORD)
                 .build();
 
-        var constraintName = session.run("SHOW CONSTRAINT WHERE 'Document4' IN labelsOrTypes").single().get("name").asString();
+        var constraintName = session.run("SHOW CONSTRAINT WHERE 'Document4' IN labelsOrTypes")
+                .single()
+                .get("name")
+                .asString();
         assertThat(constraintName).isEqualTo("nk4");
     }
 
@@ -113,13 +126,17 @@ class Neo4jEmbeddingStoreSchemaCreationTest extends Neo4jEmbeddingStoreBaseTest 
                 .withBasicAuth(neo4jContainer.getBoltUrl(), USERNAME, ADMIN_PASSWORD)
                 .build();
 
-        var constraintProperties = session.run("SHOW CONSTRAINT WHERE 'Document5' IN labelsOrTypes").single().get("properties").asList(ofString());
+        var constraintProperties = session.run("SHOW CONSTRAINT WHERE 'Document5' IN labelsOrTypes")
+                .single()
+                .get("properties")
+                .asList(ofString());
         assertThat(constraintProperties).containsExactly("docId");
     }
 
     @Test
     void should_detect_existing_constraint_if_created_backticked() {
-        var createNodeKeyConstraintQuery = """
+        var createNodeKeyConstraintQuery =
+                """
                 CREATE CONSTRAINT nk6
                 FOR (n:Document6)
                 REQUIRE n.`id property` IS NODE KEY;
@@ -135,13 +152,17 @@ class Neo4jEmbeddingStoreSchemaCreationTest extends Neo4jEmbeddingStoreBaseTest 
                 .withBasicAuth(neo4jContainer.getBoltUrl(), USERNAME, ADMIN_PASSWORD)
                 .build();
 
-        var constraintName = session.run("SHOW CONSTRAINT WHERE 'Document6' IN labelsOrTypes").single().get("name").asString();
+        var constraintName = session.run("SHOW CONSTRAINT WHERE 'Document6' IN labelsOrTypes")
+                .single()
+                .get("name")
+                .asString();
         assertThat(constraintName).isEqualTo("nk6");
     }
 
     @Test
     void should_detect_existing_vector_index_if_created_backticked() {
-        var createVectorIndexQuery = """
+        var createVectorIndexQuery =
+                """
                     CREATE VECTOR INDEX vector7
                     FOR (n:`Document Seven`) ON n.embedding
                     OPTIONS {
@@ -160,7 +181,8 @@ class Neo4jEmbeddingStoreSchemaCreationTest extends Neo4jEmbeddingStoreBaseTest 
                 .withBasicAuth(neo4jContainer.getBoltUrl(), USERNAME, ADMIN_PASSWORD)
                 .build();
 
-        var existingVectorIndexes = session.run("SHOW VECTOR INDEX WHERE 'Document Seven' IN labelsOrTypes").list();
+        var existingVectorIndexes = session.run("SHOW VECTOR INDEX WHERE 'Document Seven' IN labelsOrTypes")
+                .list();
         assertThat(existingVectorIndexes).hasSize(1);
     }
 }


### PR DESCRIPTION
## Issue

Closes #125  - Embedding store cannot be instantiated if node key constraint exist

## Change

- Added existing constraint check before constraint creation
- Upgrade to Neo4j Enterprise container for tests, `NODE KEY` constraint not available in Neo4j community


## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [X] There are no breaking changes
- [X] I have added unit and integration tests for my change
- [X] I have manually run all the unit tests in _all_ modules, and they are all green
- [X] I have manually run all integration tests in the module I have added/changed, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)


## Checklist for adding new maven module
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-community-bom/pom.xml`


## Checklist for adding new embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
