### PR TITLE
Release to Maven Central Portal

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,9 +17,9 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
           cache: maven
-          server-id: ossrh
-          server-username: OSSRH_USERNAME
-          server-password: OSSRH_PASSWORD
+          server-id: central
+          server-username: MAVEN_CENTRAL_USERNAME
+          server-password: MAVEN_CENTRAL_PASSWORD
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg-passphrase: GPG_PASSPHRASE
 
@@ -31,5 +31,5 @@ jobs:
             clean deploy
         env:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}

--- a/.github/workflows/snapshot_release.yaml
+++ b/.github/workflows/snapshot_release.yaml
@@ -22,13 +22,13 @@ jobs:
         # JVMs running the version specified in each module's maven.compiler.target property
           java-version: '21'
           distribution: 'temurin'
-          server-id: ossrh
-          server-username: OSSRH_USERNAME
-          server-password: OSSRH_PASSWORD
+          server-id: central
+          server-username: MAVEN_CENTRAL_USERNAME
+          server-password: MAVEN_CENTRAL_PASSWORD
       - name: snapshot_release
         env:
-          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
         # Notes:
         #  - tests already run in a separate action (main)
         run: |

--- a/content-retrievers/langchain4j-community-lucene/pom.xml
+++ b/content-retrievers/langchain4j-community-lucene/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>dev.langchain4j</groupId>
         <artifactId>langchain4j-community</artifactId>
-        <version>1.0.0-beta4-SNAPSHOT</version>
+        <version>1.1.0-beta7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/content-retrievers/langchain4j-community-neo4j-retriever/pom.xml
+++ b/content-retrievers/langchain4j-community-neo4j-retriever/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>dev.langchain4j</groupId>
         <artifactId>langchain4j-community</artifactId>
-        <version>1.0.0-beta4-SNAPSHOT</version>
+        <version>1.1.0-beta7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/document-parsers/langchain4j-community-document-parser-llamaparse/pom.xml
+++ b/document-parsers/langchain4j-community-document-parser-llamaparse/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>dev.langchain4j</groupId>
         <artifactId>langchain4j-community</artifactId>
-        <version>1.0.0-beta4-SNAPSHOT</version>
+        <version>1.1.0-beta7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/document-transformers/langchain4j-community-llm-graph-transformer/pom.xml
+++ b/document-transformers/langchain4j-community-llm-graph-transformer/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>dev.langchain4j</groupId>
         <artifactId>langchain4j-community</artifactId>
-        <version>1.0.0-beta4-SNAPSHOT</version>
+        <version>1.1.0-beta7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/embedding-stores/langchain4j-community-alloydb-pg/README.md
+++ b/embedding-stores/langchain4j-community-alloydb-pg/README.md
@@ -28,7 +28,7 @@ steps:
 <dependency>
     <groupId>dev.langchain4j</groupId>
     <artificatId>langchain4j-community-alloydb-pg</artificatId>
-    <version>1.0.0-beta4-SNAPSHOT</version>
+    <version>1.1.0-beta7-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/embedding-stores/langchain4j-community-alloydb-pg/pom.xml
+++ b/embedding-stores/langchain4j-community-alloydb-pg/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>dev.langchain4j</groupId>
         <artifactId>langchain4j-community</artifactId>
-        <version>1.0.0-beta4-SNAPSHOT</version>
+        <version>1.1.0-beta7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/embedding-stores/langchain4j-community-clickhouse/pom.xml
+++ b/embedding-stores/langchain4j-community-clickhouse/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>dev.langchain4j</groupId>
         <artifactId>langchain4j-community</artifactId>
-        <version>1.0.0-beta4-SNAPSHOT</version>
+        <version>1.1.0-beta7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/embedding-stores/langchain4j-community-cloud-sql-pg/README.md
+++ b/embedding-stores/langchain4j-community-cloud-sql-pg/README.md
@@ -32,7 +32,7 @@ steps:
 <dependency>
     <groupId>dev.langchain4j</groupId>
     <artificatId>langchain4j-community-cloud-sql-pg</artificatId>
