### PR TITLE
redis: RedisChatMemoryStore  ttl & prefix support

### DIFF
--- a/embedding-stores/langchain4j-community-redis/src/main/java/dev/langchain4j/community/store/memory/chat/redis/RedisChatMemoryStore.java
+++ b/embedding-stores/langchain4j-community-redis/src/main/java/dev/langchain4j/community/store/memory/chat/redis/RedisChatMemoryStore.java
@@ -15,8 +15,14 @@ import redis.clients.jedis.JedisPooled;
 public class RedisChatMemoryStore implements ChatMemoryStore {
 
     private final JedisPooled client;
+    private final String keyPrefix;
+    private final Long ttl;
 
     public RedisChatMemoryStore(String host, Integer port, String user, String password) {
+        this(host, port, user, password, "", 0L);
+    }
+
+    public RedisChatMemoryStore(String host, Integer port, String user, String password, String prefix, Long ttl) {
         String finalHost = ensureNotBlank(host, "host");
         int finalPort = ensureNotNull(port, "port");
         if (user != null) {
@@ -26,18 +32,26 @@ public class RedisChatMemoryStore implements ChatMemoryStore {
         } else {
             this.client = new JedisPooled(finalHost, finalPort);
         }
+        this.keyPrefix = ensureNotNull(prefix, "prefix");
+        this.ttl = ensureNotNull(ttl, "ttl");
     }
 
     @Override
     public List<ChatMessage> getMessages(Object memoryId) {
-        String json = client.get(toMemoryIdString(memoryId));
+        String json = client.get(toRedisKey(memoryId));
         return json == null ? new ArrayList<>() : ChatMessageDeserializer.messagesFromJson(json);
     }
 
     @Override
     public void updateMessages(Object memoryId, List<ChatMessage> messages) {
         String json = ChatMessageSerializer.messagesToJson(ensureNotEmpty(messages, "messages"));
-        String res = client.set(toMemoryIdString(memoryId), json);
+        String key = toRedisKey(memoryId);
+        String res;
+        if (ttl > 0) {
+            res = client.setex(key, ttl, json);
+        } else {
+            res = client.set(key, json);
+        }
         if (!"OK".equals(res)) {
             throw new RedisChatMemoryStoreException("Set memory error, msg=" + res);
         }
@@ -45,15 +59,22 @@ public class RedisChatMemoryStore implements ChatMemoryStore {
 
     @Override
     public void deleteMessages(Object memoryId) {
-        client.del(toMemoryIdString(memoryId));
+        client.del(toRedisKey(memoryId));
     }
 
-    private static String toMemoryIdString(Object memoryId) {
+    private String toMemoryIdString(Object memoryId) {
         boolean isNullOrEmpty = memoryId == null || memoryId.toString().trim().isEmpty();
         if (isNullOrEmpty) {
             throw new IllegalArgumentException("memoryId cannot be null or empty");
         }
         return memoryId.toString();
+    }
+
+    /**
+     * Get the Redis key for a memory ID
+     */
+    private String toRedisKey(Object memoryId) {
+        return keyPrefix + toMemoryIdString(memoryId);
     }
 
     public static Builder builder() {
@@ -66,6 +87,8 @@ public class RedisChatMemoryStore implements ChatMemoryStore {
         private Integer port;
         private String user;
         private String password;
+        private Long ttl = 0L;
+        private String prefix = "";
 
         public Builder host(String host) {
             this.host = host;
@@ -87,8 +110,18 @@ public class RedisChatMemoryStore implements ChatMemoryStore {
             return this;
         }
 
+        public Builder ttl(Long ttl) {
+            this.ttl = ttl;
+            return this;
+        }
+
+        public Builder prefix(String prefix) {
+            this.prefix = prefix;
+            return this;
+        }
+
         public RedisChatMemoryStore build() {
-            return new RedisChatMemoryStore(host, port, user, password);
+            return new RedisChatMemoryStore(host, port, user, password, prefix, ttl);
         }
     }
 }

--- a/embedding-stores/langchain4j-community-redis/src/main/java/dev/langchain4j/community/store/memory/chat/redis/RedisChatMemoryStore.java
+++ b/embedding-stores/langchain4j-community-redis/src/main/java/dev/langchain4j/community/store/memory/chat/redis/RedisChatMemoryStore.java
@@ -12,16 +12,54 @@ import java.util.ArrayList;
 import java.util.List;
 import redis.clients.jedis.JedisPooled;
 
+/**
+ * Implementation of {@link ChatMemoryStore} that stores chat messages in Redis.
+ * Uses Jedis client to connect to Redis and manage message persistence.
+ * <p>
+ * Messages are stored as JSON strings under keys derived from the memory ID.
+ * Optional TTL (time-to-live) can be specified for automatic key expiration.
+ */
 public class RedisChatMemoryStore implements ChatMemoryStore {
 
+    /**
+     * Redis client for database operations.
+     */
     private final JedisPooled client;
+
+    /**
+     * Prefix to be added to all Redis keys.
+     */
     private final String keyPrefix;
+
+    /**
+     * Time-to-live value for Redis keys in seconds.
+     * Keys will automatically expire after this duration.
+     * A value of 0 or less means keys will not expire.
+     */
     private final Long ttl;
 
+    /**
+     * Constructs a new Redis chat memory store with default prefix and TTL.
+     *
+     * @param host     Redis server hostname
+     * @param port     Redis server port
+     * @param user     Redis user (can be null for non-authenticated connections)
+     * @param password Redis password (required if user is provided)
+     */
     public RedisChatMemoryStore(String host, Integer port, String user, String password) {
         this(host, port, user, password, "", 0L);
     }
 
+    /**
+     * Constructs a new Redis chat memory store with custom prefix and TTL.
+     *
+     * @param host     Redis server hostname
+     * @param port     Redis server port
+     * @param user     Redis user (can be null for non-authenticated connections)
+     * @param password Redis password (required if user is provided)
+     * @param prefix   Prefix for Redis keys (for namespacing)
+     * @param ttl      Time-to-live value in seconds (≤0 means no expiration)
+     */
     public RedisChatMemoryStore(String host, Integer port, String user, String password, String prefix, Long ttl) {
         String finalHost = ensureNotBlank(host, "host");
         int finalPort = ensureNotNull(port, "port");
@@ -36,12 +74,26 @@ public class RedisChatMemoryStore implements ChatMemoryStore {
         this.ttl = ensureNotNull(ttl, "ttl");
     }
 
+    /**
+     * Retrieves all chat messages associated with the given memory ID.
+     *
+     * @param memoryId The identifier for the memory to retrieve
+     * @return List of chat messages or an empty list if no messages found
+     */
     @Override
     public List<ChatMessage> getMessages(Object memoryId) {
         String json = client.get(toRedisKey(memoryId));
         return json == null ? new ArrayList<>() : ChatMessageDeserializer.messagesFromJson(json);
     }
 
+    /**
+     * Updates the messages associated with the given memory ID.
+     * If TTL is set, the keys will automatically expire after the specified duration.
+     *
+     * @param memoryId The identifier for the memory to update
+     * @param messages The list of messages to store
+     * @throws RedisChatMemoryStoreException If the Redis operation fails
+     */
     @Override
     public void updateMessages(Object memoryId, List<ChatMessage> messages) {
         String json = ChatMessageSerializer.messagesToJson(ensureNotEmpty(messages, "messages"));
@@ -57,11 +109,23 @@ public class RedisChatMemoryStore implements ChatMemoryStore {
         }
     }
 
+    /**
+     * Deletes all messages associated with the given memory ID.
+     *
+     * @param memoryId The identifier for the memory to delete
+     */
     @Override
     public void deleteMessages(Object memoryId) {
         client.del(toRedisKey(memoryId));
     }
 
+    /**
+     * Converts a memory ID object to a string representation.
+     *
+     * @param memoryId The memory ID to convert
+     * @return String representation of the memory ID
+     * @throws IllegalArgumentException If memoryId is null or empty
+     */
     private String toMemoryIdString(Object memoryId) {
         boolean isNullOrEmpty = memoryId == null || memoryId.toString().trim().isEmpty();
         if (isNullOrEmpty) {
@@ -71,16 +135,27 @@ public class RedisChatMemoryStore implements ChatMemoryStore {
     }
 
     /**
-     * Get the Redis key for a memory ID
+     * Generates a Redis key for the given memory ID by applying the configured prefix.
+     *
+     * @param memoryId The memory ID to generate a key for
+     * @return The Redis key string
      */
     private String toRedisKey(Object memoryId) {
         return keyPrefix + toMemoryIdString(memoryId);
     }
 
+    /**
+     * Creates a new builder instance for constructing a RedisChatMemoryStore.
+     *
+     * @return A new Builder instance
+     */
     public static Builder builder() {
         return new Builder();
     }
 
+    /**
+     * Builder for creating RedisChatMemoryStore instances with fluent API.
+     */
     public static class Builder {
 
         private String host;
@@ -90,36 +165,80 @@ public class RedisChatMemoryStore implements ChatMemoryStore {
         private Long ttl = 0L;
         private String prefix = "";
 
+        /**
+         * Sets the Redis host.
+         *
+         * @param host The Redis server hostname or IP address
+         * @return This builder for method chaining
+         */
         public Builder host(String host) {
             this.host = host;
             return this;
         }
 
+        /**
+         * Sets the Redis port.
+         *
+         * @param port The Redis server port
+         * @return This builder for method chaining
+         */
         public Builder port(Integer port) {
             this.port = port;
             return this;
         }
 
+        /**
+         * Sets the Redis user for authentication.
+         *
+         * @param user The Redis username
+         * @return This builder for method chaining
+         */
         public Builder user(String user) {
             this.user = user;
             return this;
         }
 
+        /**
+         * Sets the Redis password for authentication.
+         *
+         * @param password The Redis password
+         * @return This builder for method chaining
+         */
         public Builder password(String password) {
             this.password = password;
             return this;
         }
 
+        /**
+         * Sets the Time-To-Live (TTL) value for the Redis keys.
+         * This value determines how long the keys will persist in Redis before being automatically deleted.
+         *
+         * @param ttl The TTL value in seconds. A value of 0 or less means the keys will not expire.
+         * @return The Builder instance for method chaining.
+         */
         public Builder ttl(Long ttl) {
             this.ttl = ttl;
             return this;
         }
 
+        /**
+         * Sets the prefix to be used for Redis keys.
+         * This prefix is prepended to all keys stored in Redis, allowing for better organization or namespacing.
+         * Usually would end with a colon. ex "chat:"
+         *
+         * @param prefix The prefix string to be added to Redis keys.
+         * @return The Builder instance for method chaining.
+         */
         public Builder prefix(String prefix) {
             this.prefix = prefix;
             return this;
         }
 
+        /**
+         * Builds a new RedisChatMemoryStore instance with the configured parameters.
+         *
+         * @return A new RedisChatMemoryStore instance
+         */
         public RedisChatMemoryStore build() {
             return new RedisChatMemoryStore(host, port, user, password, prefix, ttl);
         }

--- a/embedding-stores/langchain4j-community-redis/src/test/java/dev/langchain4j/community/store/memory/chat/redis/RedisChatMemoryStoreIT.java
+++ b/embedding-stores/langchain4j-community-redis/src/test/java/dev/langchain4j/community/store/memory/chat/redis/RedisChatMemoryStoreIT.java
@@ -83,6 +83,42 @@ class RedisChatMemoryStoreIT {
     }
 
     @Test
+    void should_set_messages_with_ttl_into_redis() {
+        RedisChatMemoryStore ttlMemoryStore = RedisChatMemoryStore.builder()
+                .port(redis.getFirstMappedPort())
+                .host(redis.getHost())
+                .ttl(3L) // 3 seconds
+                .build();
+
+        // given
+        List<ChatMessage> messages = ttlMemoryStore.getMessages(userId);
+        assertThat(messages).isEmpty();
+
+        // when
+        List<ChatMessage> chatMessages = new ArrayList<>();
+        chatMessages.add(new SystemMessage("You are a large language model working with Langchain4j"));
+        List<Content> userMsgContents = new ArrayList<>();
+        userMsgContents.add(new ImageContent("someCatImageUrl"));
+        chatMessages.add(new UserMessage("What do you see in this image?", userMsgContents));
+        ttlMemoryStore.updateMessages(userId, chatMessages);
+
+        // then
+        messages = ttlMemoryStore.getMessages(userId);
+        assertThat(messages).hasSize(2);
+
+        // wait for 4 seconds to check if the messages are deleted
+        try {
+            Thread.sleep(4000);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+
+        // verify that messages
+        messages = ttlMemoryStore.getMessages(userId);
+        assertThat(messages).isEmpty();
+    }
+
+    @Test
     void getMessages_memoryId_null() {
         assertThatThrownBy(() -> memoryStore.getMessages(null))
                 .isExactlyInstanceOf(IllegalArgumentException.class)
@@ -171,6 +207,28 @@ class RedisChatMemoryStoreIT {
                         .build())
                 .isExactlyInstanceOf(IllegalArgumentException.class)
                 .hasMessage("host cannot be null or blank");
+    }
+
+    @Test
+    void constructor_ttl_null() {
+        assertThatThrownBy(() -> RedisChatMemoryStore.builder()
+                        .port(redis.getFirstMappedPort())
+                        .host(redis.getHost())
+                        .ttl(null)
+                        .build())
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ttl cannot be null");
+    }
+
+    @Test
+    void constructor_prefix_null() {
+        assertThatThrownBy(() -> RedisChatMemoryStore.builder()
+                        .port(redis.getFirstMappedPort())
+                        .host(redis.getHost())
+                        .prefix(null)
+                        .build())
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("prefix cannot be null");
     }
 
     @Test

--- a/embedding-stores/langchain4j-community-redis/src/test/java/dev/langchain4j/community/store/memory/chat/redis/RedisChatMemoryStoreIT.java
+++ b/embedding-stores/langchain4j-community-redis/src/test/java/dev/langchain4j/community/store/memory/chat/redis/RedisChatMemoryStoreIT.java
@@ -119,6 +119,31 @@ class RedisChatMemoryStoreIT {
     }
 
     @Test
+    void should_set_messages_with_prefix_into_redis() {
+        RedisChatMemoryStore prefixStore = RedisChatMemoryStore.builder()
+                .port(redis.getFirstMappedPort())
+                .host(redis.getHost())
+                .prefix("chat:")
+                .build();
+
+        // given
+        List<ChatMessage> messages = prefixStore.getMessages(userId);
+        assertThat(messages).isEmpty();
+
+        // when
+        List<ChatMessage> chatMessages = new ArrayList<>();
+        chatMessages.add(new SystemMessage("You are a large language model working with Langchain4j"));
+        List<Content> userMsgContents = new ArrayList<>();
+        userMsgContents.add(new ImageContent("someCatImageUrl"));
+        chatMessages.add(new UserMessage("What do you see in this image?", userMsgContents));
+        prefixStore.updateMessages(userId, chatMessages);
+
+        // then
+        messages = prefixStore.getMessages(userId);
+        assertThat(messages).hasSize(2);
+    }
+
+    @Test
     void getMessages_memoryId_null() {
         assertThatThrownBy(() -> memoryStore.getMessages(null))
                 .isExactlyInstanceOf(IllegalArgumentException.class)


### PR DESCRIPTION

## Issue
<!-- Please specify the ID of the issue this PR is addressing. For example: "Closes #1234" or "Fixes #1234" -->
Redis based RedisChatMemoryStore doesn't support ttl & prefix which is supported in the [python version](https://github.com/langchain-ai/langchain-redis/blob/main/libs/redis/langchain_redis/chat_message_history.py).

## Change
Added support for ttl & prefixKey in RedisChatMemoryStore.


## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [x] There are no breaking changes
- [x] I have added unit and integration tests for my change
- [x] I have manually run all the unit tests in _all_ modules, and they are all green
- [x] I have manually run all integration tests in the module I have added/changed, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

  
## Checklist for changing existing embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [x] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
