### PR TITLE
feat: Add GitLabDocumentLoader for importing files from GitLab repositories

### DIFF
--- a/document-loaders/langchain4j-community-document-loader-gitlab/pom.xml
+++ b/document-loaders/langchain4j-community-document-loader-gitlab/pom.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>dev.langchain4j</groupId>
+        <artifactId>langchain4j-community</artifactId>
+        <version>1.11.0-beta19-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>langchain4j-community-document-loader-gitlab</artifactId>
+    <packaging>jar</packaging>
+    <name>LangChain4j :: Community :: Document loader :: GitLab</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-core</artifactId>
+            <version>${langchain4j.core.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-http-client-jdk</artifactId>
+            <version>${langchain4j.http-client-jdk.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j</artifactId>
+            <version>${langchain4j.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/document-loaders/langchain4j-community-document-loader-gitlab/src/main/java/dev/langchain4j/community/data/document/loader/gitlab/GitLabDocumentLoader.java
+++ b/document-loaders/langchain4j-community-document-loader-gitlab/src/main/java/dev/langchain4j/community/data/document/loader/gitlab/GitLabDocumentLoader.java
@@ -1,0 +1,521 @@
+package dev.langchain4j.community.data.document.loader.gitlab;
+
+import static dev.langchain4j.internal.Utils.firstNotNull;
+import static dev.langchain4j.internal.Utils.isNullOrBlank;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.langchain4j.community.data.document.source.gitlab.GitLabSource;
+import dev.langchain4j.data.document.Document;
+import dev.langchain4j.data.document.DocumentLoader;
+import dev.langchain4j.data.document.DocumentParser;
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.exception.HttpException;
+import dev.langchain4j.http.client.HttpClient;
+import dev.langchain4j.http.client.HttpMethod;
+import dev.langchain4j.http.client.HttpRequest;
+import dev.langchain4j.http.client.SuccessfulHttpResponse;
+import dev.langchain4j.http.client.jdk.JdkHttpClientBuilder;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Loads documents from a GitLab repository using GitLab REST API v4.
+ *
+ * <p>Authentication: Personal Access Token via {@code PRIVATE-TOKEN} header.
+ *
+ * <p>Uses:
+ *
+ * <ul>
+ *   <li>{@code GET /projects/:id/repository/tree}</li>
+ *   <li>{@code GET /projects/:id/repository/files/:file_path/raw}</li>
+ * </ul>
+ */
+public class GitLabDocumentLoader {
+
+    public static final String METADATA_GITLAB_PROJECT_ID = "gitlab_project_id";
+
+    private static final Logger logger = LoggerFactory.getLogger(GitLabDocumentLoader.class);
+
+    private static final String BASE_URL_ENV = "GITLAB_BASE_URL";
+    private static final String BASE_URL_PROPERTY = "gitlab.base.url";
+    private static final String DEFAULT_BASE_URL = "https://gitlab.com";
+    private static final int DEFAULT_PER_PAGE = 100;
+    private static final String API_PATH = "/api";
+    private static final String API_V4_PATH = "/api/v4";
+    private static final String PROJECTS_PATH = "/projects/";
+
+    private final HttpClient httpClient;
+    private final ObjectMapper objectMapper;
+
+    private final String apiBaseUrl;
+    private final String projectId;
+    private final String encodedProjectId;
+    private final String projectWebUrl;
+    private final String personalAccessToken;
+
+    private GitLabDocumentLoader(Builder builder) {
+        String baseUrl = ensureNotBlank(resolveBaseUrl(builder.baseUrl), "baseUrl");
+        this.apiBaseUrl = apiBaseUrl(baseUrl);
+
+        this.projectId = ensureNotBlank(builder.projectId, "projectId").trim();
+        this.encodedProjectId = encodePathSegment(this.projectId);
+        this.projectWebUrl = projectWebUrl(webBaseUrl(baseUrl), this.projectId);
+
+        this.personalAccessToken = ensureNotBlank(builder.personalAccessToken, "personalAccessToken");
+
+        this.httpClient = firstNotNull("httpClient", builder.httpClient, new JdkHttpClientBuilder().build());
+        this.objectMapper = firstNotNull("objectMapper", builder.objectMapper, new ObjectMapper());
+    }
+
+    /**
+     * Loads a single file from the repository.
+     *
+     * <p>If {@code ref} is not provided, it will try {@code main} and then {@code master}.
+     */
+    public Document loadDocument(String filePath, DocumentParser parser) {
+        return loadDocument(null, filePath, parser);
+    }
+
+    /**
+     * Loads a single file from the repository.
+     *
+     * @param ref the branch/tag/commit SHA to load from. If blank, it will try {@code main} and then {@code master}.
+     */
+    public Document loadDocument(String ref, String filePath, DocumentParser parser) {
+        ensureNotBlank(filePath, "filePath");
+        ensureNotNull(parser, "parser");
+
+        TreeItem item = new TreeItem("blob", normalizePath(filePath));
+
+        RuntimeException lastException = null;
+        for (String candidateRef : resolveRefCandidates(ref)) {
+            try {
+                return loadFile(candidateRef, item, parser);
+            } catch (RuntimeException e) {
+                lastException = e;
+            }
+        }
+
+        throw ensureNotNull(lastException, "lastException");
+    }
+
+    /**
+     * Loads documents from a directory.
+     *
+     * @param ref       branch/tag/commit SHA. If blank, it will try {@code main} and then {@code master}.
+     * @param path      optional directory path within the repository. Blank means root.
+     * @param recursive whether to traverse sub-directories recursively.
+     */
+    public List<Document> loadDocuments(String ref, String path, boolean recursive, DocumentParser parser) {
+        ensureNotNull(parser, "parser");
+
+        String normalizedPath = blankToNull(path);
+
+        List<TreeItem> items = null;
+        String resolvedRef = null;
+        RuntimeException lastException = null;
+        for (String candidateRef : resolveRefCandidates(ref)) {
+            try {
+                items = listRepositoryTree(candidateRef, normalizedPath, recursive);
+                resolvedRef = candidateRef;
+                break;
+            } catch (RuntimeException e) {
+                lastException = e;
+            }
+        }
+
+        if (items == null || resolvedRef == null) {
+            throw ensureNotNull(lastException, "lastException");
+        }
+
+        List<Document> documents = new ArrayList<>();
+        for (TreeItem item : items) {
+            if (!"blob".equals(item.type)) {
+                continue;
+            }
+            try {
+                documents.add(loadFile(resolvedRef, item, parser));
+            } catch (RuntimeException e) {
+                logger.error("Failed to read document from GitLab: {}/{}", projectId, item.path, e);
+            }
+        }
+
+        return documents;
+    }
+
+    /**
+     * Loads all documents from the repository recursively.
+     *
+     * <p>If {@code ref} is not provided, it will try {@code main} and then {@code master}.
+     */
+    public List<Document> loadDocuments(DocumentParser parser) {
+        return loadDocuments(null, null, true, parser);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    private Document loadFile(String ref, TreeItem item, DocumentParser parser) {
+
+        URI uri = buildRawFileUri(ref, item.path);
+
+        logger.info("Loading document from GitLab: {}", uri);
+
+        HttpRequest request = HttpRequest.builder()
+                .url(uri.toString())
+                .method(HttpMethod.GET)
+                .addHeader("User-Agent", "LangChain4j")
+                .addHeader("PRIVATE-TOKEN", personalAccessToken)
+                .build();
+
+        byte[] bytes;
+
+        try {
+
+            SuccessfulHttpResponse response = httpClient.execute(request);
+
+            bytes = response.body().getBytes(StandardCharsets.UTF_8);
+
+        } catch (HttpException e) {
+
+            throw new GitLabDocumentLoaderException(
+                    "GitLab API request failed with status code " + e.statusCode() + ": " + e.getMessage(), e);
+
+        } catch (RuntimeException e) {
+
+            throw new GitLabDocumentLoaderException("Failed to call GitLab API: " + uri, e);
+        }
+
+        Metadata metadata = new Metadata();
+
+        metadata.put(METADATA_GITLAB_PROJECT_ID, projectId);
+
+        metadata.put(Document.FILE_NAME, fileName(item.path));
+
+        String url = buildWebUrl(projectWebUrl, ref, item.path);
+
+        if (!isNullOrBlank(url)) {
+
+            metadata.put(Document.URL, url);
+        }
+
+        return DocumentLoader.load(new GitLabSource(bytes, metadata), parser);
+    }
+
+    private List<TreeItem> listRepositoryTree(String ref, String path, boolean recursive) {
+        int page = 1;
+        List<TreeItem> items = new ArrayList<>();
+
+        while (page > 0) {
+            URI uri = buildRepositoryTreeUri(ref, path, recursive, page, DEFAULT_PER_PAGE);
+            SuccessfulHttpResponse response = sendJsonRequest(uri);
+            JsonNode body = readJsonBody(response, uri);
+
+            if (!body.isArray() || body.isEmpty()) {
+                return items;
+            }
+
+            addTreeItems(body, items);
+            page = nextPage(response);
+        }
+
+        return items;
+    }
+
+    private JsonNode readJsonBody(SuccessfulHttpResponse response, URI uri) {
+        try {
+            return objectMapper.readTree(response.body());
+        } catch (IOException e) {
+            throw new GitLabDocumentLoaderException("Failed to parse GitLab API response: " + uri, e);
+        }
+    }
+
+    private static void addTreeItems(JsonNode body, List<TreeItem> items) {
+        for (JsonNode node : body) {
+            TreeItem item = toTreeItem(node);
+            if (item != null) {
+                items.add(item);
+            }
+        }
+    }
+
+    private static TreeItem toTreeItem(JsonNode node) {
+        String type = node.path("type").asText(null);
+        String itemPath = node.path("path").asText(null);
+        if (isNullOrBlank(type) || isNullOrBlank(itemPath)) {
+            return null;
+        }
+        return new TreeItem(type, itemPath);
+    }
+
+    private static int nextPage(SuccessfulHttpResponse response) {
+        List<String> nextPages = response.headers().get("X-Next-Page");
+        if (nextPages == null || nextPages.isEmpty()) {
+            return 0;
+        }
+        String nextPage = nextPages.get(0);
+        if (isNullOrBlank(nextPage)) {
+            return 0;
+        }
+        return Integer.parseInt(nextPage);
+    }
+
+    private SuccessfulHttpResponse sendJsonRequest(URI uri) {
+
+        HttpRequest request = HttpRequest.builder()
+                .url(uri.toString())
+                .method(HttpMethod.GET)
+                .addHeader("Accept", "application/json")
+                .addHeader("User-Agent", "LangChain4j")
+                .addHeader("PRIVATE-TOKEN", personalAccessToken)
+                .build();
+
+        try {
+
+            return httpClient.execute(request);
+
+        } catch (HttpException e) {
+
+            throw new GitLabDocumentLoaderException(
+                    "GitLab API request failed with status code " + e.statusCode() + ": " + e.getMessage(), e);
+
+        } catch (RuntimeException e) {
+
+            throw new GitLabDocumentLoaderException("Failed to call GitLab API: " + uri, e);
+        }
+    }
+
+    private URI buildRepositoryTreeUri(String ref, String path, boolean recursive, int page, int perPage) {
+        Map<String, String> queryParams = new LinkedHashMap<>();
+        queryParams.put("recursive", String.valueOf(recursive));
+        queryParams.put("per_page", String.valueOf(perPage));
+        queryParams.put("page", String.valueOf(page));
+        if (!isNullOrBlank(ref)) {
+            queryParams.put("ref", ref);
+        }
+        if (!isNullOrBlank(path)) {
+            queryParams.put("path", path);
+        }
+
+        return URI.create(
+                apiBaseUrl + PROJECTS_PATH + encodedProjectId + "/repository/tree?" + encodeQuery(queryParams));
+    }
+
+    private URI buildRawFileUri(String ref, String filePath) {
+        Map<String, String> queryParams = new LinkedHashMap<>();
+        queryParams.put("ref", ensureNotBlank(ref, "ref"));
+
+        String encodedFilePath = encodePathSegment(normalizePath(filePath));
+        return URI.create(apiBaseUrl + PROJECTS_PATH + encodedProjectId + "/repository/files/" + encodedFilePath
+                + "/raw?" + encodeQuery(queryParams));
+    }
+
+    private static List<String> resolveRefCandidates(String ref) {
+        if (!isNullOrBlank(ref)) {
+            return List.of(ref.trim());
+        }
+        return List.of("main", "master");
+    }
+
+    private static String buildWebUrl(String projectWebUrl, String ref, String filePath) {
+        if (isNullOrBlank(projectWebUrl)) {
+            return null;
+        }
+
+        String normalizedProjectWebUrl = projectWebUrl.trim();
+        while (normalizedProjectWebUrl.endsWith("/")) {
+            normalizedProjectWebUrl = normalizedProjectWebUrl.substring(0, normalizedProjectWebUrl.length() - 1);
+        }
+
+        String encodedRef = encodePathSegment(ref);
+        String encodedPath = encodePathPreservingSlashes(normalizePath(filePath));
+        return normalizedProjectWebUrl + "/-/blob/" + encodedRef + "/" + encodedPath;
+    }
+
+    private static String encodePathPreservingSlashes(String path) {
+        String normalized = normalizePath(path);
+        String[] parts = normalized.split("/");
+        StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < parts.length; i++) {
+            if (i > 0) {
+                builder.append('/');
+            }
+            builder.append(encodePathSegment(parts[i]));
+        }
+        return builder.toString();
+    }
+
+    private static String encodeQuery(Map<String, String> queryParams) {
+        StringBuilder builder = new StringBuilder();
+        for (Map.Entry<String, String> entry : queryParams.entrySet()) {
+            if (!builder.isEmpty()) {
+                builder.append('&');
+            }
+            builder.append(URLEncoder.encode(entry.getKey(), StandardCharsets.UTF_8));
+            builder.append('=');
+            builder.append(URLEncoder.encode(entry.getValue(), StandardCharsets.UTF_8));
+        }
+        return builder.toString();
+    }
+
+    private static String encodePathSegment(String value) {
+        String decoded = decodePercentEncodedPreservingPlus(ensureNotBlank(value, "value"));
+        String encoded = URLEncoder.encode(decoded, StandardCharsets.UTF_8);
+        return encoded.replace("+", "%20");
+    }
+
+    private static String decodePercentEncodedPreservingPlus(String value) {
+        try {
+            return URLDecoder.decode(value.replace("+", "%2B"), StandardCharsets.UTF_8);
+        } catch (IllegalArgumentException e) {
+            return value;
+        }
+    }
+
+    private static String apiBaseUrl(String baseUrl) {
+        String normalized = normalizeBaseUrl(baseUrl);
+
+        if (normalized.endsWith(API_V4_PATH)) {
+            return normalized;
+        }
+        if (normalized.endsWith(API_PATH)) {
+            return normalized + "/v4";
+        }
+        return normalized + API_V4_PATH;
+    }
+
+    private static String webBaseUrl(String baseUrl) {
+        String normalized = normalizeBaseUrl(baseUrl);
+        if (normalized.endsWith(API_V4_PATH)) {
+            return normalized.substring(0, normalized.length() - API_V4_PATH.length());
+        }
+        if (normalized.endsWith(API_PATH)) {
+            return normalized.substring(0, normalized.length() - API_PATH.length());
+        }
+        return normalized;
+    }
+
+    private static String projectWebUrl(String webBaseUrl, String projectId) {
+        // The GitLab API accepts both numeric project IDs and URL-encoded paths (e.g. group%2Fproject),
+        // but the web URL should use the decoded project path (e.g. group/project).
+        String decodedProjectId = decodePercentEncodedPreservingPlus(
+                ensureNotBlank(projectId, "projectId").trim());
+        while (decodedProjectId.startsWith("/")) {
+            decodedProjectId = decodedProjectId.substring(1);
+        }
+
+        if (decodedProjectId.matches("\\d+")) {
+            return webBaseUrl + PROJECTS_PATH + decodedProjectId;
+        }
+
+        return webBaseUrl + "/" + decodedProjectId;
+    }
+
+    private static String normalizeBaseUrl(String baseUrl) {
+        String normalized = ensureNotBlank(baseUrl, "baseUrl").trim();
+        while (normalized.endsWith("/")) {
+            normalized = normalized.substring(0, normalized.length() - 1);
+        }
+        return normalized;
+    }
+
+    private static String normalizePath(String path) {
+        String normalized = ensureNotBlank(path, "path").trim();
+        while (normalized.startsWith("/")) {
+            normalized = normalized.substring(1);
+        }
+        return normalized;
+    }
+
+    private static String fileName(String path) {
+        String normalized = normalizePath(path);
+        int idx = normalized.lastIndexOf('/');
+        return idx >= 0 ? normalized.substring(idx + 1) : normalized;
+    }
+
+    private static String resolveBaseUrl(String baseUrl) {
+        String resolved = blankToNull(baseUrl);
+        if (resolved != null) {
+            return resolved;
+        }
+        String fromProperty = blankToNull(System.getProperty(BASE_URL_PROPERTY));
+        if (fromProperty != null) {
+            return fromProperty;
+        }
+        String fromEnv = blankToNull(System.getenv(BASE_URL_ENV));
+        if (fromEnv != null) {
+            return fromEnv;
+        }
+        return DEFAULT_BASE_URL;
+    }
+
+    private static String blankToNull(String value) {
+        return isNullOrBlank(value) ? null : value.trim();
+    }
+
+    private record TreeItem(String type, String path) {}
+
+    public static class Builder {
+
+        private String baseUrl;
+        private String projectId;
+        private String personalAccessToken;
+
+        private HttpClient httpClient;
+        private ObjectMapper objectMapper;
+
+        /**
+         * Base URL of the GitLab instance.
+         *
+         * <p>When unset, uses {@code GITLAB_BASE_URL} or {@code gitlab.base.url}, falling
+         * back to {@code https://gitlab.com}.
+         */
+        public Builder baseUrl(String baseUrl) {
+            this.baseUrl = baseUrl;
+            return this;
+        }
+
+        /**
+         * Project ID or URL-encoded path (e.g. {@code 123} or {@code group%2Fproject}).
+         */
+        public Builder projectId(String projectId) {
+            this.projectId = projectId;
+            return this;
+        }
+
+        /**
+         * Personal access token used as {@code PRIVATE-TOKEN}.
+         */
+        public Builder personalAccessToken(String personalAccessToken) {
+            this.personalAccessToken = personalAccessToken;
+            return this;
+        }
+
+        public Builder httpClient(HttpClient httpClient) {
+            this.httpClient = httpClient;
+            return this;
+        }
+
+        public Builder objectMapper(ObjectMapper objectMapper) {
+            this.objectMapper = objectMapper;
+            return this;
+        }
+
+        public GitLabDocumentLoader build() {
+            return new GitLabDocumentLoader(this);
+        }
+    }
+}

--- a/document-loaders/langchain4j-community-document-loader-gitlab/src/main/java/dev/langchain4j/community/data/document/loader/gitlab/GitLabDocumentLoaderException.java
+++ b/document-loaders/langchain4j-community-document-loader-gitlab/src/main/java/dev/langchain4j/community/data/document/loader/gitlab/GitLabDocumentLoaderException.java
@@ -1,0 +1,10 @@
+package dev.langchain4j.community.data.document.loader.gitlab;
+
+import dev.langchain4j.exception.LangChain4jException;
+
+public class GitLabDocumentLoaderException extends LangChain4jException {
+
+    public GitLabDocumentLoaderException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/document-loaders/langchain4j-community-document-loader-gitlab/src/main/java/dev/langchain4j/community/data/document/source/gitlab/GitLabSource.java
+++ b/document-loaders/langchain4j-community-document-loader-gitlab/src/main/java/dev/langchain4j/community/data/document/source/gitlab/GitLabSource.java
@@ -1,0 +1,29 @@
+package dev.langchain4j.community.data.document.source.gitlab;
+
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
+import dev.langchain4j.data.document.DocumentSource;
+import dev.langchain4j.data.document.Metadata;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+public class GitLabSource implements DocumentSource {
+
+    private final byte[] bytes;
+    private final Metadata metadata;
+
+    public GitLabSource(byte[] bytes, Metadata metadata) {
+        this.bytes = ensureNotNull(bytes, "bytes");
+        this.metadata = ensureNotNull(metadata, "metadata");
+    }
+
+    @Override
+    public InputStream inputStream() {
+        return new ByteArrayInputStream(bytes);
+    }
+
+    @Override
+    public Metadata metadata() {
+        return metadata;
+    }
+}

--- a/document-loaders/langchain4j-community-document-loader-gitlab/src/test/java/dev/langchain4j/community/data/document/loader/gitlab/GitLabDocumentLoaderIT.java
+++ b/document-loaders/langchain4j-community-document-loader-gitlab/src/test/java/dev/langchain4j/community/data/document/loader/gitlab/GitLabDocumentLoaderIT.java
@@ -1,0 +1,133 @@
+package dev.langchain4j.community.data.document.loader.gitlab;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import dev.langchain4j.data.document.Document;
+import dev.langchain4j.data.document.DocumentParser;
+import dev.langchain4j.data.document.parser.TextDocumentParser;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+@EnabledIfEnvironmentVariable(named = "GITLAB_TOKEN", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "GITLAB_PROJECT_ID", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "GITLAB_TEST_FILE", matches = ".+")
+class GitLabDocumentLoaderIT {
+
+    private static final String ENV_GITLAB_TOKEN = "GITLAB_TOKEN";
+    private static final String ENV_GITLAB_PROJECT_ID = "GITLAB_PROJECT_ID";
+    private static final String ENV_GITLAB_TEST_FILE = "GITLAB_TEST_FILE";
+    private static final String ENV_GITLAB_BASE_URL = "GITLAB_BASE_URL";
+    private static final String ENV_GITLAB_REF = "GITLAB_REF";
+
+    private static final String DEFAULT_BASE_URL = "https://gitlab.com";
+
+    private GitLabDocumentLoader loader;
+    private final DocumentParser parser = new TextDocumentParser();
+
+    @BeforeEach
+    void setUp() {
+        loader = GitLabDocumentLoader.builder()
+                .baseUrl(envOrDefault(ENV_GITLAB_BASE_URL, DEFAULT_BASE_URL))
+                .projectId(envRequired(ENV_GITLAB_PROJECT_ID))
+                .personalAccessToken(envRequired(ENV_GITLAB_TOKEN))
+                .build();
+    }
+
+    @Test
+    void should_load_file() {
+        String ref = blankToNull(System.getenv(ENV_GITLAB_REF));
+        String filePath = envRequired(ENV_GITLAB_TEST_FILE);
+
+        Document document = loader.loadDocument(ref, filePath, parser);
+
+        assertThat(document.text()).isNotBlank();
+        assertThat(document.metadata().getString(GitLabDocumentLoader.METADATA_GITLAB_PROJECT_ID))
+                .isEqualTo(envRequired(ENV_GITLAB_PROJECT_ID));
+        assertThat(document.metadata().getString(Document.FILE_NAME)).isEqualTo(fileName(filePath));
+        assertThat(document.metadata().getString(Document.URL)).contains("/-/blob/");
+        if (!isBlank(ref)) {
+            assertThat(document.metadata().getString(Document.URL)).contains("/-/blob/" + ref + "/");
+        }
+    }
+
+    @Test
+    void should_load_documents_from_directory() {
+        String ref = blankToNull(System.getenv(ENV_GITLAB_REF));
+        String filePath = envRequired(ENV_GITLAB_TEST_FILE);
+        String directory = directoryOf(filePath);
+
+        List<Document> documents = loader.loadDocuments(ref, directory, false, parser);
+
+        assertThat(documents).isNotEmpty();
+        boolean hasTargetFile = documents.stream()
+                .map(doc -> doc.metadata().getString(Document.FILE_NAME))
+                .anyMatch(fileName(filePath)::equals);
+        assertThat(hasTargetFile).isTrue();
+    }
+
+    @Test
+    void should_fail_when_project_does_not_exist() {
+        GitLabDocumentLoader missingProjectLoader = GitLabDocumentLoader.builder()
+                .baseUrl(envOrDefault(ENV_GITLAB_BASE_URL, DEFAULT_BASE_URL))
+                .projectId("non-existent-project-" + System.currentTimeMillis())
+                .personalAccessToken(envRequired(ENV_GITLAB_TOKEN))
+                .build();
+
+        assertThatThrownBy(() -> missingProjectLoader.loadDocuments(parser))
+                .isInstanceOf(GitLabDocumentLoaderException.class)
+                .satisfies(e -> assertThat(e.getMessage()).contains("status code 404"));
+    }
+
+    @Test
+    void should_fail_with_invalid_token() {
+        GitLabDocumentLoader invalidTokenLoader = GitLabDocumentLoader.builder()
+                .baseUrl(envOrDefault(ENV_GITLAB_BASE_URL, DEFAULT_BASE_URL))
+                .projectId(envRequired(ENV_GITLAB_PROJECT_ID))
+                .personalAccessToken("invalid-token")
+                .build();
+
+        assertThatThrownBy(() -> invalidTokenLoader.loadDocuments(parser))
+                .isInstanceOf(GitLabDocumentLoaderException.class)
+                .satisfies(e -> assertThat(e.getMessage()).contains("status code 401"));
+    }
+
+    private static String envRequired(String name) {
+        return System.getenv(name);
+    }
+
+    private static String envOrDefault(String name, String defaultValue) {
+        String value = System.getenv(name);
+        return isBlank(value) ? defaultValue : value.trim();
+    }
+
+    private static String blankToNull(String value) {
+        return isBlank(value) ? null : value.trim();
+    }
+
+    private static boolean isBlank(String value) {
+        return value == null || value.trim().isEmpty();
+    }
+
+    private static String normalizePath(String path) {
+        String normalized = path == null ? "" : path.trim();
+        while (normalized.startsWith("/")) {
+            normalized = normalized.substring(1);
+        }
+        return normalized;
+    }
+
+    private static String fileName(String path) {
+        String normalized = normalizePath(path);
+        int idx = normalized.lastIndexOf('/');
+        return idx >= 0 ? normalized.substring(idx + 1) : normalized;
+    }
+
+    private static String directoryOf(String path) {
+        String normalized = normalizePath(path);
+        int idx = normalized.lastIndexOf('/');
+        return idx >= 0 ? normalized.substring(0, idx) : null;
+    }
+}

--- a/document-loaders/langchain4j-community-document-loader-gitlab/src/test/java/dev/langchain4j/community/data/document/loader/gitlab/GitLabDocumentLoaderTest.java
+++ b/document-loaders/langchain4j-community-document-loader-gitlab/src/test/java/dev/langchain4j/community/data/document/loader/gitlab/GitLabDocumentLoaderTest.java
@@ -1,0 +1,550 @@
+package dev.langchain4j.community.data.document.loader.gitlab;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import dev.langchain4j.data.document.Document;
+import dev.langchain4j.data.document.DocumentParser;
+import dev.langchain4j.exception.HttpException;
+import dev.langchain4j.http.client.HttpClient;
+import dev.langchain4j.http.client.HttpRequest;
+import dev.langchain4j.http.client.SuccessfulHttpResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class GitLabDocumentLoaderTest {
+
+    @Test
+    void shouldLoadTwoDocumentsFromRepositoryTree() {
+        HttpClient httpClient = mock(HttpClient.class);
+
+        SuccessfulHttpResponse treeResponse = SuccessfulHttpResponse.builder()
+                .statusCode(200)
+                .body(repositoryTreeResponseBody())
+                .build();
+
+        SuccessfulHttpResponse readmeResponse = SuccessfulHttpResponse.builder()
+                .statusCode(200)
+                .body(new String(readmeRawContent(), StandardCharsets.UTF_8))
+                .build();
+
+        SuccessfulHttpResponse mainJavaResponse = SuccessfulHttpResponse.builder()
+                .statusCode(200)
+                .body(new String(mainJavaRawContent(), StandardCharsets.UTF_8))
+                .build();
+
+        ArgumentCaptor<HttpRequest> requestCaptor = ArgumentCaptor.forClass(HttpRequest.class);
+
+        when(httpClient.execute(requestCaptor.capture())).thenReturn(treeResponse, readmeResponse, mainJavaResponse);
+
+        GitLabDocumentLoader loader = GitLabDocumentLoader.builder()
+                .baseUrl("https://gitlab.com")
+                .projectId("123")
+                .personalAccessToken("token")
+                .httpClient(httpClient)
+                .build();
+
+        DocumentParser parser = inputStream -> {
+            try {
+                return Document.from(new String(inputStream.readAllBytes(), StandardCharsets.UTF_8));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        };
+
+        List<Document> documents = loader.loadDocuments(parser);
+
+        assertThat(documents).hasSize(2);
+
+        Document readme = documents.get(0);
+        assertThat(readme.text()).isEqualTo("README content");
+        assertThat(readme.metadata().getString(GitLabDocumentLoader.METADATA_GITLAB_PROJECT_ID))
+                .isEqualTo("123");
+        assertThat(readme.metadata().getString(Document.FILE_NAME)).isEqualTo("README.md");
+        assertThat(readme.metadata().getString(Document.URL))
+                .isEqualTo("https://gitlab.com/projects/123/-/blob/main/README.md");
+
+        Document mainJava = documents.get(1);
+        assertThat(mainJava.text()).isEqualTo("public class Main {}");
+        assertThat(mainJava.metadata().getString(GitLabDocumentLoader.METADATA_GITLAB_PROJECT_ID))
+                .isEqualTo("123");
+        assertThat(mainJava.metadata().getString(Document.FILE_NAME)).isEqualTo("Main.java");
+        assertThat(mainJava.metadata().getString(Document.URL))
+                .isEqualTo("https://gitlab.com/projects/123/-/blob/main/src/Main.java");
+
+        List<HttpRequest> requests = requestCaptor.getAllValues();
+        assertThat(requests).hasSize(3);
+
+        assertThat(requests.get(0).url())
+                .isEqualTo(
+                        "https://gitlab.com/api/v4/projects/123/repository/tree?recursive=true&per_page=100&page=1&ref=main");
+        assertThat(requests.get(1).url())
+                .isEqualTo("https://gitlab.com/api/v4/projects/123/repository/files/README.md/raw?ref=main");
+        assertThat(requests.get(2).url())
+                .isEqualTo("https://gitlab.com/api/v4/projects/123/repository/files/src%2FMain.java/raw?ref=main");
+
+        assertThat(requests.get(0).headers().get("PRIVATE-TOKEN")).contains("token");
+        assertThat(requests.get(1).headers().get("PRIVATE-TOKEN")).contains("token");
+        assertThat(requests.get(2).headers().get("PRIVATE-TOKEN")).contains("token");
+    }
+
+    @Test
+    void shouldHandlePaginationWhenListingRepositoryTree() {
+        HttpClient httpClient = mock(HttpClient.class);
+
+        SuccessfulHttpResponse treePage1Response = SuccessfulHttpResponse.builder()
+                .statusCode(200)
+                .body(repositoryTreeResponseBodyPage1())
+                .headers(Map.of("X-Next-Page", List.of("2")))
+                .build();
+
+        SuccessfulHttpResponse treePage2Response = SuccessfulHttpResponse.builder()
+                .statusCode(200)
+                .body(repositoryTreeResponseBodyPage2())
+                .headers(Map.of("X-Next-Page", List.of("")))
+                .build();
+
+        SuccessfulHttpResponse readmeResponse = SuccessfulHttpResponse.builder()
+                .statusCode(200)
+                .body(new String(readmeRawContent(), StandardCharsets.UTF_8))
+                .build();
+
+        SuccessfulHttpResponse mainJavaResponse = SuccessfulHttpResponse.builder()
+                .statusCode(200)
+                .body(new String(mainJavaRawContent(), StandardCharsets.UTF_8))
+                .build();
+
+        ArgumentCaptor<HttpRequest> requestCaptor = ArgumentCaptor.forClass(HttpRequest.class);
+
+        when(httpClient.execute(requestCaptor.capture()))
+                .thenReturn(treePage1Response, treePage2Response, readmeResponse, mainJavaResponse);
+
+        GitLabDocumentLoader loader = GitLabDocumentLoader.builder()
+                .baseUrl("https://gitlab.com")
+                .projectId("123")
+                .personalAccessToken("token")
+                .httpClient(httpClient)
+                .build();
+
+        DocumentParser parser = inputStream -> {
+            try {
+                return Document.from(new String(inputStream.readAllBytes(), StandardCharsets.UTF_8));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        };
+
+        List<Document> documents = loader.loadDocuments(parser);
+
+        assertThat(documents).hasSize(2);
+        assertThat(documents.get(0).text()).isEqualTo("README content");
+        assertThat(documents.get(1).text()).isEqualTo("public class Main {}");
+
+        List<HttpRequest> requests = requestCaptor.getAllValues();
+        assertThat(requests).hasSize(4);
+
+        assertThat(requests.get(0).url())
+                .isEqualTo(
+                        "https://gitlab.com/api/v4/projects/123/repository/tree?recursive=true&per_page=100&page=1&ref=main");
+        assertThat(requests.get(1).url())
+                .isEqualTo(
+                        "https://gitlab.com/api/v4/projects/123/repository/tree?recursive=true&per_page=100&page=2&ref=main");
+        assertThat(requests.get(2).url())
+                .isEqualTo("https://gitlab.com/api/v4/projects/123/repository/files/README.md/raw?ref=main");
+        assertThat(requests.get(3).url())
+                .isEqualTo("https://gitlab.com/api/v4/projects/123/repository/files/src%2FMain.java/raw?ref=main");
+
+        assertThat(requests.get(0).headers().get("PRIVATE-TOKEN")).contains("token");
+        assertThat(requests.get(1).headers().get("PRIVATE-TOKEN")).contains("token");
+        assertThat(requests.get(2).headers().get("PRIVATE-TOKEN")).contains("token");
+        assertThat(requests.get(3).headers().get("PRIVATE-TOKEN")).contains("token");
+    }
+
+    @Test
+    void shouldFallbackFromMainToMasterWhenBranchNotFound() {
+        HttpClient httpClient = mock(HttpClient.class);
+
+        // First call for 'main' fails with 404
+        HttpException notFoundException = new HttpException(404, "Not Found");
+
+        SuccessfulHttpResponse treeMasterResponse = SuccessfulHttpResponse.builder()
+                .statusCode(200)
+                .body(repositoryTreeResponseBody())
+                .build();
+
+        SuccessfulHttpResponse readmeResponse = SuccessfulHttpResponse.builder()
+                .statusCode(200)
+                .body(new String(readmeRawContent(), StandardCharsets.UTF_8))
+                .build();
+
+        SuccessfulHttpResponse mainJavaResponse = SuccessfulHttpResponse.builder()
+                .statusCode(200)
+                .body(new String(mainJavaRawContent(), StandardCharsets.UTF_8))
+                .build();
+
+        ArgumentCaptor<HttpRequest> requestCaptor = ArgumentCaptor.forClass(HttpRequest.class);
+
+        when(httpClient.execute(requestCaptor.capture()))
+                .thenThrow(notFoundException)
+                .thenReturn(treeMasterResponse, readmeResponse, mainJavaResponse);
+
+        GitLabDocumentLoader loader = GitLabDocumentLoader.builder()
+                .baseUrl("https://gitlab.com")
+                .projectId("123")
+                .personalAccessToken("token")
+                .httpClient(httpClient)
+                .build();
+
+        DocumentParser parser = inputStream -> {
+            try {
+                return Document.from(new String(inputStream.readAllBytes(), StandardCharsets.UTF_8));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        };
+
+        List<Document> documents = loader.loadDocuments(parser);
+
+        assertThat(documents).hasSize(2);
+
+        Document readme = documents.get(0);
+        assertThat(readme.metadata().getString(Document.URL))
+                .isEqualTo("https://gitlab.com/projects/123/-/blob/master/README.md");
+
+        Document mainJava = documents.get(1);
+        assertThat(mainJava.metadata().getString(Document.URL))
+                .isEqualTo("https://gitlab.com/projects/123/-/blob/master/src/Main.java");
+
+        List<HttpRequest> requests = requestCaptor.getAllValues();
+        assertThat(requests).hasSize(4);
+
+        assertThat(requests.get(0).url())
+                .isEqualTo(
+                        "https://gitlab.com/api/v4/projects/123/repository/tree?recursive=true&per_page=100&page=1&ref=main");
+        assertThat(requests.get(1).url())
+                .isEqualTo(
+                        "https://gitlab.com/api/v4/projects/123/repository/tree?recursive=true&per_page=100&page=1&ref=master");
+        assertThat(requests.get(2).url())
+                .isEqualTo("https://gitlab.com/api/v4/projects/123/repository/files/README.md/raw?ref=master");
+        assertThat(requests.get(3).url())
+                .isEqualTo("https://gitlab.com/api/v4/projects/123/repository/files/src%2FMain.java/raw?ref=master");
+    }
+
+    @Test
+    void shouldBuildUrlsForProjectPath() {
+        HttpClient httpClient = mock(HttpClient.class);
+
+        SuccessfulHttpResponse treeResponse = SuccessfulHttpResponse.builder()
+                .statusCode(200)
+                .body(repositoryTreeResponseBodyReadmeOnly())
+                .build();
+
+        SuccessfulHttpResponse readmeResponse = SuccessfulHttpResponse.builder()
+                .statusCode(200)
+                .body(new String(readmeRawContent(), StandardCharsets.UTF_8))
+                .build();
+
+        ArgumentCaptor<HttpRequest> requestCaptor = ArgumentCaptor.forClass(HttpRequest.class);
+
+        when(httpClient.execute(requestCaptor.capture())).thenReturn(treeResponse, readmeResponse);
+
+        GitLabDocumentLoader loader = GitLabDocumentLoader.builder()
+                .baseUrl("https://gitlab.example.com")
+                .projectId("group/project")
+                .personalAccessToken("token")
+                .httpClient(httpClient)
+                .build();
+
+        DocumentParser parser = inputStream -> {
+            try {
+                return Document.from(new String(inputStream.readAllBytes(), StandardCharsets.UTF_8));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        };
+
+        List<Document> documents = loader.loadDocuments(parser);
+
+        assertThat(documents).hasSize(1);
+
+        Document readme = documents.get(0);
+        assertThat(readme.metadata().getString(GitLabDocumentLoader.METADATA_GITLAB_PROJECT_ID))
+                .isEqualTo("group/project");
+        assertThat(readme.metadata().getString(Document.URL))
+                .isEqualTo("https://gitlab.example.com/group/project/-/blob/main/README.md");
+
+        List<HttpRequest> requests = requestCaptor.getAllValues();
+        assertThat(requests).hasSize(2);
+
+        assertThat(requests.get(0).url())
+                .isEqualTo(
+                        "https://gitlab.example.com/api/v4/projects/group%2Fproject/repository/tree?recursive=true&per_page=100&page=1&ref=main");
+        assertThat(requests.get(1).url())
+                .isEqualTo(
+                        "https://gitlab.example.com/api/v4/projects/group%2Fproject/repository/files/README.md/raw?ref=main");
+    }
+
+    @Test
+    void shouldThrowWhenTreeRequestReturnsNon2xx() {
+        HttpClient httpClient = mock(HttpClient.class);
+
+        when(httpClient.execute(any(HttpRequest.class))).thenThrow(new HttpException(500, "Boom"));
+
+        GitLabDocumentLoader loader = GitLabDocumentLoader.builder()
+                .baseUrl("https://gitlab.com")
+                .projectId("123")
+                .personalAccessToken("token")
+                .httpClient(httpClient)
+                .build();
+
+        DocumentParser parser = inputStream -> {
+            try {
+                return Document.from(new String(inputStream.readAllBytes(), StandardCharsets.UTF_8));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        };
+
+        assertThatThrownBy(() -> loader.loadDocuments("main", null, true, parser))
+                .isInstanceOf(GitLabDocumentLoaderException.class)
+                .hasMessageContaining("status code 500");
+    }
+
+    @Test
+    void shouldThrowWhenTreeResponseIsInvalidJson() {
+        HttpClient httpClient = mock(HttpClient.class);
+
+        SuccessfulHttpResponse treeResponse = SuccessfulHttpResponse.builder()
+                .statusCode(200)
+                .body("not-json")
+                .build();
+
+        when(httpClient.execute(any(HttpRequest.class))).thenReturn(treeResponse);
+
+        GitLabDocumentLoader loader = GitLabDocumentLoader.builder()
+                .baseUrl("https://gitlab.com")
+                .projectId("123")
+                .personalAccessToken("token")
+                .httpClient(httpClient)
+                .build();
+
+        DocumentParser parser = inputStream -> {
+            try {
+                return Document.from(new String(inputStream.readAllBytes(), StandardCharsets.UTF_8));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        };
+
+        assertThatThrownBy(() -> loader.loadDocuments("main", null, true, parser))
+                .isInstanceOf(GitLabDocumentLoaderException.class)
+                .hasMessageContaining("Failed to parse GitLab API response");
+    }
+
+    @Test
+    void shouldThrowWhenTreeRequestFails() {
+        HttpClient httpClient = mock(HttpClient.class);
+        when(httpClient.execute(any(HttpRequest.class))).thenThrow(new RuntimeException("boom"));
+
+        GitLabDocumentLoader loader = GitLabDocumentLoader.builder()
+                .baseUrl("https://gitlab.com")
+                .projectId("123")
+                .personalAccessToken("token")
+                .httpClient(httpClient)
+                .build();
+
+        DocumentParser parser = inputStream -> {
+            try {
+                return Document.from(new String(inputStream.readAllBytes(), StandardCharsets.UTF_8));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        };
+
+        assertThatThrownBy(() -> loader.loadDocuments("main", null, true, parser))
+                .isInstanceOf(GitLabDocumentLoaderException.class)
+                .hasMessageContaining("Failed to call GitLab API");
+    }
+
+    @Test
+    void shouldSkipFileWhenRawRequestFails() {
+        HttpClient httpClient = mock(HttpClient.class);
+
+        SuccessfulHttpResponse treeResponse = SuccessfulHttpResponse.builder()
+                .statusCode(200)
+                .body(repositoryTreeResponseBody())
+                .build();
+
+        HttpException notFoundException = new HttpException(404, "Not Found");
+
+        SuccessfulHttpResponse mainJavaResponse = SuccessfulHttpResponse.builder()
+                .statusCode(200)
+                .body(new String(mainJavaRawContent(), StandardCharsets.UTF_8))
+                .build();
+
+        when(httpClient.execute(any(HttpRequest.class)))
+                .thenReturn(treeResponse)
+                .thenThrow(notFoundException)
+                .thenReturn(mainJavaResponse);
+
+        GitLabDocumentLoader loader = GitLabDocumentLoader.builder()
+                .baseUrl("https://gitlab.com")
+                .projectId("123")
+                .personalAccessToken("token")
+                .httpClient(httpClient)
+                .build();
+
+        DocumentParser parser = inputStream -> {
+            try {
+                return Document.from(new String(inputStream.readAllBytes(), StandardCharsets.UTF_8));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        };
+
+        List<Document> documents = loader.loadDocuments("main", null, true, parser);
+
+        assertThat(documents).hasSize(1);
+        Document mainJava = documents.get(0);
+        assertThat(mainJava.text()).isEqualTo("public class Main {}");
+        assertThat(mainJava.metadata().getString(Document.FILE_NAME)).isEqualTo("Main.java");
+    }
+
+    @Test
+    void shouldFallbackToMasterWhenLoadingSingleDocument() {
+        HttpClient httpClient = mock(HttpClient.class);
+
+        HttpException notFoundException = new HttpException(404, "Not Found");
+
+        SuccessfulHttpResponse masterResponse = SuccessfulHttpResponse.builder()
+                .statusCode(200)
+                .body(new String(readmeRawContent(), StandardCharsets.UTF_8))
+                .build();
+
+        ArgumentCaptor<HttpRequest> requestCaptor = ArgumentCaptor.forClass(HttpRequest.class);
+
+        when(httpClient.execute(requestCaptor.capture()))
+                .thenThrow(notFoundException)
+                .thenReturn(masterResponse);
+
+        GitLabDocumentLoader loader = GitLabDocumentLoader.builder()
+                .baseUrl("https://gitlab.com")
+                .projectId("123")
+                .personalAccessToken("token")
+                .httpClient(httpClient)
+                .build();
+
+        DocumentParser parser = inputStream -> {
+            try {
+                return Document.from(new String(inputStream.readAllBytes(), StandardCharsets.UTF_8));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        };
+
+        Document document = loader.loadDocument("README.md", parser);
+
+        assertThat(document.text()).isEqualTo("README content");
+        assertThat(document.metadata().getString(Document.URL))
+                .isEqualTo("https://gitlab.com/projects/123/-/blob/master/README.md");
+
+        List<HttpRequest> requests = requestCaptor.getAllValues();
+        assertThat(requests).hasSize(2);
+        assertThat(requests.get(0).url())
+                .isEqualTo("https://gitlab.com/api/v4/projects/123/repository/files/README.md/raw?ref=main");
+        assertThat(requests.get(1).url())
+                .isEqualTo("https://gitlab.com/api/v4/projects/123/repository/files/README.md/raw?ref=master");
+
+        assertThat(requests.get(0).headers().get("PRIVATE-TOKEN")).contains("token");
+        assertThat(requests.get(1).headers().get("PRIVATE-TOKEN")).contains("token");
+    }
+
+    @Test
+    void shouldIncludePathAndNonRecursiveWhenListingRepositoryTree() {
+        HttpClient httpClient = mock(HttpClient.class);
+
+        SuccessfulHttpResponse treeResponse = SuccessfulHttpResponse.builder()
+                .statusCode(200)
+                .body(repositoryTreeResponseBodyDocsReadmeOnly())
+                .build();
+
+        SuccessfulHttpResponse readmeResponse = SuccessfulHttpResponse.builder()
+                .statusCode(200)
+                .body(new String(readmeRawContent(), StandardCharsets.UTF_8))
+                .build();
+
+        ArgumentCaptor<HttpRequest> requestCaptor = ArgumentCaptor.forClass(HttpRequest.class);
+
+        when(httpClient.execute(requestCaptor.capture())).thenReturn(treeResponse, readmeResponse);
+
+        GitLabDocumentLoader loader = GitLabDocumentLoader.builder()
+                .baseUrl("https://gitlab.com")
+                .projectId("123")
+                .personalAccessToken("token")
+                .httpClient(httpClient)
+                .build();
+
+        DocumentParser parser = inputStream -> {
+            try {
+                return Document.from(new String(inputStream.readAllBytes(), StandardCharsets.UTF_8));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        };
+
+        List<Document> documents = loader.loadDocuments("main", "docs", false, parser);
+
+        assertThat(documents).hasSize(1);
+        Document readme = documents.get(0);
+        assertThat(readme.text()).isEqualTo("README content");
+        assertThat(readme.metadata().getString(Document.FILE_NAME)).isEqualTo("README.md");
+        assertThat(readme.metadata().getString(Document.URL))
+                .isEqualTo("https://gitlab.com/projects/123/-/blob/main/docs/README.md");
+
+        List<HttpRequest> requests = requestCaptor.getAllValues();
+        assertThat(requests).hasSize(2);
+        assertThat(requests.get(0).url())
+                .isEqualTo(
+                        "https://gitlab.com/api/v4/projects/123/repository/tree?recursive=false&per_page=100&page=1&ref=main&path=docs");
+        assertThat(requests.get(1).url())
+                .isEqualTo("https://gitlab.com/api/v4/projects/123/repository/files/docs%2FREADME.md/raw?ref=main");
+    }
+
+    private static String repositoryTreeResponseBody() {
+        return "["
+                + "{\"type\":\"blob\",\"path\":\"README.md\"},"
+                + "{\"type\":\"blob\",\"path\":\"src/Main.java\"}"
+                + "]";
+    }
+
+    private static String repositoryTreeResponseBodyPage1() {
+        return "[" + "{\"type\":\"blob\",\"path\":\"README.md\"}" + "]";
+    }
+
+    private static String repositoryTreeResponseBodyPage2() {
+        return "[" + "{\"type\":\"blob\",\"path\":\"src/Main.java\"}" + "]";
+    }
+
+    private static String repositoryTreeResponseBodyReadmeOnly() {
+        return "[" + "{\"type\":\"blob\",\"path\":\"README.md\"}" + "]";
+    }
+
+    private static String repositoryTreeResponseBodyDocsReadmeOnly() {
+        return "[" + "{\"type\":\"blob\",\"path\":\"docs/README.md\"}" + "]";
+    }
+
+    private static byte[] readmeRawContent() {
+        return "README content".getBytes(StandardCharsets.UTF_8);
+    }
+
+    private static byte[] mainJavaRawContent() {
+        return "public class Main {}".getBytes(StandardCharsets.UTF_8);
+    }
+}

--- a/langchain4j-community-bom/pom.xml
+++ b/langchain4j-community-bom/pom.xml
@@ -141,6 +141,12 @@
                 <version>${project.version}</version>
             </dependency>
 
+            <dependency>
+                <groupId>dev.langchain4j</groupId>
+                <artifactId>langchain4j-community-document-loader-gitlab</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
             <!-- document parsers -->
             <dependency>
                 <groupId>dev.langchain4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@
 
         <!-- Integration of document loaders -->
         <module>document-loaders/langchain4j-community-document-loader-confluence</module>
+        <module>document-loaders/langchain4j-community-document-loader-gitlab</module>
 
         <!-- Integration of document parsers -->
         <module>document-parsers/langchain4j-community-document-parser-llamaparse</module>


### PR DESCRIPTION
## Issue
Closes #506

## Change
This PR introduces `langchain4j-document-loader-gitlab`, enabling seamless ingestion of documents and code from **GitLab** (SaaS & Self-Managed).

**Motivation:**
Following the recent addition of the `ConfluenceDocumentLoader`, this module completes the "Enterprise Knowledge" puzzle by supporting GitLab, ensuring developers can ingest both documentation and source code from their repositories.

**Key Features:**
* **Dual Identity Support:** Handles both **Project ID** (numeric e.g., `12345`) and **Project Path** (URL-encoded e.g., `group/project`) seamlessly for both API calls and Web URL generation.
* **Smart Branch Detection:** Automatically attempts to fetch from `main`, falling back to `master` if the default branch is not explicitly provided, simplifying configuration for older repositories.
* **Robust Encoding:** Specifically handles GitLab API's strict requirements for URL encoding (e.g., handling `%2F` in paths and ensuring `%20` for spaces instead of `+`).
* **Pagination:** Implements `do-while` loops respecting the `X-Next-Page` header to ensure complete file tree traversal.
* **Recursive Loading:** Leverages GitLab API's `recursive=true` parameter for efficient tree retrieval.

**Implementation Details:**
* Uses standard `java.net.http.HttpClient` to minimize external dependencies.
* Added extensive unit tests with `Mockito` covering pagination loops, branch fallback logic, and complex URL construction edge cases.

## General checklist
- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [x] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)


## Checklist for adding new maven module
- [x] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`


## Checklist for adding new embedding store integration
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j