-    <version>1.0.0-beta4-SNAPSHOT</version>
+    <version>1.1.0-beta7-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/embedding-stores/langchain4j-community-cloud-sql-pg/pom.xml
+++ b/embedding-stores/langchain4j-community-cloud-sql-pg/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>dev.langchain4j</groupId>
         <artifactId>langchain4j-community</artifactId>
-        <version>1.0.0-beta4-SNAPSHOT</version>
+        <version>1.1.0-beta7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/embedding-stores/langchain4j-community-duckdb/pom.xml
+++ b/embedding-stores/langchain4j-community-duckdb/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>dev.langchain4j</groupId>
         <artifactId>langchain4j-community</artifactId>
-        <version>1.0.0-beta4-SNAPSHOT</version>
+        <version>1.1.0-beta7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/embedding-stores/langchain4j-community-neo4j/pom.xml
+++ b/embedding-stores/langchain4j-community-neo4j/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>dev.langchain4j</groupId>
         <artifactId>langchain4j-community</artifactId>
-        <version>1.0.0-beta4-SNAPSHOT</version>
+        <version>1.1.0-beta7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/embedding-stores/langchain4j-community-redis/pom.xml
+++ b/embedding-stores/langchain4j-community-redis/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>dev.langchain4j</groupId>
         <artifactId>langchain4j-community</artifactId>
-        <version>1.0.0-beta4-SNAPSHOT</version>
+        <version>1.1.0-beta7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/embedding-stores/langchain4j-community-vearch/pom.xml
+++ b/embedding-stores/langchain4j-community-vearch/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>dev.langchain4j</groupId>
         <artifactId>langchain4j-community</artifactId>
-        <version>1.0.0-beta4-SNAPSHOT</version>
+        <version>1.1.0-beta7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/langchain4j-community-bom/pom.xml
+++ b/langchain4j-community-bom/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>dev.langchain4j</groupId>
         <artifactId>langchain4j-community</artifactId>
-        <version>1.0.0-beta4-SNAPSHOT</version>
+        <version>1.1.0-beta7-SNAPSHOT</version>
     </parent>
 
     <artifactId>langchain4j-community-bom</artifactId>

--- a/langchain4j-community-core/pom.xml
+++ b/langchain4j-community-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>dev.langchain4j</groupId>
         <artifactId>langchain4j-community</artifactId>
-        <version>1.0.0-beta4-SNAPSHOT</version>
+        <version>1.1.0-beta7-SNAPSHOT</version>
     </parent>
 
     <artifactId>langchain4j-community-core</artifactId>

--- a/models/langchain4j-community-chatglm/pom.xml
+++ b/models/langchain4j-community-chatglm/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>dev.langchain4j</groupId>
         <artifactId>langchain4j-community</artifactId>
-        <version>1.0.0-beta4-SNAPSHOT</version>
+        <version>1.1.0-beta7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/models/langchain4j-community-dashscope/pom.xml
+++ b/models/langchain4j-community-dashscope/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>dev.langchain4j</groupId>
         <artifactId>langchain4j-community</artifactId>
-        <version>1.0.0-beta4-SNAPSHOT</version>
+        <version>1.1.0-beta7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/models/langchain4j-community-qianfan/pom.xml
+++ b/models/langchain4j-community-qianfan/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>dev.langchain4j</groupId>
         <artifactId>langchain4j-community</artifactId>
-        <version>1.0.0-beta4-SNAPSHOT</version>
+        <version>1.1.0-beta7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/models/langchain4j-community-xinference/pom.xml
+++ b/models/langchain4j-community-xinference/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>dev.langchain4j</groupId>
         <artifactId>langchain4j-community</artifactId>
-        <version>1.0.0-beta4-SNAPSHOT</version>
+        <version>1.1.0-beta7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/models/langchain4j-community-zhipu-ai/pom.xml
+++ b/models/langchain4j-community-zhipu-ai/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>dev.langchain4j</groupId>
         <artifactId>langchain4j-community</artifactId>
-        <version>1.0.0-beta4-SNAPSHOT</version>
+        <version>1.1.0-beta7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -90,13 +90,6 @@
         <url>https://github.com/langchain4j/langchain4j-community</url>
     </scm>
 
-    <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-    </distributionManagement>
-
     <properties>
         <gib.disable>true</gib.disable>
         <langchain4j.core.version>1.0.0-beta4-SNAPSHOT</langchain4j.core.version>
@@ -104,16 +97,6 @@
         <langchain4j.http-client-jdk.version>1.0.0-beta4-SNAPSHOT</langchain4j.http-client-jdk.version>
         <langchain4j.open-ai.version>1.0.0-beta4-SNAPSHOT</langchain4j.open-ai.version>
     </properties>
-
-    <repositories>
-        <repository>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-            <id>ossrh-snapshots</id>
-            <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
-        </repository>
-    </repositories>
 
     <build>
         <plugins>
@@ -215,13 +198,13 @@
             </plugin>
 
             <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <version>0.7.0</version>
                 <extensions>true</extensions>
                 <configuration>
-                    <serverId>ossrh</serverId>
-                    <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                    <publishingServerId>central</publishingServerId>
+                    <autoPublish>true</autoPublish>
                 </configuration>
             </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,20 @@
         <langchain4j.open-ai.version>1.0.0-beta4-SNAPSHOT</langchain4j.open-ai.version>
     </properties>
 
+    <repositories>
+        <repository>
+            <name>Central Portal Snapshots</name>
+            <id>central-portal-snapshots</id>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
     <build>
         <plugins>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>dev.langchain4j</groupId>
         <artifactId>langchain4j-parent</artifactId>
-        <version>1.0.0-beta4-SNAPSHOT</version>
+        <version>1.1.0-beta7-SNAPSHOT</version>
         <relativePath></relativePath>
     </parent>
 
@@ -92,23 +92,23 @@
 
     <properties>
         <gib.disable>true</gib.disable>
-        <langchain4j.core.version>1.0.0-beta4-SNAPSHOT</langchain4j.core.version>
-        <langchain4j.version>1.0.0-beta4-SNAPSHOT</langchain4j.version>
-        <langchain4j.http-client-jdk.version>1.0.0-beta4-SNAPSHOT</langchain4j.http-client-jdk.version>
-        <langchain4j.open-ai.version>1.0.0-beta4-SNAPSHOT</langchain4j.open-ai.version>
+        <langchain4j.core.version>1.1.0-SNAPSHOT</langchain4j.core.version>
+        <langchain4j.version>1.1.0-SNAPSHOT</langchain4j.version>
+        <langchain4j.http-client-jdk.version>1.1.0-SNAPSHOT</langchain4j.http-client-jdk.version>
+        <langchain4j.open-ai.version>1.1.0-SNAPSHOT</langchain4j.open-ai.version>
     </properties>
 
     <repositories>
         <repository>
-            <name>Central Portal Snapshots</name>
-            <id>central-portal-snapshots</id>
-            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
             <releases>
                 <enabled>false</enabled>
             </releases>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
+            <id>central-portal-snapshots</id>
+            <name>Central Portal Snapshots</name>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
         </repository>
     </repositories>
 

--- a/spring-boot-starters/langchain4j-community-clickhouse-spring-boot-starter/pom.xml
+++ b/spring-boot-starters/langchain4j-community-clickhouse-spring-boot-starter/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>dev.langchain4j</groupId>
         <artifactId>langchain4j-community-spring-boot-starters</artifactId>
-        <version>1.0.0-beta4-SNAPSHOT</version>
+        <version>1.1.0-beta7-SNAPSHOT</version>
     </parent>
 
     <artifactId>langchain4j-community-clickhouse-spring-boot-starter</artifactId>

--- a/spring-boot-starters/langchain4j-community-dashscope-spring-boot-starter/pom.xml
+++ b/spring-boot-starters/langchain4j-community-dashscope-spring-boot-starter/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>dev.langchain4j</groupId>
         <artifactId>langchain4j-community-spring-boot-starters</artifactId>
-        <version>1.0.0-beta4-SNAPSHOT</version>
+        <version>1.1.0-beta7-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/spring-boot-starters/langchain4j-community-neo4j-spring-boot-starter/pom.xml
+++ b/spring-boot-starters/langchain4j-community-neo4j-spring-boot-starter/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>dev.langchain4j</groupId>
         <artifactId>langchain4j-community-spring-boot-starters</artifactId>
-        <version>1.0.0-beta4-SNAPSHOT</version>
+        <version>1.1.0-beta7-SNAPSHOT</version>
     </parent>
 
     <artifactId>langchain4j-community-neo4j-spring-boot-starter</artifactId>

--- a/spring-boot-starters/langchain4j-community-qianfan-spring-boot-starter/pom.xml
+++ b/spring-boot-starters/langchain4j-community-qianfan-spring-boot-starter/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>dev.langchain4j</groupId>
         <artifactId>langchain4j-community-spring-boot-starters</artifactId>
-        <version>1.0.0-beta4-SNAPSHOT</version>
+        <version>1.1.0-beta7-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/spring-boot-starters/langchain4j-community-redis-spring-boot-starter/pom.xml
+++ b/spring-boot-starters/langchain4j-community-redis-spring-boot-starter/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>dev.langchain4j</groupId>
         <artifactId>langchain4j-community-spring-boot-starters</artifactId>
-        <version>1.0.0-beta4-SNAPSHOT</version>
+        <version>1.1.0-beta7-SNAPSHOT</version>
     </parent>
 
     <artifactId>langchain4j-community-redis-spring-boot-starter</artifactId>

--- a/spring-boot-starters/langchain4j-community-vearch-spring-boot-starter/pom.xml
+++ b/spring-boot-starters/langchain4j-community-vearch-spring-boot-starter/pom.xml
@@ -29,29 +29,6 @@
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-http-client-spring-restclient</artifactId>
             <version>${project.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.springframework</groupId>
-                    <artifactId>spring-web</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>dev.langchain4j</groupId>
-                    <artifactId>langchain4j-http-client</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <!-- FIXME: it's strange langchain4j-http-client-spring-restclient does not contain spring-web and langchain4j-http-client -->
-
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-web</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>dev.langchain4j</groupId>
-            <artifactId>langchain4j-http-client</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/spring-boot-starters/langchain4j-community-vearch-spring-boot-starter/pom.xml
+++ b/spring-boot-starters/langchain4j-community-vearch-spring-boot-starter/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>dev.langchain4j</groupId>
         <artifactId>langchain4j-community-spring-boot-starters</artifactId>
-        <version>1.0.0-beta4-SNAPSHOT</version>
+        <version>1.1.0-beta7-SNAPSHOT</version>
     </parent>
 
     <artifactId>langchain4j-community-vearch-spring-boot-starter</artifactId>

--- a/spring-boot-starters/langchain4j-community-xinference-spring-boot-starter/pom.xml
+++ b/spring-boot-starters/langchain4j-community-xinference-spring-boot-starter/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>dev.langchain4j</groupId>
         <artifactId>langchain4j-community-spring-boot-starters</artifactId>
-        <version>1.0.0-beta4-SNAPSHOT</version>
+        <version>1.1.0-beta7-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/spring-boot-starters/pom.xml
+++ b/spring-boot-starters/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>dev.langchain4j</groupId>
         <artifactId>langchain4j-community</artifactId>
-        <version>1.0.0-beta4-SNAPSHOT</version>
+        <version>1.1.0-beta7-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/web-search-engines/langchain4j-community-web-search-engine-searxng/pom.xml
+++ b/web-search-engines/langchain4j-community-web-search-engine-searxng/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>dev.langchain4j</groupId>
         <artifactId>langchain4j-community</artifactId>
-        <version>1.0.0-beta4-SNAPSHOT</version>
+        <version>1.1.0-beta7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
Hi @Martin7-1, `dev.langchain4j` namespace has been migrated from `s01.oss.sonatype.org` to [maven central portal](https://central.sonatype.org/publish/publish-portal-maven/), we need to update the way we deploy artifacts