### PR TITLE
Add MiniMax as LLM provider integration

### DIFF
--- a/langchain4j-community-bom/pom.xml
+++ b/langchain4j-community-bom/pom.xml
@@ -66,6 +66,12 @@
                 <version>${project.version}</version>
             </dependency>
 
+            <dependency>
+                <groupId>dev.langchain4j</groupId>
+                <artifactId>langchain4j-community-minimax</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
             <!-- embedding stores -->
             <dependency>
                 <groupId>dev.langchain4j</groupId>

--- a/models/langchain4j-community-minimax/pom.xml
+++ b/models/langchain4j-community-minimax/pom.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>dev.langchain4j</groupId>
+        <artifactId>langchain4j-community</artifactId>
+        <version>1.13.0-beta23-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>langchain4j-community-minimax</artifactId>
+    <name>LangChain4j :: Community :: Integration :: MiniMax</name>
+
+    <licenses>
+        <license>
+            <name>Apache-2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+            <comments>A business-friendly OSS license</comments>
+        </license>
+    </licenses>
+
+    <properties>
+        <skipMiniMaxITs>false</skipMiniMaxITs>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-core</artifactId>
+            <version>${langchain4j.core.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.squareup.retrofit2</groupId>
+            <artifactId>retrofit</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.squareup.retrofit2</groupId>
+            <artifactId>converter-jackson</artifactId>
+        </dependency>
+
+        <!-- DEPENDENCY CONFLICT RESOLUTION FOR OKHTTP (START) -->
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp-sse</artifactId>
+        </dependency>
+        <!-- DEPENDENCY CONFLICT RESOLUTION FOR OKHTTP (END)  -->
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-core</artifactId>
+            <version>${langchain4j.core.version}</version>
+            <classifier>tests</classifier>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j</artifactId>
+            <version>${langchain4j.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j</artifactId>
+            <version>${langchain4j.version}</version>
+            <classifier>tests</classifier>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.tinylog</groupId>
+            <artifactId>tinylog-impl</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.tinylog</groupId>
+            <artifactId>slf4j-tinylog</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <skipTests>${skipMiniMaxITs}</skipTests>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/InternalMiniMaxHelper.java
+++ b/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/InternalMiniMaxHelper.java
@@ -1,0 +1,157 @@
+package dev.langchain4j.community.model.minimax;
+
+import static dev.langchain4j.internal.Exceptions.illegalArgument;
+import static dev.langchain4j.internal.JsonSchemaElementUtils.toMap;
+import static dev.langchain4j.internal.Utils.isNullOrBlank;
+import static dev.langchain4j.internal.Utils.isNullOrEmpty;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.community.model.minimax.client.chat.Function;
+import dev.langchain4j.community.model.minimax.client.chat.Parameters;
+import dev.langchain4j.community.model.minimax.client.chat.Tool;
+import dev.langchain4j.community.model.minimax.client.chat.ToolType;
+import dev.langchain4j.community.model.minimax.client.chat.message.AssistantMessage;
+import dev.langchain4j.community.model.minimax.client.chat.message.FunctionCall;
+import dev.langchain4j.community.model.minimax.client.chat.message.Message;
+import dev.langchain4j.community.model.minimax.client.chat.message.SystemMessage;
+import dev.langchain4j.community.model.minimax.client.chat.message.ToolCall;
+import dev.langchain4j.community.model.minimax.client.chat.message.ToolMessage;
+import dev.langchain4j.community.model.minimax.client.chat.message.UserMessage;
+import dev.langchain4j.community.model.minimax.client.shared.CompletionUsage;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.TextContent;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.model.output.FinishReason;
+import dev.langchain4j.model.output.TokenUsage;
+import java.util.List;
+import java.util.Objects;
+
+class InternalMiniMaxHelper {
+
+    static List<Message> toMiniMaxMessages(List<ChatMessage> messages) {
+        if (isNullOrEmpty(messages)) {
+            return null;
+        }
+        return messages.stream()
+                .map(msg -> {
+                    if (msg instanceof dev.langchain4j.data.message.SystemMessage message) {
+                        return SystemMessage.of(message.text());
+                    } else if (msg instanceof AiMessage message) {
+                        if (!message.hasToolExecutionRequests()) {
+                            return AssistantMessage.of(message.text());
+                        }
+                        List<ToolCall> list = message.toolExecutionRequests().stream()
+                                .map(it -> ToolCall.builder()
+                                        .id(it.id())
+                                        .type(ToolType.FUNCTION)
+                                        .function(FunctionCall.builder()
+                                                .id(it.id())
+                                                .name(it.name())
+                                                .arguments(it.arguments())
+                                                .build())
+                                        .build())
+                                .toList();
+                        return AssistantMessage.of(message.text(), list.toArray(new ToolCall[0]));
+                    } else if (msg instanceof dev.langchain4j.data.message.UserMessage message) {
+                        if (message.hasSingleText()) {
+                            return UserMessage.builder()
+                                    .content(message.singleText())
+                                    .name(message.name())
+                                    .build();
+                        } else {
+                            // MiniMax supports text content in multimodal messages
+                            StringBuilder textContent = new StringBuilder();
+                            message.contents().forEach(item -> {
+                                if (item instanceof TextContent content) {
+                                    textContent.append(content.text());
+                                }
+                            });
+                            return UserMessage.builder()
+                                    .content(textContent.toString())
+                                    .name(message.name())
+                                    .build();
+                        }
+                    } else if (msg instanceof ToolExecutionResultMessage message) {
+                        return ToolMessage.of(message.id(), message.text());
+                    }
+                    throw illegalArgument("Unknown message type: " + msg.type());
+                })
+                .toList();
+    }
+
+    static List<Tool> toTools(List<ToolSpecification> toolSpecifications) {
+        if (isNullOrEmpty(toolSpecifications)) {
+            return null;
+        }
+        return toolSpecifications.stream().map(InternalMiniMaxHelper::toTool).toList();
+    }
+
+    static Tool toTool(ToolSpecification toolSpecification) {
+        return Tool.builder()
+                .function(Function.builder()
+                        .description(toolSpecification.description())
+                        .name(toolSpecification.name())
+                        .parameters(toParameters(toolSpecification))
+                        .build())
+                .build();
+    }
+
+    static AiMessage aiMessageFrom(AssistantMessage assistantMessage) {
+        String text = assistantMessage.getContent();
+        List<ToolCall> toolCalls = assistantMessage.getToolCalls();
+        if (!isNullOrEmpty(toolCalls)) {
+            List<ToolExecutionRequest> toolExecutionRequests = toolCalls.stream()
+                    .filter(toolCall -> toolCall.getType() == ToolType.FUNCTION)
+                    .map(InternalMiniMaxHelper::toToolExecutionRequest)
+                    .toList();
+            return isNullOrBlank(text)
+                    ? AiMessage.from(toolExecutionRequests)
+                    : AiMessage.from(text, toolExecutionRequests);
+        }
+        return AiMessage.from(text);
+    }
+
+    private static ToolExecutionRequest toToolExecutionRequest(ToolCall toolCall) {
+        FunctionCall functionCall = toolCall.getFunction();
+        return ToolExecutionRequest.builder()
+                .id(toolCall.getId())
+                .name(functionCall.getName())
+                .arguments(functionCall.getArguments())
+                .build();
+    }
+
+    private static Parameters toParameters(ToolSpecification toolSpecification) {
+        if (toolSpecification.parameters() != null) {
+            JsonObjectSchema parameters = toolSpecification.parameters();
+            return Parameters.builder()
+                    .properties(toMap(parameters.properties()))
+                    .required(parameters.required())
+                    .build();
+        } else {
+            return null;
+        }
+    }
+
+    public static TokenUsage tokenUsageFrom(CompletionUsage usage) {
+        if (Objects.isNull(usage)) {
+            return null;
+        }
+        return new TokenUsage(usage.getPromptTokens(), usage.getCompletionTokens(), usage.getTotalTokens());
+    }
+
+    public static FinishReason finishReasonFrom(String finishReason) {
+        if (isNullOrBlank(finishReason)) {
+            return null;
+        }
+        return switch (finishReason) {
+            case "stop" -> FinishReason.STOP;
+            case "length" -> FinishReason.LENGTH;
+            case "tool_calls", "function_call" -> FinishReason.TOOL_EXECUTION;
+            case "content_filter" -> FinishReason.CONTENT_FILTER;
+            default -> null;
+        };
+    }
+}

--- a/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/MiniMaxChatModel.java
+++ b/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/MiniMaxChatModel.java
@@ -1,0 +1,324 @@
+package dev.langchain4j.community.model.minimax;
+
+import static dev.langchain4j.community.model.minimax.InternalMiniMaxHelper.aiMessageFrom;
+import static dev.langchain4j.community.model.minimax.InternalMiniMaxHelper.finishReasonFrom;
+import static dev.langchain4j.community.model.minimax.InternalMiniMaxHelper.toTools;
+import static dev.langchain4j.community.model.minimax.InternalMiniMaxHelper.toMiniMaxMessages;
+import static dev.langchain4j.community.model.minimax.InternalMiniMaxHelper.tokenUsageFrom;
+import static dev.langchain4j.internal.RetryUtils.withRetry;
+import static dev.langchain4j.internal.Utils.copy;
+import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+import static dev.langchain4j.spi.ServiceHelper.loadFactories;
+
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.community.model.minimax.client.MiniMaxClient;
+import dev.langchain4j.community.model.minimax.client.chat.ChatCompletionChoice;
+import dev.langchain4j.community.model.minimax.client.chat.ChatCompletionRequest;
+import dev.langchain4j.community.model.minimax.client.chat.ChatCompletionResponse;
+import dev.langchain4j.community.model.minimax.spi.MiniMaxChatModelBuilderFactory;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.listener.ChatModelListener;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.ChatResponseMetadata;
+import java.net.Proxy;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Represents a MiniMax chat model that uses the OpenAI-compatible Chat Completions API.
+ * <p>
+ * MiniMax provides models such as MiniMax-M2.7, MiniMax-M2.5, and MiniMax-M2.5-highspeed
+ * via the endpoint {@code https://api.minimax.io/v1}.
+ *
+ * @see MiniMaxChatModelName
+ * @see <a href="https://platform.minimaxi.com/document/Models">MiniMax API Documentation</a>
+ */
+public class MiniMaxChatModel implements ChatModel {
+
+    private static final Logger log = LoggerFactory.getLogger(MiniMaxChatModel.class);
+    private static final String DEFAULT_BASE_URL = "https://api.minimax.io/";
+
+    private final MiniMaxClient client;
+    private final Integer maxRetries;
+    private final List<ChatModelListener> listeners;
+    private final ChatRequestParameters defaultRequestParameters;
+
+    private final Integer seed;
+    private final String user;
+    private final Object toolChoice;
+    private final Boolean parallelToolCalls;
+
+    public MiniMaxChatModel(
+            String baseUrl,
+            String apiKey,
+            String modelName,
+            Double temperature,
+            Double topP,
+            List<String> stop,
+            Integer maxTokens,
+            Double presencePenalty,
+            Double frequencyPenalty,
+            Integer seed,
+            String user,
+            Object toolChoice,
+            Boolean parallelToolCalls,
+            Integer maxRetries,
+            Duration timeout,
+            Proxy proxy,
+            Boolean logRequests,
+            Boolean logResponses,
+            Map<String, String> customHeaders,
+            List<ChatModelListener> listeners) {
+        baseUrl = getOrDefault(baseUrl, DEFAULT_BASE_URL);
+        timeout = getOrDefault(timeout, Duration.ofSeconds(60));
+        this.maxRetries = getOrDefault(maxRetries, 3);
+        this.listeners = copy(listeners);
+
+        this.client = MiniMaxClient.builder()
+                .baseUrl(baseUrl)
+                .apiKey(apiKey)
+                .callTimeout(timeout)
+                .connectTimeout(timeout)
+                .readTimeout(timeout)
+                .writeTimeout(timeout)
+                .proxy(proxy)
+                .logRequests(logRequests)
+                .logResponses(logResponses)
+                .customHeaders(customHeaders)
+                .build();
+        this.defaultRequestParameters = ChatRequestParameters.builder()
+                .modelName(ensureNotBlank(modelName, "modelName"))
+                .temperature(temperature)
+                .topP(topP)
+                .stopSequences(stop)
+                .maxOutputTokens(maxTokens)
+                .presencePenalty(presencePenalty)
+                .frequencyPenalty(frequencyPenalty)
+                .build();
+
+        this.seed = seed;
+        this.user = user;
+        this.toolChoice = toolChoice;
+        this.parallelToolCalls = parallelToolCalls;
+    }
+
+    public static MiniMaxChatModelBuilder builder() {
+        for (MiniMaxChatModelBuilderFactory factory : loadFactories(MiniMaxChatModelBuilderFactory.class)) {
+            return factory.get();
+        }
+        return new MiniMaxChatModelBuilder();
+    }
+
+    @Override
+    public ChatRequestParameters defaultRequestParameters() {
+        return defaultRequestParameters;
+    }
+
+    @Override
+    public List<ChatModelListener> listeners() {
+        return listeners;
+    }
+
+    @Override
+    public ChatResponse doChat(ChatRequest request) {
+        List<ChatMessage> messages = request.messages();
+        ChatRequestParameters parameters = request.parameters();
+        List<ToolSpecification> toolSpecifications = parameters.toolSpecifications();
+        ChatCompletionRequest.Builder builder = ChatCompletionRequest.builder()
+                .model(parameters.modelName())
+                .messages(toMiniMaxMessages(messages))
+                .temperature(parameters.temperature())
+                .topP(parameters.topP())
+                .stop(parameters.stopSequences())
+                .maxTokens(parameters.maxOutputTokens())
+                .presencePenalty(parameters.presencePenalty())
+                .frequencyPenalty(parameters.frequencyPenalty())
+                .user(user)
+                .seed(seed)
+                .toolChoice(toolChoice)
+                .parallelToolCalls(parallelToolCalls);
+
+        if (toolSpecifications != null && !toolSpecifications.isEmpty()) {
+            builder.tools(toTools(toolSpecifications));
+            if (parameters.toolChoice() != null) {
+                builder.toolChoice(parameters.toolChoice());
+            }
+        }
+
+        ChatCompletionRequest miniMaxRequest = builder.build();
+        ChatCompletionResponse chatCompletionResponse =
+                withRetry(() -> client.chatCompletions(miniMaxRequest).execute(), maxRetries);
+
+        ChatCompletionChoice completionChoice =
+                chatCompletionResponse.getChoices().get(0);
+
+        return ChatResponse.builder()
+                .aiMessage(aiMessageFrom(completionChoice.getMessage()))
+                .metadata(ChatResponseMetadata.builder()
+                        .id(chatCompletionResponse.getId())
+                        .modelName(request.modelName())
+                        .finishReason(finishReasonFrom(completionChoice.getFinishReason()))
+                        .tokenUsage(tokenUsageFrom(chatCompletionResponse.getUsage()))
+                        .build())
+                .build();
+    }
+
+    public static class MiniMaxChatModelBuilder {
+        private String baseUrl;
+        private String apiKey;
+        private String modelName;
+        private Double temperature;
+        private Double topP;
+        private List<String> stop;
+        private Integer maxTokens;
+        private Double presencePenalty;
+        private Double frequencyPenalty;
+        private Integer seed;
+        private String user;
+        private Object toolChoice;
+        private Boolean parallelToolCalls;
+        private Integer maxRetries;
+        private Duration timeout;
+        private Proxy proxy;
+        private Boolean logRequests;
+        private Boolean logResponses;
+        private Map<String, String> customHeaders;
+        private List<ChatModelListener> listeners;
+
+        public MiniMaxChatModelBuilder baseUrl(String baseUrl) {
+            this.baseUrl = baseUrl;
+            return this;
+        }
+
+        public MiniMaxChatModelBuilder apiKey(String apiKey) {
+            this.apiKey = apiKey;
+            return this;
+        }
+
+        public MiniMaxChatModelBuilder modelName(String modelName) {
+            this.modelName = modelName;
+            return this;
+        }
+
+        public MiniMaxChatModelBuilder modelName(MiniMaxChatModelName modelName) {
+            this.modelName = modelName.toString();
+            return this;
+        }
+
+        public MiniMaxChatModelBuilder temperature(Double temperature) {
+            this.temperature = temperature;
+            return this;
+        }
+
+        public MiniMaxChatModelBuilder topP(Double topP) {
+            this.topP = topP;
+            return this;
+        }
+
+        public MiniMaxChatModelBuilder stop(List<String> stop) {
+            this.stop = stop;
+            return this;
+        }
+
+        public MiniMaxChatModelBuilder maxTokens(Integer maxTokens) {
+            this.maxTokens = maxTokens;
+            return this;
+        }
+
+        public MiniMaxChatModelBuilder presencePenalty(Double presencePenalty) {
+            this.presencePenalty = presencePenalty;
+            return this;
+        }
+
+        public MiniMaxChatModelBuilder frequencyPenalty(Double frequencyPenalty) {
+            this.frequencyPenalty = frequencyPenalty;
+            return this;
+        }
+
+        public MiniMaxChatModelBuilder seed(Integer seed) {
+            this.seed = seed;
+            return this;
+        }
+
+        public MiniMaxChatModelBuilder user(String user) {
+            this.user = user;
+            return this;
+        }
+
+        public MiniMaxChatModelBuilder toolChoice(Object toolChoice) {
+            this.toolChoice = toolChoice;
+            return this;
+        }
+
+        public MiniMaxChatModelBuilder parallelToolCalls(Boolean parallelToolCalls) {
+            this.parallelToolCalls = parallelToolCalls;
+            return this;
+        }
+
+        public MiniMaxChatModelBuilder maxRetries(Integer maxRetries) {
+            this.maxRetries = maxRetries;
+            return this;
+        }
+
+        public MiniMaxChatModelBuilder timeout(Duration timeout) {
+            this.timeout = timeout;
+            return this;
+        }
+
+        public MiniMaxChatModelBuilder proxy(Proxy proxy) {
+            this.proxy = proxy;
+            return this;
+        }
+
+        public MiniMaxChatModelBuilder logRequests(Boolean logRequests) {
+            this.logRequests = logRequests;
+            return this;
+        }
+
+        public MiniMaxChatModelBuilder logResponses(Boolean logResponses) {
+            this.logResponses = logResponses;
+            return this;
+        }
+
+        public MiniMaxChatModelBuilder customHeaders(Map<String, String> customHeaders) {
+            this.customHeaders = customHeaders;
+            return this;
+        }
+
+        public MiniMaxChatModelBuilder listeners(List<ChatModelListener> listeners) {
+            this.listeners = listeners;
+            return this;
+        }
+
+        public MiniMaxChatModel build() {
+            return new MiniMaxChatModel(
+                    this.baseUrl,
+                    this.apiKey,
+                    this.modelName,
+                    this.temperature,
+                    this.topP,
+                    this.stop,
+                    this.maxTokens,
+                    this.presencePenalty,
+                    this.frequencyPenalty,
+                    this.seed,
+                    this.user,
+                    this.toolChoice,
+                    this.parallelToolCalls,
+                    this.maxRetries,
+                    this.timeout,
+                    this.proxy,
+                    this.logRequests,
+                    this.logResponses,
+                    this.customHeaders,
+                    this.listeners);
+        }
+    }
+}

--- a/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/MiniMaxChatModelName.java
+++ b/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/MiniMaxChatModelName.java
@@ -1,0 +1,37 @@
+package dev.langchain4j.community.model.minimax;
+
+/**
+ * Enum representing available MiniMax chat model names.
+ * <p>
+ * MiniMax provides an OpenAI-compatible API at {@code https://api.minimax.io/v1}.
+ *
+ * @see <a href="https://platform.minimaxi.com/document/Models">MiniMax Models Documentation</a>
+ */
+public enum MiniMaxChatModelName {
+
+    /**
+     * MiniMax-M2.7 — the latest and most capable model.
+     */
+    MINIMAX_M2_7("MiniMax-M2.7"),
+
+    /**
+     * MiniMax-M2.5 — a high-performance model with 204K context.
+     */
+    MINIMAX_M2_5("MiniMax-M2.5"),
+
+    /**
+     * MiniMax-M2.5-highspeed — optimized for speed with 204K context.
+     */
+    MINIMAX_M2_5_HIGHSPEED("MiniMax-M2.5-highspeed");
+
+    private final String value;
+
+    MiniMaxChatModelName(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+}

--- a/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/MiniMaxStreamingChatModel.java
+++ b/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/MiniMaxStreamingChatModel.java
@@ -1,0 +1,313 @@
+package dev.langchain4j.community.model.minimax;
+
+import static dev.langchain4j.community.model.minimax.InternalMiniMaxHelper.toTools;
+import static dev.langchain4j.community.model.minimax.InternalMiniMaxHelper.toMiniMaxMessages;
+import static dev.langchain4j.internal.Utils.copy;
+import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.Utils.isNotNullOrEmpty;
+import static dev.langchain4j.internal.Utils.isNullOrEmpty;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+import static dev.langchain4j.spi.ServiceHelper.loadFactories;
+
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.community.model.minimax.client.MiniMaxClient;
+import dev.langchain4j.community.model.minimax.client.chat.ChatCompletionChoice;
+import dev.langchain4j.community.model.minimax.client.chat.ChatCompletionRequest;
+import dev.langchain4j.community.model.minimax.client.chat.Delta;
+import dev.langchain4j.community.model.minimax.client.shared.StreamOptions;
+import dev.langchain4j.community.model.minimax.spi.MiniMaxStreamingChatModelBuilderFactory;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.listener.ChatModelListener;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import java.net.Proxy;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Represents a MiniMax streaming chat model that uses the OpenAI-compatible Chat Completions API.
+ *
+ * @see MiniMaxChatModelName
+ * @see <a href="https://platform.minimaxi.com/document/Models">MiniMax API Documentation</a>
+ */
+public class MiniMaxStreamingChatModel implements StreamingChatModel {
+
+    private static final Logger log = LoggerFactory.getLogger(MiniMaxStreamingChatModel.class);
+    private static final String DEFAULT_BASE_URL = "https://api.minimax.io/";
+
+    private final MiniMaxClient client;
+    private final List<ChatModelListener> listeners;
+    private final ChatRequestParameters defaultRequestParameters;
+
+    private final Integer seed;
+    private final String user;
+    private final Object toolChoice;
+    private final Boolean parallelToolCalls;
+
+    public MiniMaxStreamingChatModel(
+            String baseUrl,
+            String apiKey,
+            String modelName,
+            Double temperature,
+            Double topP,
+            List<String> stop,
+            Integer maxTokens,
+            Double presencePenalty,
+            Double frequencyPenalty,
+            Integer seed,
+            String user,
+            Object toolChoice,
+            Boolean parallelToolCalls,
+            Duration timeout,
+            Proxy proxy,
+            Boolean logRequests,
+            Boolean logResponses,
+            Map<String, String> customHeaders,
+            List<ChatModelListener> listeners) {
+        baseUrl = getOrDefault(baseUrl, DEFAULT_BASE_URL);
+        timeout = getOrDefault(timeout, Duration.ofSeconds(60));
+        this.listeners = copy(listeners);
+
+        this.client = MiniMaxClient.builder()
+                .baseUrl(baseUrl)
+                .apiKey(apiKey)
+                .callTimeout(timeout)
+                .connectTimeout(timeout)
+                .readTimeout(timeout)
+                .writeTimeout(timeout)
+                .proxy(proxy)
+                .logRequests(logRequests)
+                .logStreamingResponses(logResponses)
+                .customHeaders(customHeaders)
+                .build();
+        this.defaultRequestParameters = ChatRequestParameters.builder()
+                .modelName(ensureNotBlank(modelName, "modelName"))
+                .temperature(temperature)
+                .topP(topP)
+                .stopSequences(stop)
+                .maxOutputTokens(maxTokens)
+                .presencePenalty(presencePenalty)
+                .frequencyPenalty(frequencyPenalty)
+                .build();
+
+        this.seed = seed;
+        this.user = user;
+        this.toolChoice = toolChoice;
+        this.parallelToolCalls = parallelToolCalls;
+    }
+
+    public static MiniMaxStreamingChatModelBuilder builder() {
+        for (MiniMaxStreamingChatModelBuilderFactory factory :
+                loadFactories(MiniMaxStreamingChatModelBuilderFactory.class)) {
+            return factory.get();
+        }
+        return new MiniMaxStreamingChatModelBuilder();
+    }
+
+    @Override
+    public ChatRequestParameters defaultRequestParameters() {
+        return defaultRequestParameters;
+    }
+
+    @Override
+    public List<ChatModelListener> listeners() {
+        return listeners;
+    }
+
+    @Override
+    public void doChat(ChatRequest request, StreamingChatResponseHandler handler) {
+        List<ChatMessage> messages = request.messages();
+        ChatRequestParameters parameters = request.parameters();
+        List<ToolSpecification> toolSpecifications = parameters.toolSpecifications();
+        ChatCompletionRequest.Builder builder = ChatCompletionRequest.builder().stream(true)
+                .streamOptions(StreamOptions.of(true))
+                .model(parameters.modelName())
+                .messages(toMiniMaxMessages(messages))
+                .temperature(parameters.temperature())
+                .topP(parameters.topP())
+                .stop(parameters.stopSequences())
+                .maxTokens(parameters.maxOutputTokens())
+                .presencePenalty(parameters.presencePenalty())
+                .frequencyPenalty(parameters.frequencyPenalty())
+                .user(user)
+                .seed(seed)
+                .toolChoice(toolChoice)
+                .parallelToolCalls(parallelToolCalls);
+
+        if (toolSpecifications != null && !toolSpecifications.isEmpty()) {
+            builder.tools(toTools(toolSpecifications));
+            if (parameters.toolChoice() != null) {
+                builder.toolChoice(parameters.toolChoice());
+            }
+        }
+
+        ChatCompletionRequest miniMaxRequest = builder.build();
+        MiniMaxStreamingResponseBuilder responseBuilder = new MiniMaxStreamingResponseBuilder();
+        client.chatCompletions(miniMaxRequest)
+                .onPartialResponse(partialResponse -> {
+                    responseBuilder.append(partialResponse);
+                    List<ChatCompletionChoice> choices = partialResponse.getChoices();
+                    if (!isNullOrEmpty(choices)) {
+                        Delta delta = choices.get(0).getDelta();
+                        String content = delta.getContent();
+                        if (isNotNullOrEmpty(content)) {
+                            handler.onPartialResponse(content);
+                        }
+                    }
+                })
+                .onComplete(() -> handler.onCompleteResponse(responseBuilder.build()))
+                .onError(handler::onError)
+                .execute();
+    }
+
+    public static class MiniMaxStreamingChatModelBuilder {
+
+        private String baseUrl;
+        private String apiKey;
+        private String modelName;
+        private Double temperature;
+        private Double topP;
+        private List<String> stop;
+        private Integer maxTokens;
+        private Double presencePenalty;
+        private Double frequencyPenalty;
+        private Integer seed;
+        private String user;
+        private Object toolChoice;
+        private Boolean parallelToolCalls;
+        private Duration timeout;
+        private Proxy proxy;
+        private Boolean logRequests;
+        private Boolean logResponses;
+        private Map<String, String> customHeaders;
+        private List<ChatModelListener> listeners;
+
+        public MiniMaxStreamingChatModelBuilder baseUrl(String baseUrl) {
+            this.baseUrl = baseUrl;
+            return this;
+        }
+
+        public MiniMaxStreamingChatModelBuilder apiKey(String apiKey) {
+            this.apiKey = apiKey;
+            return this;
+        }
+
+        public MiniMaxStreamingChatModelBuilder modelName(String modelName) {
+            this.modelName = modelName;
+            return this;
+        }
+
+        public MiniMaxStreamingChatModelBuilder modelName(MiniMaxChatModelName modelName) {
+            this.modelName = modelName.toString();
+            return this;
+        }
+
+        public MiniMaxStreamingChatModelBuilder temperature(Double temperature) {
+            this.temperature = temperature;
+            return this;
+        }
+
+        public MiniMaxStreamingChatModelBuilder topP(Double topP) {
+            this.topP = topP;
+            return this;
+        }
+
+        public MiniMaxStreamingChatModelBuilder stop(List<String> stop) {
+            this.stop = stop;
+            return this;
+        }
+
+        public MiniMaxStreamingChatModelBuilder maxTokens(Integer maxTokens) {
+            this.maxTokens = maxTokens;
+            return this;
+        }
+
+        public MiniMaxStreamingChatModelBuilder presencePenalty(Double presencePenalty) {
+            this.presencePenalty = presencePenalty;
+            return this;
+        }
+
+        public MiniMaxStreamingChatModelBuilder frequencyPenalty(Double frequencyPenalty) {
+            this.frequencyPenalty = frequencyPenalty;
+            return this;
+        }
+
+        public MiniMaxStreamingChatModelBuilder seed(Integer seed) {
+            this.seed = seed;
+            return this;
+        }
+
+        public MiniMaxStreamingChatModelBuilder user(String user) {
+            this.user = user;
+            return this;
+        }
+
+        public MiniMaxStreamingChatModelBuilder toolChoice(Object toolChoice) {
+            this.toolChoice = toolChoice;
+            return this;
+        }
+
+        public MiniMaxStreamingChatModelBuilder parallelToolCalls(Boolean parallelToolCalls) {
+            this.parallelToolCalls = parallelToolCalls;
+            return this;
+        }
+
+        public MiniMaxStreamingChatModelBuilder timeout(Duration timeout) {
+            this.timeout = timeout;
+            return this;
+        }
+
+        public MiniMaxStreamingChatModelBuilder proxy(Proxy proxy) {
+            this.proxy = proxy;
+            return this;
+        }
+
+        public MiniMaxStreamingChatModelBuilder logRequests(Boolean logRequests) {
+            this.logRequests = logRequests;
+            return this;
+        }
+
+        public MiniMaxStreamingChatModelBuilder logResponses(Boolean logResponses) {
+            this.logResponses = logResponses;
+            return this;
+        }
+
+        public MiniMaxStreamingChatModelBuilder customHeaders(Map<String, String> customHeaders) {
+            this.customHeaders = customHeaders;
+            return this;
+        }
+
+        public MiniMaxStreamingChatModelBuilder listeners(List<ChatModelListener> listeners) {
+            this.listeners = listeners;
+            return this;
+        }
+
+        public MiniMaxStreamingChatModel build() {
+            return new MiniMaxStreamingChatModel(
+                    this.baseUrl,
+                    this.apiKey,
+                    this.modelName,
+                    this.temperature,
+                    this.topP,
+                    this.stop,
+                    this.maxTokens,
+                    this.presencePenalty,
+                    this.frequencyPenalty,
+                    this.seed,
+                    this.user,
+                    this.toolChoice,
+                    this.parallelToolCalls,
+                    this.timeout,
+                    this.proxy,
+                    this.logRequests,
+                    this.logResponses,
+                    this.customHeaders,
+                    this.listeners);
+        }
+    }
+}

--- a/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/MiniMaxStreamingResponseBuilder.java
+++ b/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/MiniMaxStreamingResponseBuilder.java
@@ -1,0 +1,138 @@
+package dev.langchain4j.community.model.minimax;
+
+import static dev.langchain4j.community.model.minimax.InternalMiniMaxHelper.finishReasonFrom;
+import static dev.langchain4j.community.model.minimax.InternalMiniMaxHelper.tokenUsageFrom;
+import static dev.langchain4j.internal.Utils.isNotNullOrBlank;
+import static dev.langchain4j.internal.Utils.isNullOrBlank;
+import static dev.langchain4j.internal.Utils.isNullOrEmpty;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.community.model.minimax.client.chat.ChatCompletionChoice;
+import dev.langchain4j.community.model.minimax.client.chat.ChatCompletionResponse;
+import dev.langchain4j.community.model.minimax.client.chat.Delta;
+import dev.langchain4j.community.model.minimax.client.chat.message.FunctionCall;
+import dev.langchain4j.community.model.minimax.client.shared.CompletionUsage;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.ChatResponseMetadata;
+import dev.langchain4j.model.output.FinishReason;
+import dev.langchain4j.model.output.TokenUsage;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Thread-safe builder for assembling streaming chat completion responses.
+ */
+public class MiniMaxStreamingResponseBuilder {
+
+    private final StringBuffer contentBuilder = new StringBuffer();
+    private final AtomicReference<String> responseId = new AtomicReference<>();
+    private final AtomicReference<String> responseModel = new AtomicReference<>();
+    private volatile TokenUsage tokenUsage;
+    private volatile FinishReason finishReason;
+    private volatile List<ToolExecutionRequestBuilder> toolExecutionRequestList;
+
+    public void append(ChatCompletionResponse partialResponse) {
+        if (partialResponse == null) {
+            return;
+        }
+        if (isNotNullOrBlank(partialResponse.getId())) {
+            responseId.set(partialResponse.getId());
+        }
+        if (isNotNullOrBlank(partialResponse.getModel())) {
+            responseModel.set(partialResponse.getModel());
+        }
+        CompletionUsage usage = partialResponse.getUsage();
+        if (usage != null) {
+            this.tokenUsage = tokenUsageFrom(usage);
+        }
+        List<ChatCompletionChoice> choices = partialResponse.getChoices();
+        if (choices == null || choices.isEmpty()) {
+            return;
+        }
+        ChatCompletionChoice chatCompletionChoice = choices.get(0);
+        if (chatCompletionChoice == null) {
+            return;
+        }
+        String finishReason = chatCompletionChoice.getFinishReason();
+        if (finishReason != null) {
+            this.finishReason = finishReasonFrom(finishReason);
+        }
+        Delta delta = chatCompletionChoice.getDelta();
+        if (delta == null) {
+            return;
+        }
+        String content = delta.getContent();
+        if (content != null) {
+            contentBuilder.append(content);
+            return;
+        }
+        if (!isNullOrEmpty(delta.getToolCalls())) {
+            toolExecutionRequestList = delta.getToolCalls().stream()
+                    .map(toolCall -> {
+                        ToolExecutionRequestBuilder toolExecutionRequestBuilder = new ToolExecutionRequestBuilder();
+                        if (toolCall.getId() != null) {
+                            toolExecutionRequestBuilder.idBuilder.append(toolCall.getId());
+                        }
+                        FunctionCall functionCall = toolCall.getFunction();
+                        if (functionCall.getName() != null) {
+                            toolExecutionRequestBuilder.nameBuilder.append(functionCall.getName());
+                        }
+                        if (functionCall.getArguments() != null) {
+                            toolExecutionRequestBuilder.argumentsBuilder.append(functionCall.getArguments());
+                        }
+                        return toolExecutionRequestBuilder;
+                    })
+                    .toList();
+        }
+    }
+
+    public ChatResponse build() {
+        String text = contentBuilder.toString();
+        if (!isNullOrEmpty(toolExecutionRequestList)) {
+            List<ToolExecutionRequest> list = toolExecutionRequestList.stream()
+                    .map(it -> ToolExecutionRequest.builder()
+                            .id(it.idBuilder.toString())
+                            .name(it.nameBuilder.toString())
+                            .arguments(it.argumentsBuilder.toString())
+                            .build())
+                    .toList();
+            AiMessage aiMessage = isNullOrBlank(text) ? AiMessage.from(list) : AiMessage.from(text, list);
+            return ChatResponse.builder()
+                    .aiMessage(aiMessage)
+                    .metadata(ChatResponseMetadata.builder()
+                            .id(getResponseId())
+                            .modelName(getResponseModel())
+                            .finishReason(finishReason)
+                            .tokenUsage(tokenUsage)
+                            .build())
+                    .build();
+        }
+        if (!isNullOrBlank(text)) {
+            return ChatResponse.builder()
+                    .aiMessage(AiMessage.from(text))
+                    .metadata(ChatResponseMetadata.builder()
+                            .id(getResponseId())
+                            .modelName(getResponseModel())
+                            .finishReason(finishReason)
+                            .tokenUsage(tokenUsage)
+                            .build())
+                    .build();
+        }
+        return null;
+    }
+
+    public String getResponseId() {
+        return responseId.get();
+    }
+
+    public String getResponseModel() {
+        return responseModel.get();
+    }
+
+    private static class ToolExecutionRequestBuilder {
+        private final StringBuffer idBuilder = new StringBuffer();
+        private final StringBuffer nameBuilder = new StringBuffer();
+        private final StringBuffer argumentsBuilder = new StringBuffer();
+    }
+}

--- a/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/AsyncRequestExecutor.java
+++ b/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/AsyncRequestExecutor.java
@@ -1,0 +1,62 @@
+package dev.langchain4j.community.model.minimax.client;
+
+import static dev.langchain4j.community.model.minimax.client.utils.ExceptionUtil.toException;
+
+import java.io.IOException;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import retrofit2.Call;
+
+class AsyncRequestExecutor<Response, ResponseContent> {
+
+    private final Call<Response> call;
+    private final Function<Response, ResponseContent> responseContentExtractor;
+
+    AsyncRequestExecutor(Call<Response> call, Function<Response, ResponseContent> responseContentExtractor) {
+        this.call = call;
+        this.responseContentExtractor = responseContentExtractor;
+    }
+
+    AsyncResponseHandling onResponse(Consumer<ResponseContent> responseHandler) {
+        return new AsyncResponseHandling() {
+
+            @Override
+            public ErrorHandling onError(Consumer<Throwable> errorHandler) {
+                return () -> {
+                    try {
+                        retrofit2.Response<Response> retrofitResponse = AsyncRequestExecutor.this.call.execute();
+                        if (retrofitResponse.isSuccessful()) {
+                            Response response = retrofitResponse.body();
+                            ResponseContent responseContent =
+                                    AsyncRequestExecutor.this.responseContentExtractor.apply(response);
+                            responseHandler.accept(responseContent);
+                        } else {
+                            errorHandler.accept(toException(retrofitResponse));
+                        }
+                    } catch (IOException e) {
+                        errorHandler.accept(e);
+                    }
+                    return new ResponseHandle();
+                };
+            }
+
+            @Override
+            public ErrorHandling ignoreErrors() {
+                return () -> {
+                    try {
+                        retrofit2.Response<Response> retrofitResponse = AsyncRequestExecutor.this.call.execute();
+                        if (retrofitResponse.isSuccessful()) {
+                            Response response = retrofitResponse.body();
+                            ResponseContent responseContent =
+                                    AsyncRequestExecutor.this.responseContentExtractor.apply(response);
+                            responseHandler.accept(responseContent);
+                        }
+                    } catch (IOException e) {
+                        // intentionally ignoring, because user called ignoreErrors()
+                    }
+                    return new ResponseHandle();
+                };
+            }
+        };
+    }
+}

--- a/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/AsyncResponseHandling.java
+++ b/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/AsyncResponseHandling.java
@@ -1,0 +1,9 @@
+package dev.langchain4j.community.model.minimax.client;
+
+import java.util.function.Consumer;
+
+public interface AsyncResponseHandling {
+    ErrorHandling onError(Consumer<Throwable> var1);
+
+    ErrorHandling ignoreErrors();
+}

--- a/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/AuthorizationHeaderInjector.java
+++ b/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/AuthorizationHeaderInjector.java
@@ -1,0 +1,10 @@
+package dev.langchain4j.community.model.minimax.client;
+
+import java.util.Collections;
+
+class AuthorizationHeaderInjector extends GenericHeaderInjector {
+
+    AuthorizationHeaderInjector(String apiKey) {
+        super(Collections.singletonMap("Authorization", "Bearer " + apiKey));
+    }
+}

--- a/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/ErrorHandling.java
+++ b/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/ErrorHandling.java
@@ -1,0 +1,5 @@
+package dev.langchain4j.community.model.minimax.client;
+
+public interface ErrorHandling {
+    ResponseHandle execute();
+}

--- a/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/GenericHeaderInjector.java
+++ b/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/GenericHeaderInjector.java
@@ -1,0 +1,27 @@
+package dev.langchain4j.community.model.minimax.client;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import okhttp3.Interceptor;
+import okhttp3.Request.Builder;
+import okhttp3.Response;
+import org.jetbrains.annotations.NotNull;
+
+class GenericHeaderInjector implements Interceptor {
+    private final Map<String, String> headers = new HashMap<>();
+
+    GenericHeaderInjector(Map<String, String> headers) {
+        Optional.ofNullable(headers).ifPresent(this.headers::putAll);
+    }
+
+    @NotNull
+    @Override
+    public Response intercept(Chain chain) throws IOException {
+        Builder builder = chain.request().newBuilder();
+        // Add headers
+        this.headers.forEach(builder::addHeader);
+        return chain.proceed(builder.build());
+    }
+}

--- a/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/MiniMaxApi.java
+++ b/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/MiniMaxApi.java
@@ -1,0 +1,15 @@
+package dev.langchain4j.community.model.minimax.client;
+
+import dev.langchain4j.community.model.minimax.client.chat.ChatCompletionRequest;
+import dev.langchain4j.community.model.minimax.client.chat.ChatCompletionResponse;
+import retrofit2.Call;
+import retrofit2.http.Body;
+import retrofit2.http.Headers;
+import retrofit2.http.POST;
+
+public interface MiniMaxApi {
+
+    @POST("v1/chat/completions")
+    @Headers("Content-Type: application/json")
+    Call<ChatCompletionResponse> chatCompletions(@Body ChatCompletionRequest request);
+}

--- a/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/MiniMaxClient.java
+++ b/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/MiniMaxClient.java
@@ -1,0 +1,215 @@
+package dev.langchain4j.community.model.minimax.client;
+
+import static dev.langchain4j.community.model.minimax.client.utils.JsonUtil.getObjectMapper;
+
+import dev.langchain4j.community.model.minimax.client.chat.ChatCompletionRequest;
+import dev.langchain4j.community.model.minimax.client.chat.ChatCompletionResponse;
+import dev.langchain4j.community.model.minimax.client.shared.StreamOptions;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import okhttp3.Cache;
+import okhttp3.OkHttpClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import retrofit2.Retrofit;
+import retrofit2.converter.jackson.JacksonConverterFactory;
+
+public class MiniMaxClient {
+
+    private static final Logger log = LoggerFactory.getLogger(MiniMaxClient.class);
+
+    private final String baseUrl;
+    private final OkHttpClient okHttpClient;
+    private final MiniMaxApi miniMaxApi;
+    private final boolean logStreamingResponses;
+
+    private MiniMaxClient(Builder builder) {
+        this.baseUrl = builder.baseUrl;
+        OkHttpClient.Builder okHttpClientBuilder = new OkHttpClient.Builder()
+                .callTimeout(builder.callTimeout)
+                .connectTimeout(builder.connectTimeout)
+                .readTimeout(builder.readTimeout)
+                .writeTimeout(builder.writeTimeout);
+
+        if (builder.apiKey != null) {
+            okHttpClientBuilder.addInterceptor(new AuthorizationHeaderInjector(builder.apiKey));
+        }
+        Map<String, String> headers = new HashMap<>();
+        if (builder.customHeaders != null) {
+            headers.putAll(builder.customHeaders);
+        }
+        if (!headers.isEmpty()) {
+            okHttpClientBuilder.addInterceptor(new GenericHeaderInjector(headers));
+        }
+        if (builder.proxy != null) {
+            okHttpClientBuilder.proxy(builder.proxy);
+        }
+        if (builder.logRequests) {
+            okHttpClientBuilder.addInterceptor(new RequestLoggingInterceptor());
+        }
+        if (builder.logResponses) {
+            okHttpClientBuilder.addInterceptor(new ResponseLoggingInterceptor());
+        }
+        this.logStreamingResponses = builder.logStreamingResponses;
+        this.okHttpClient = okHttpClientBuilder.build();
+        Retrofit.Builder retrofitBuilder =
+                new Retrofit.Builder().baseUrl(this.baseUrl).client(okHttpClient);
+        retrofitBuilder.addConverterFactory(JacksonConverterFactory.create(getObjectMapper()));
+        this.miniMaxApi = retrofitBuilder.build().create(MiniMaxApi.class);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public void shutdown() {
+        okHttpClient.dispatcher().executorService().shutdown();
+        okHttpClient.connectionPool().evictAll();
+        Cache cache = okHttpClient.cache();
+        if (cache != null) {
+            try {
+                cache.close();
+            } catch (IOException e) {
+                log.error("Failed to close cache", e);
+            }
+        }
+    }
+
+    public SyncOrAsyncOrStreaming<ChatCompletionResponse> chatCompletions(ChatCompletionRequest request) {
+        return new RequestExecutor<>(
+                miniMaxApi.chatCompletions(
+                        ChatCompletionRequest.builder().from(request).stream(null).build()),
+                r -> r,
+                okHttpClient,
+                formatUrl("v1/chat/completions"),
+                () -> ChatCompletionRequest.builder().from(request).stream(true)
+                        .streamOptions(StreamOptions.of(true))
+                        .build(),
+                ChatCompletionResponse.class,
+                r -> r,
+                logStreamingResponses);
+    }
+
+    private String formatUrl(String endpoint) {
+        return this.baseUrl + endpoint;
+    }
+
+    public static class Builder {
+
+        private String baseUrl;
+        private String apiKey;
+        private Duration callTimeout = Duration.ofSeconds(60);
+        private Duration connectTimeout = Duration.ofSeconds(60);
+        private Duration readTimeout = Duration.ofSeconds(60);
+        private Duration writeTimeout = Duration.ofSeconds(60);
+        private Proxy proxy;
+        private boolean logRequests;
+        private boolean logResponses;
+        private boolean logStreamingResponses;
+        private Map<String, String> customHeaders;
+
+        public Builder baseUrl(String baseUrl) {
+            if (baseUrl == null || baseUrl.trim().isEmpty()) {
+                throw new IllegalArgumentException("baseUrl cannot be null or empty");
+            }
+            this.baseUrl = baseUrl.endsWith("/") ? baseUrl : baseUrl + "/";
+            return this;
+        }
+
+        public Builder apiKey(String apiKey) {
+            this.apiKey = apiKey;
+            return this;
+        }
+
+        public Builder callTimeout(Duration callTimeout) {
+            if (callTimeout == null) {
+                throw new IllegalArgumentException("callTimeout cannot be null");
+            }
+            this.callTimeout = callTimeout;
+            return this;
+        }
+
+        public Builder connectTimeout(Duration connectTimeout) {
+            if (connectTimeout == null) {
+                throw new IllegalArgumentException("connectTimeout cannot be null");
+            }
+            this.connectTimeout = connectTimeout;
+            return this;
+        }
+
+        public Builder readTimeout(Duration readTimeout) {
+            if (readTimeout == null) {
+                throw new IllegalArgumentException("readTimeout cannot be null");
+            }
+            this.readTimeout = readTimeout;
+            return this;
+        }
+
+        public Builder writeTimeout(Duration writeTimeout) {
+            if (writeTimeout == null) {
+                throw new IllegalArgumentException("writeTimeout cannot be null");
+            }
+            this.writeTimeout = writeTimeout;
+            return this;
+        }
+
+        public Builder proxy(Proxy.Type type, String ip, int port) {
+            this.proxy = new Proxy(type, new InetSocketAddress(ip, port));
+            return this;
+        }
+
+        public Builder proxy(Proxy proxy) {
+            this.proxy = proxy;
+            return this;
+        }
+
+        public Builder logRequests() {
+            return this.logRequests(true);
+        }
+
+        public Builder logRequests(Boolean logRequests) {
+            if (logRequests == null) {
+                logRequests = false;
+            }
+            this.logRequests = logRequests;
+            return this;
+        }
+
+        public Builder logResponses() {
+            return this.logResponses(true);
+        }
+
+        public Builder logResponses(Boolean logResponses) {
+            if (logResponses == null) {
+                logResponses = false;
+            }
+            this.logResponses = logResponses;
+            return this;
+        }
+
+        public Builder logStreamingResponses() {
+            return logStreamingResponses(true);
+        }
+
+        public Builder logStreamingResponses(Boolean logStreamingResponses) {
+            if (logStreamingResponses == null) {
+                logStreamingResponses = false;
+            }
+            this.logStreamingResponses = logStreamingResponses;
+            return this;
+        }
+
+        public Builder customHeaders(Map<String, String> customHeaders) {
+            this.customHeaders = customHeaders;
+            return this;
+        }
+
+        public MiniMaxClient build() {
+            return new MiniMaxClient(this);
+        }
+    }
+}

--- a/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/MiniMaxHttpException.java
+++ b/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/MiniMaxHttpException.java
@@ -1,0 +1,16 @@
+package dev.langchain4j.community.model.minimax.client;
+
+import dev.langchain4j.exception.LangChain4jException;
+
+public class MiniMaxHttpException extends LangChain4jException {
+    private final int code;
+
+    public MiniMaxHttpException(int code, String message) {
+        super(message);
+        this.code = code;
+    }
+
+    public int code() {
+        return code;
+    }
+}

--- a/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/RequestExecutor.java
+++ b/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/RequestExecutor.java
@@ -1,0 +1,72 @@
+package dev.langchain4j.community.model.minimax.client;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import okhttp3.OkHttpClient;
+import retrofit2.Call;
+
+class RequestExecutor<Request, Response, ResponseContent> implements SyncOrAsyncOrStreaming<ResponseContent> {
+
+    private final Call<Response> call;
+    private final Function<Response, ResponseContent> responseContentExtractor;
+
+    private final OkHttpClient okHttpClient;
+    private final String endpointUrl;
+    private final Supplier<Request> requestWithStreamSupplier;
+    private final Class<Response> responseClass;
+    private final Function<Response, ResponseContent> streamEventContentExtractor;
+    private final boolean logStreamingResponses;
+
+    RequestExecutor(
+            Call<Response> call,
+            Function<Response, ResponseContent> responseContentExtractor,
+            OkHttpClient okHttpClient,
+            String endpointUrl,
+            Supplier<Request> requestWithStreamSupplier,
+            Class<Response> responseClass,
+            Function<Response, ResponseContent> streamEventContentExtractor,
+            boolean logStreamingResponses) {
+        this.call = call;
+        this.responseContentExtractor = responseContentExtractor;
+        this.okHttpClient = okHttpClient;
+        this.endpointUrl = endpointUrl;
+        this.requestWithStreamSupplier = requestWithStreamSupplier;
+        this.responseClass = responseClass;
+        this.streamEventContentExtractor = streamEventContentExtractor;
+        this.logStreamingResponses = logStreamingResponses;
+    }
+
+    RequestExecutor(Call<Response> call, Function<Response, ResponseContent> responseContentExtractor) {
+        this.call = call;
+        this.responseContentExtractor = responseContentExtractor;
+        this.okHttpClient = null;
+        this.endpointUrl = null;
+        this.requestWithStreamSupplier = null;
+        this.responseClass = null;
+        this.streamEventContentExtractor = null;
+        this.logStreamingResponses = false;
+    }
+
+    @Override
+    public ResponseContent execute() {
+        return new SyncRequestExecutor<>(call, responseContentExtractor).execute();
+    }
+
+    @Override
+    public AsyncResponseHandling onResponse(Consumer<ResponseContent> responseHandler) {
+        return new AsyncRequestExecutor<>(call, responseContentExtractor).onResponse(responseHandler);
+    }
+
+    @Override
+    public StreamingResponseHandling onPartialResponse(Consumer<ResponseContent> partialResponseHandler) {
+        return new StreamingRequestExecutor<>(
+                        okHttpClient,
+                        endpointUrl,
+                        requestWithStreamSupplier,
+                        responseClass,
+                        streamEventContentExtractor,
+                        logStreamingResponses)
+                .onPartialResponse(partialResponseHandler);
+    }
+}

--- a/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/RequestLoggingInterceptor.java
+++ b/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/RequestLoggingInterceptor.java
@@ -1,0 +1,84 @@
+package dev.langchain4j.community.model.minimax.client;
+
+import dev.langchain4j.internal.Utils;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+import okhttp3.Headers;
+import okhttp3.Interceptor;
+import okhttp3.Request;
+import okhttp3.Response;
+import okio.Buffer;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class RequestLoggingInterceptor implements Interceptor {
+
+    private static final Logger log = LoggerFactory.getLogger(RequestLoggingInterceptor.class);
+
+    private static final Set<String> COMMON_SECRET_HEADERS =
+            new HashSet<>(List.of("authorization", "x-api-key", "x-auth-token"));
+
+    private static String getBody(Request request) {
+        try {
+            Buffer buffer = new Buffer();
+            if (request.body() == null) {
+                return "";
+            }
+            request.body().writeTo(buffer);
+            return buffer.readUtf8();
+        } catch (Exception e) {
+            log.warn("Exception while getting body", e);
+            return "Exception while getting body: " + e.getMessage();
+        }
+    }
+
+    private static String getHeaders(Headers headers) {
+        return StreamSupport.stream(headers.spliterator(), false)
+                .map(header -> formatHeader(header.component1(), header.component2()))
+                .collect(Collectors.joining(", "));
+    }
+
+    private static String formatHeader(String headerKey, String headerValue) {
+        if (COMMON_SECRET_HEADERS.contains(headerKey.toLowerCase())) {
+            headerValue = maskSecretKey(headerValue);
+        }
+        return String.format("[%s: %s]", headerKey, headerValue);
+    }
+
+    private static String maskSecretKey(String key) {
+        if (Utils.isNullOrBlank(key)) {
+            return key;
+        }
+
+        if (key.length() >= 7) {
+            return key.substring(0, 5) + "..." + key.substring(key.length() - 2);
+        } else {
+            return "..."; // to short to be masked
+        }
+    }
+
+    @Override
+    public @NotNull Response intercept(Chain chain) throws IOException {
+        Request request = chain.request();
+        this.log(request);
+        return chain.proceed(request);
+    }
+
+    private void log(Request request) {
+        try {
+            log.debug(
+                    "Request:\n- method: {}\n- url: {}\n- headers: {}\n- body: {}",
+                    request.method(),
+                    request.url(),
+                    getHeaders(request.headers()),
+                    getBody(request));
+        } catch (Exception e) {
+            log.warn("Error while logging request: {}", e.getMessage());
+        }
+    }
+}

--- a/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/ResponseHandle.java
+++ b/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/ResponseHandle.java
@@ -1,0 +1,16 @@
+package dev.langchain4j.community.model.minimax.client;
+
+/**
+ * Provides a mechanism to cancel the response after a request has been initiated.
+ */
+public class ResponseHandle {
+
+    volatile boolean cancelled = false;
+
+    /**
+     * Cancels the response. Currently, this only works for streaming. It has no effect on regular asynchronous responses.
+     */
+    public void cancel() {
+        cancelled = true;
+    }
+}

--- a/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/ResponseLoggingInterceptor.java
+++ b/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/ResponseLoggingInterceptor.java
@@ -1,0 +1,50 @@
+package dev.langchain4j.community.model.minimax.client;
+
+import java.io.IOException;
+import okhttp3.Interceptor;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class ResponseLoggingInterceptor implements Interceptor {
+    private static final Logger log = LoggerFactory.getLogger(ResponseLoggingInterceptor.class);
+
+    public ResponseLoggingInterceptor() {}
+
+    private static boolean isEventStream(Response response) {
+        String contentType = response.header("Content-Type");
+        return contentType != null && contentType.contains("event-stream");
+    }
+
+    @Override
+    public @NotNull Response intercept(Chain chain) throws IOException {
+        Request request = chain.request();
+        Response response = chain.proceed(request);
+        this.log(response);
+        return response;
+    }
+
+    public void log(Response response) {
+        try {
+            log(
+                    "Response:\n- status code: {}\n- headers: {}\n- body: {}",
+                    response.code(),
+                    response.headers(),
+                    this.getBody(response));
+        } catch (Exception e) {
+            log.warn("Error while logging response: {}", e.getMessage());
+        }
+    }
+
+    public void log(String message, Object... args) {
+        log.debug(message, args);
+    }
+
+    private String getBody(Response response) throws IOException {
+        return isEventStream(response)
+                ? "[skipping response body due to streaming]"
+                : response.peekBody(Long.MAX_VALUE).string();
+    }
+}

--- a/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/StreamingCompletionHandling.java
+++ b/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/StreamingCompletionHandling.java
@@ -1,0 +1,9 @@
+package dev.langchain4j.community.model.minimax.client;
+
+import java.util.function.Consumer;
+
+public interface StreamingCompletionHandling {
+    ErrorHandling onError(Consumer<Throwable> errorHandler);
+
+    ErrorHandling ignoreErrors();
+}

--- a/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/StreamingRequestExecutor.java
+++ b/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/StreamingRequestExecutor.java
@@ -1,0 +1,188 @@
+package dev.langchain4j.community.model.minimax.client;
+
+import static dev.langchain4j.community.model.minimax.client.utils.ExceptionUtil.toException;
+import static dev.langchain4j.community.model.minimax.client.utils.JsonUtil.toJson;
+import static dev.langchain4j.community.model.minimax.client.utils.JsonUtil.toObject;
+
+import java.io.IOException;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.RequestBody;
+import okhttp3.sse.EventSource;
+import okhttp3.sse.EventSourceListener;
+import okhttp3.sse.EventSources;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class StreamingRequestExecutor<Request, Response, ResponseContent> {
+    private static final Logger log = LoggerFactory.getLogger(StreamingRequestExecutor.class);
+    private final OkHttpClient okHttpClient;
+    private final String endpointUrl;
+    private final Supplier<Request> requestWithStreamSupplier;
+    private final Class<Response> responseClass;
+    private final Function<Response, ResponseContent> streamEventContentExtractor;
+    private final boolean logStreamingResponses;
+    private final ResponseLoggingInterceptor responseLogger = new ResponseLoggingInterceptor();
+
+    StreamingRequestExecutor(
+            OkHttpClient okHttpClient,
+            String endpointUrl,
+            Supplier<Request> requestWithStreamSupplier,
+            Class<Response> responseClass,
+            Function<Response, ResponseContent> streamEventContentExtractor,
+            boolean logStreamingResponses) {
+        this.okHttpClient = okHttpClient;
+        this.endpointUrl = endpointUrl;
+        this.requestWithStreamSupplier = requestWithStreamSupplier;
+        this.responseClass = responseClass;
+        this.streamEventContentExtractor = streamEventContentExtractor;
+        this.logStreamingResponses = logStreamingResponses;
+    }
+
+    StreamingResponseHandling onPartialResponse(Consumer<ResponseContent> partialResponseHandler) {
+        return new StreamingResponseHandling() {
+            @Override
+            public StreamingCompletionHandling onComplete(Runnable streamingCompletionCallback) {
+                return new StreamingCompletionHandling() {
+                    @Override
+                    public ErrorHandling onError(Consumer<Throwable> errorHandler) {
+                        return () -> stream(partialResponseHandler, streamingCompletionCallback, errorHandler);
+                    }
+
+                    @Override
+                    public ErrorHandling ignoreErrors() {
+                        return () -> stream(partialResponseHandler, streamingCompletionCallback, (e) -> {
+                            // intentionally ignoring because user called ignoreErrors()
+                        });
+                    }
+                };
+            }
+
+            @Override
+            public ErrorHandling onError(Consumer<Throwable> errorHandler) {
+                return () -> stream(
+                        partialResponseHandler,
+                        () -> {
+                            // intentionally ignoring because user did not provide callback
+                        },
+                        errorHandler);
+            }
+
+            @Override
+            public ErrorHandling ignoreErrors() {
+                return () -> stream(
+                        partialResponseHandler,
+                        () -> {
+                            // intentionally ignoring because user did not provide callback
+                        },
+                        (e) -> {
+                            // intentionally ignoring because user called ignoreErrors()
+                        });
+            }
+        };
+    }
+
+    private ResponseHandle stream(
+            Consumer<ResponseContent> partialResponseHandler,
+            Runnable streamingCompletionCallback,
+            Consumer<Throwable> errorHandler) {
+
+        Request request = requestWithStreamSupplier.get();
+
+        String requestJson = toJson(request);
+
+        okhttp3.Request okHttpRequest = new okhttp3.Request.Builder()
+                .url(endpointUrl)
+                .post(RequestBody.create(requestJson, MediaType.get("application/json; charset=utf-8")))
+                .build();
+
+        ResponseHandle responseHandle = new ResponseHandle();
+
+        EventSourceListener eventSourceListener = new EventSourceListener() {
+
+            @Override
+            public void onOpen(@NotNull EventSource eventSource, @NotNull okhttp3.Response response) {
+                if (responseHandle.cancelled) {
+                    eventSource.cancel();
+                    return;
+                }
+
+                if (logStreamingResponses) {
+                    responseLogger.log(response);
+                }
+            }
+
+            @Override
+            public void onEvent(@NotNull EventSource eventSource, String id, String type, @NotNull String data) {
+                if (responseHandle.cancelled) {
+                    eventSource.cancel();
+                    return;
+                }
+
+                if (logStreamingResponses) {
+                    responseLogger.log("onEvent() {}", data);
+                }
+
+                if ("[DONE]".equals(data)) {
+                    return;
+                }
+
+                try {
+                    Response response = toObject(data, responseClass);
+                    ResponseContent responseContent = streamEventContentExtractor.apply(response);
+                    if (responseContent != null) {
+                        partialResponseHandler.accept(responseContent); // do not handle exception, fail-fast
+                    }
+                } catch (Exception e) {
+                    errorHandler.accept(e);
+                }
+            }
+
+            @Override
+            public void onClosed(@NotNull EventSource eventSource) {
+                if (responseHandle.cancelled) {
+                    eventSource.cancel();
+                    return;
+                }
+                if (logStreamingResponses) {
+                    responseLogger.log("onClosed()");
+                }
+                streamingCompletionCallback.run();
+            }
+
+            @Override
+            public void onFailure(@NotNull EventSource eventSource, Throwable t, okhttp3.Response response) {
+                if (responseHandle.cancelled) {
+                    return;
+                }
+
+                // TODO remove this when migrating from okhttp
+                if (t instanceof IllegalArgumentException && "byteCount < 0: -1".equals(t.getMessage())) {
+                    streamingCompletionCallback.run();
+                    return;
+                }
+
+                if (logStreamingResponses) {
+                    responseLogger.log("onFailure()", t);
+                    responseLogger.log(response);
+                }
+
+                if (t != null) {
+                    errorHandler.accept(t); // TODO also include information from response?
+                } else {
+                    try {
+                        errorHandler.accept(toException(response));
+                    } catch (IOException e) {
+                        errorHandler.accept(e); // TODO right thing to do?
+                    }
+                }
+            }
+        };
+        EventSources.createFactory(okHttpClient).newEventSource(okHttpRequest, eventSourceListener);
+        return responseHandle;
+    }
+}

--- a/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/StreamingResponseHandling.java
+++ b/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/StreamingResponseHandling.java
@@ -1,0 +1,5 @@
+package dev.langchain4j.community.model.minimax.client;
+
+public interface StreamingResponseHandling extends AsyncResponseHandling {
+    StreamingCompletionHandling onComplete(Runnable streamingCompletionCallback);
+}

--- a/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/SyncOrAsync.java
+++ b/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/SyncOrAsync.java
@@ -1,0 +1,9 @@
+package dev.langchain4j.community.model.minimax.client;
+
+import java.util.function.Consumer;
+
+public interface SyncOrAsync<ResponseContent> {
+    ResponseContent execute();
+
+    AsyncResponseHandling onResponse(Consumer<ResponseContent> responseHandler);
+}

--- a/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/SyncOrAsyncOrStreaming.java
+++ b/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/SyncOrAsyncOrStreaming.java
@@ -1,0 +1,7 @@
+package dev.langchain4j.community.model.minimax.client;
+
+import java.util.function.Consumer;
+
+public interface SyncOrAsyncOrStreaming<ResponseContent> extends SyncOrAsync<ResponseContent> {
+    StreamingResponseHandling onPartialResponse(Consumer<ResponseContent> partialResponseHandler);
+}

--- a/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/SyncRequestExecutor.java
+++ b/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/SyncRequestExecutor.java
@@ -1,0 +1,32 @@
+package dev.langchain4j.community.model.minimax.client;
+
+import static dev.langchain4j.community.model.minimax.client.utils.ExceptionUtil.toException;
+
+import java.io.IOException;
+import java.util.function.Function;
+import retrofit2.Call;
+
+class SyncRequestExecutor<Response, ResponseContent> {
+
+    private final Call<Response> call;
+    private final Function<Response, ResponseContent> responseContentExtractor;
+
+    SyncRequestExecutor(Call<Response> call, Function<Response, ResponseContent> responseContentExtractor) {
+        this.call = call;
+        this.responseContentExtractor = responseContentExtractor;
+    }
+
+    ResponseContent execute() {
+        try {
+            retrofit2.Response<Response> retrofitResponse = call.execute();
+            if (retrofitResponse.isSuccessful()) {
+                Response response = retrofitResponse.body();
+                return responseContentExtractor.apply(response);
+            } else {
+                throw toException(retrofitResponse);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/chat/ChatCompletionChoice.java
+++ b/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/chat/ChatCompletionChoice.java
@@ -1,0 +1,82 @@
+package dev.langchain4j.community.model.minimax.client.chat;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import dev.langchain4j.community.model.minimax.client.chat.message.AssistantMessage;
+
+@JsonDeserialize(builder = ChatCompletionChoice.Builder.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public final class ChatCompletionChoice {
+    private final Integer index;
+    private final String finishReason;
+    private final AssistantMessage message;
+    private final Delta delta;
+
+    private ChatCompletionChoice(Builder builder) {
+        index = builder.index;
+        finishReason = builder.finishReason;
+        message = builder.message;
+        delta = builder.delta;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public Integer getIndex() {
+        return index;
+    }
+
+    public String getFinishReason() {
+        return finishReason;
+    }
+
+    public AssistantMessage getMessage() {
+        return message;
+    }
+
+    public Delta getDelta() {
+        return delta;
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public static final class Builder {
+        private Integer index;
+        private String finishReason;
+        private AssistantMessage message;
+        private Delta delta;
+
+        private Builder() {}
+
+        public Builder index(Integer val) {
+            index = val;
+            return this;
+        }
+
+        public Builder finishReason(String val) {
+            finishReason = val;
+            return this;
+        }
+
+        public Builder message(AssistantMessage val) {
+            message = val;
+            return this;
+        }
+
+        public Builder delta(Delta val) {
+            delta = val;
+            return this;
+        }
+
+        public ChatCompletionChoice build() {
+            return new ChatCompletionChoice(this);
+        }
+    }
+}

--- a/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/chat/ChatCompletionRequest.java
+++ b/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/chat/ChatCompletionRequest.java
@@ -1,0 +1,248 @@
+package dev.langchain4j.community.model.minimax.client.chat;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import dev.langchain4j.community.model.minimax.client.chat.message.Message;
+import dev.langchain4j.community.model.minimax.client.shared.StreamOptions;
+import java.util.List;
+
+@JsonDeserialize(builder = ChatCompletionRequest.Builder.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public final class ChatCompletionRequest {
+    private final String model;
+    private final List<Message> messages;
+    private final Double temperature;
+    private final Double topP;
+    private final Integer n;
+    private final Boolean stream;
+    private final StreamOptions streamOptions;
+    private final List<String> stop;
+    private final Integer maxTokens;
+    private final Double presencePenalty;
+    private final Double frequencyPenalty;
+    private final String user;
+    private final Integer seed;
+    private final List<Tool> tools;
+    private final Object toolChoice;
+    private final Boolean parallelToolCalls;
+
+    private ChatCompletionRequest(Builder builder) {
+        model = builder.model;
+        messages = builder.messages;
+        temperature = builder.temperature;
+        topP = builder.topP;
+        n = builder.n;
+        stream = builder.stream;
+        streamOptions = builder.streamOptions;
+        stop = builder.stop;
+        maxTokens = builder.maxTokens;
+        presencePenalty = builder.presencePenalty;
+        frequencyPenalty = builder.frequencyPenalty;
+        user = builder.user;
+        seed = builder.seed;
+        tools = builder.tools;
+        toolChoice = builder.toolChoice;
+        parallelToolCalls = builder.parallelToolCalls;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public String getModel() {
+        return model;
+    }
+
+    public List<Message> getMessages() {
+        return messages;
+    }
+
+    public Double getTemperature() {
+        return temperature;
+    }
+
+    public Double getTopP() {
+        return topP;
+    }
+
+    public Integer getN() {
+        return n;
+    }
+
+    public Boolean getStream() {
+        return stream;
+    }
+
+    public StreamOptions getStreamOptions() {
+        return streamOptions;
+    }
+
+    public List<String> getStop() {
+        return stop;
+    }
+
+    public Integer getMaxTokens() {
+        return maxTokens;
+    }
+
+    public Double getPresencePenalty() {
+        return presencePenalty;
+    }
+
+    public Double getFrequencyPenalty() {
+        return frequencyPenalty;
+    }
+
+    public String getUser() {
+        return user;
+    }
+
+    public Integer getSeed() {
+        return seed;
+    }
+
+    public List<Tool> getTools() {
+        return tools;
+    }
+
+    public Object getToolChoice() {
+        return toolChoice;
+    }
+
+    public Boolean getParallelToolCalls() {
+        return parallelToolCalls;
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public static final class Builder {
+        private String model;
+        private List<Message> messages;
+        private Double temperature;
+        private Double topP;
+        private Integer n;
+        private Boolean stream;
+        private StreamOptions streamOptions;
+        private List<String> stop;
+        private Integer maxTokens;
+        private Double presencePenalty;
+        private Double frequencyPenalty;
+        private String user;
+        private Integer seed;
+        private List<Tool> tools;
+        private Object toolChoice;
+        private Boolean parallelToolCalls;
+
+        private Builder() {}
+
+        public Builder from(ChatCompletionRequest request) {
+            this.model(request.getModel());
+            this.messages(request.getMessages());
+            this.temperature(request.getTemperature());
+            this.topP(request.getTopP());
+            this.n(request.getN());
+            this.stream(request.getStream());
+            this.streamOptions(request.getStreamOptions());
+            this.stop(request.getStop());
+            this.maxTokens(request.getMaxTokens());
+            this.presencePenalty(request.getPresencePenalty());
+            this.frequencyPenalty(request.getFrequencyPenalty());
+            this.user(request.getUser());
+            this.seed(request.getSeed());
+            this.tools(request.getTools());
+            this.toolChoice(request.getToolChoice());
+            this.parallelToolCalls(request.getParallelToolCalls());
+            return this;
+        }
+
+        public Builder model(String val) {
+            model = val;
+            return this;
+        }
+
+        public Builder messages(List<Message> val) {
+            messages = val;
+            return this;
+        }
+
+        public Builder temperature(Double val) {
+            temperature = val;
+            return this;
+        }
+
+        public Builder topP(Double val) {
+            topP = val;
+            return this;
+        }
+
+        public Builder n(Integer val) {
+            n = val;
+            return this;
+        }
+
+        public Builder stream(Boolean val) {
+            stream = val;
+            return this;
+        }
+
+        public Builder streamOptions(StreamOptions val) {
+            streamOptions = val;
+            return this;
+        }
+
+        public Builder stop(List<String> val) {
+            stop = val;
+            return this;
+        }
+
+        public Builder maxTokens(Integer val) {
+            maxTokens = val;
+            return this;
+        }
+
+        public Builder presencePenalty(Double val) {
+            presencePenalty = val;
+            return this;
+        }
+
+        public Builder frequencyPenalty(Double val) {
+            frequencyPenalty = val;
+            return this;
+        }
+
+        public Builder user(String val) {
+            user = val;
+            return this;
+        }
+
+        public Builder seed(Integer val) {
+            seed = val;
+            return this;
+        }
+
+        public Builder tools(List<Tool> val) {
+            tools = val;
+            return this;
+        }
+
+        public Builder toolChoice(Object val) {
+            toolChoice = val;
+            return this;
+        }
+
+        public Builder parallelToolCalls(Boolean val) {
+            parallelToolCalls = val;
+            return this;
+        }
+
+        public ChatCompletionRequest build() {
+            return new ChatCompletionRequest(this);
+        }
+    }
+}

--- a/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/chat/ChatCompletionResponse.java
+++ b/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/chat/ChatCompletionResponse.java
@@ -1,0 +1,99 @@
+package dev.langchain4j.community.model.minimax.client.chat;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import dev.langchain4j.community.model.minimax.client.shared.CompletionUsage;
+import java.util.List;
+
+@JsonDeserialize(builder = ChatCompletionResponse.Builder.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public final class ChatCompletionResponse {
+    private final String id;
+    private final Integer created;
+    private final String model;
+    private final List<ChatCompletionChoice> choices;
+    private final CompletionUsage usage;
+
+    private ChatCompletionResponse(Builder builder) {
+        id = builder.id;
+        created = builder.created;
+        model = builder.model;
+        choices = builder.choices;
+        usage = builder.usage;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public Integer getCreated() {
+        return created;
+    }
+
+    public String getModel() {
+        return model;
+    }
+
+    public List<ChatCompletionChoice> getChoices() {
+        return choices;
+    }
+
+    public CompletionUsage getUsage() {
+        return usage;
+    }
+
+    public String content() {
+        return choices.get(0).getMessage().getContent();
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public static final class Builder {
+        private String id;
+        private Integer created;
+        private String model;
+        private List<ChatCompletionChoice> choices;
+        private CompletionUsage usage;
+
+        private Builder() {}
+
+        public Builder id(String val) {
+            id = val;
+            return this;
+        }
+
+        public Builder created(Integer val) {
+            created = val;
+            return this;
+        }
+
+        public Builder model(String val) {
+            model = val;
+            return this;
+        }
+
+        public Builder choices(List<ChatCompletionChoice> val) {
+            choices = val;
+            return this;
+        }
+
+        public Builder usage(CompletionUsage val) {
+            usage = val;
+            return this;
+        }
+
+        public ChatCompletionResponse build() {
+            return new ChatCompletionResponse(this);
+        }
+    }
+}

--- a/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/chat/Delta.java
+++ b/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/chat/Delta.java
@@ -1,0 +1,71 @@
+package dev.langchain4j.community.model.minimax.client.chat;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import dev.langchain4j.community.model.minimax.client.chat.message.ToolCall;
+import java.util.List;
+
+@JsonDeserialize(builder = Delta.Builder.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public final class Delta {
+    private final Role role;
+    private final String content;
+    private final List<ToolCall> toolCalls;
+
+    private Delta(Builder builder) {
+        role = builder.role;
+        content = builder.content;
+        toolCalls = builder.toolCalls;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public Role getRole() {
+        return role;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public List<ToolCall> getToolCalls() {
+        return toolCalls;
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public static final class Builder {
+        private Role role;
+        private String content;
+        private List<ToolCall> toolCalls;
+
+        private Builder() {}
+
+        public Builder role(Role val) {
+            role = val;
+            return this;
+        }
+
+        public Builder content(String val) {
+            content = val;
+            return this;
+        }
+
+        public Builder toolCalls(List<ToolCall> val) {
+            toolCalls = val;
+            return this;
+        }
+
+        public Delta build() {
+            return new Delta(this);
+        }
+    }
+}

--- a/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/chat/Function.java
+++ b/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/chat/Function.java
@@ -1,0 +1,69 @@
+package dev.langchain4j.community.model.minimax.client.chat;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+@JsonDeserialize(builder = Function.Builder.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public final class Function {
+    private final String name;
+    private final String description;
+    private final Parameters parameters;
+
+    private Function(Builder builder) {
+        name = builder.name;
+        description = builder.description;
+        parameters = builder.parameters;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public Parameters getParameters() {
+        return parameters;
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public static final class Builder {
+        private String name;
+        private String description;
+        private Parameters parameters;
+
+        private Builder() {}
+
+        public Builder name(String val) {
+            name = val;
+            return this;
+        }
+
+        public Builder description(String val) {
+            description = val;
+            return this;
+        }
+
+        public Builder parameters(Parameters val) {
+            parameters = val;
+            return this;
+        }
+
+        public Function build() {
+            return new Function(this);
+        }
+    }
+}

--- a/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/chat/Parameters.java
+++ b/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/chat/Parameters.java
@@ -1,0 +1,82 @@
+package dev.langchain4j.community.model.minimax.client.chat;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import java.util.List;
+import java.util.Map;
+
+@JsonDeserialize(builder = Parameters.Builder.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public final class Parameters {
+    private final String type;
+    private final String description;
+    private final Map<String, Map<String, Object>> properties;
+    private final List<String> required;
+
+    private Parameters(Builder builder) {
+        type = builder.type;
+        description = builder.description;
+        properties = builder.properties;
+        required = builder.required;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public Map<String, Map<String, Object>> getProperties() {
+        return properties;
+    }
+
+    public List<String> getRequired() {
+        return required;
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public static final class Builder {
+        private String type;
+        private String description;
+        private Map<String, Map<String, Object>> properties;
+        private List<String> required;
+
+        private Builder() {}
+
+        public Builder type(String val) {
+            type = val;
+            return this;
+        }
+
+        public Builder description(String val) {
+            description = val;
+            return this;
+        }
+
+        public Builder properties(Map<String, Map<String, Object>> val) {
+            properties = val;
+            return this;
+        }
+
+        public Builder required(List<String> val) {
+            required = val;
+            return this;
+        }
+
+        public Parameters build() {
+            return new Parameters(this);
+        }
+    }
+}

--- a/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/chat/Role.java
+++ b/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/chat/Role.java
@@ -1,0 +1,14 @@
+package dev.langchain4j.community.model.minimax.client.chat;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum Role {
+    @JsonProperty("system")
+    SYSTEM,
+    @JsonProperty("user")
+    USER,
+    @JsonProperty("assistant")
+    ASSISTANT,
+    @JsonProperty("tool")
+    TOOL,
+}

--- a/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/chat/Tool.java
+++ b/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/chat/Tool.java
@@ -1,0 +1,54 @@
+package dev.langchain4j.community.model.minimax.client.chat;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+@JsonDeserialize(builder = Tool.Builder.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public final class Tool {
+    private final ToolType type = ToolType.FUNCTION;
+    private final Function function;
+
+    private Tool(Builder builder) {
+        function = builder.function;
+    }
+
+    public static Tool of(Function function) {
+        return builder().function(function).build();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public ToolType getType() {
+        return type;
+    }
+
+    public Function getFunction() {
+        return function;
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public static final class Builder {
+        private Function function;
+
+        private Builder() {}
+
+        public Builder function(Function val) {
+            function = val;
+            return this;
+        }
+
+        public Tool build() {
+            return new Tool(this);
+        }
+    }
+}

--- a/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/chat/ToolType.java
+++ b/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/chat/ToolType.java
@@ -1,0 +1,8 @@
+package dev.langchain4j.community.model.minimax.client.chat;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum ToolType {
+    @JsonProperty("function")
+    FUNCTION
+}

--- a/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/chat/message/AssistantMessage.java
+++ b/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/chat/message/AssistantMessage.java
@@ -1,0 +1,72 @@
+package dev.langchain4j.community.model.minimax.client.chat.message;
+
+import static dev.langchain4j.internal.Utils.getOrDefault;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import dev.langchain4j.community.model.minimax.client.chat.Role;
+import java.util.List;
+
+@JsonDeserialize(builder = AssistantMessage.Builder.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public final class AssistantMessage implements Message {
+    private final Role role = Role.ASSISTANT;
+    private final String content;
+    private final List<ToolCall> toolCalls;
+
+    private AssistantMessage(Builder builder) {
+        // content should not be null
+        content = getOrDefault(builder.content, "");
+        toolCalls = builder.toolCalls;
+    }
+
+    public static AssistantMessage of(String content, ToolCall... toolCalls) {
+        return builder().content(content).toolCalls(List.of(toolCalls)).build();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public Role getRole() {
+        return role;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public List<ToolCall> getToolCalls() {
+        return toolCalls;
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public static final class Builder {
+        private String content;
+        private List<ToolCall> toolCalls;
+
+        private Builder() {}
+
+        public Builder content(String val) {
+            content = val;
+            return this;
+        }
+
+        public Builder toolCalls(List<ToolCall> val) {
+            toolCalls = val;
+            return this;
+        }
+
+        public AssistantMessage build() {
+            return new AssistantMessage(this);
+        }
+    }
+}

--- a/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/chat/message/FunctionCall.java
+++ b/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/chat/message/FunctionCall.java
@@ -1,0 +1,69 @@
+package dev.langchain4j.community.model.minimax.client.chat.message;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+@JsonDeserialize(builder = FunctionCall.Builder.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public final class FunctionCall {
+    private final String id;
+    private final String name;
+    private final String arguments;
+
+    private FunctionCall(Builder builder) {
+        id = builder.id;
+        name = builder.name;
+        arguments = builder.arguments;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getArguments() {
+        return arguments;
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public static final class Builder {
+        private String id;
+        private String name;
+        private String arguments;
+
+        private Builder() {}
+
+        public Builder id(String val) {
+            id = val;
+            return this;
+        }
+
+        public Builder name(String val) {
+            name = val;
+            return this;
+        }
+
+        public Builder arguments(String val) {
+            arguments = val;
+            return this;
+        }
+
+        public FunctionCall build() {
+            return new FunctionCall(this);
+        }
+    }
+}

--- a/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/chat/message/Message.java
+++ b/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/chat/message/Message.java
@@ -1,0 +1,7 @@
+package dev.langchain4j.community.model.minimax.client.chat.message;
+
+import dev.langchain4j.community.model.minimax.client.chat.Role;
+
+public interface Message {
+    Role getRole();
+}

--- a/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/chat/message/SystemMessage.java
+++ b/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/chat/message/SystemMessage.java
@@ -1,0 +1,68 @@
+package dev.langchain4j.community.model.minimax.client.chat.message;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import dev.langchain4j.community.model.minimax.client.chat.Role;
+
+@JsonDeserialize(builder = SystemMessage.Builder.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public final class SystemMessage implements Message {
+    private final Role role = Role.SYSTEM;
+    private final String content;
+    private final String name;
+
+    private SystemMessage(Builder builder) {
+        content = builder.content;
+        name = builder.name;
+    }
+
+    public static SystemMessage of(String content) {
+        return builder().content(content).build();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public Role getRole() {
+        return role;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public static final class Builder {
+        private String content;
+        private String name;
+
+        private Builder() {}
+
+        public Builder content(String val) {
+            content = val;
+            return this;
+        }
+
+        public Builder name(String val) {
+            name = val;
+            return this;
+        }
+
+        public SystemMessage build() {
+            return new SystemMessage(this);
+        }
+    }
+}

--- a/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/chat/message/ToolCall.java
+++ b/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/chat/message/ToolCall.java
@@ -1,0 +1,70 @@
+package dev.langchain4j.community.model.minimax.client.chat.message;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import dev.langchain4j.community.model.minimax.client.chat.ToolType;
+
+@JsonDeserialize(builder = ToolCall.Builder.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public final class ToolCall {
+    private final String id;
+    private final ToolType type;
+    private final FunctionCall function;
+
+    private ToolCall(Builder builder) {
+        id = builder.id;
+        type = builder.type;
+        function = builder.function;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public ToolType getType() {
+        return type;
+    }
+
+    public FunctionCall getFunction() {
+        return function;
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public static final class Builder {
+        private String id;
+        private ToolType type;
+        private FunctionCall function;
+
+        private Builder() {}
+
+        public Builder id(String val) {
+            id = val;
+            return this;
+        }
+
+        public Builder type(ToolType val) {
+            type = val;
+            return this;
+        }
+
+        public Builder function(FunctionCall val) {
+            function = val;
+            return this;
+        }
+
+        public ToolCall build() {
+            return new ToolCall(this);
+        }
+    }
+}

--- a/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/chat/message/ToolMessage.java
+++ b/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/chat/message/ToolMessage.java
@@ -1,0 +1,68 @@
+package dev.langchain4j.community.model.minimax.client.chat.message;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import dev.langchain4j.community.model.minimax.client.chat.Role;
+
+@JsonDeserialize(builder = ToolMessage.Builder.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public final class ToolMessage implements Message {
+    private final Role role = Role.TOOL;
+    private final String content;
+    private final String toolCallId;
+
+    private ToolMessage(Builder builder) {
+        content = builder.content;
+        toolCallId = builder.toolCallId;
+    }
+
+    public static ToolMessage of(String toolCallId, String content) {
+        return builder().content(content).toolCallId(toolCallId).build();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public Role getRole() {
+        return role;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public String getToolCallId() {
+        return toolCallId;
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public static final class Builder {
+        private String content;
+        private String toolCallId;
+
+        private Builder() {}
+
+        public Builder content(String val) {
+            content = val;
+            return this;
+        }
+
+        public Builder toolCallId(String val) {
+            toolCallId = val;
+            return this;
+        }
+
+        public ToolMessage build() {
+            return new ToolMessage(this);
+        }
+    }
+}

--- a/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/chat/message/UserMessage.java
+++ b/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/chat/message/UserMessage.java
@@ -1,0 +1,68 @@
+package dev.langchain4j.community.model.minimax.client.chat.message;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import dev.langchain4j.community.model.minimax.client.chat.Role;
+
+@JsonDeserialize(builder = UserMessage.Builder.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public final class UserMessage implements Message {
+    private final Role role = Role.USER;
+    private final Object content;
+    private final String name;
+
+    private UserMessage(Builder builder) {
+        content = builder.content;
+        name = builder.name;
+    }
+
+    public static UserMessage of(String content) {
+        return builder().content(content).build();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public Role getRole() {
+        return role;
+    }
+
+    public Object getContent() {
+        return content;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public static final class Builder {
+        private Object content;
+        private String name;
+
+        private Builder() {}
+
+        public Builder content(Object val) {
+            content = val;
+            return this;
+        }
+
+        public Builder name(String val) {
+            name = val;
+            return this;
+        }
+
+        public UserMessage build() {
+            return new UserMessage(this);
+        }
+    }
+}

--- a/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/shared/CompletionUsage.java
+++ b/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/shared/CompletionUsage.java
@@ -1,0 +1,69 @@
+package dev.langchain4j.community.model.minimax.client.shared;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+@JsonDeserialize(builder = CompletionUsage.Builder.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public final class CompletionUsage {
+    private final Integer totalTokens;
+    private final Integer promptTokens;
+    private final Integer completionTokens;
+
+    private CompletionUsage(Builder builder) {
+        totalTokens = builder.totalTokens;
+        promptTokens = builder.promptTokens;
+        completionTokens = builder.completionTokens;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public Integer getTotalTokens() {
+        return totalTokens;
+    }
+
+    public Integer getPromptTokens() {
+        return promptTokens;
+    }
+
+    public Integer getCompletionTokens() {
+        return completionTokens;
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public static final class Builder {
+        private Integer totalTokens;
+        private Integer promptTokens;
+        private Integer completionTokens;
+
+        private Builder() {}
+
+        public Builder totalTokens(Integer val) {
+            totalTokens = val;
+            return this;
+        }
+
+        public Builder promptTokens(Integer val) {
+            promptTokens = val;
+            return this;
+        }
+
+        public Builder completionTokens(Integer val) {
+            completionTokens = val;
+            return this;
+        }
+
+        public CompletionUsage build() {
+            return new CompletionUsage(this);
+        }
+    }
+}

--- a/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/shared/StreamOptions.java
+++ b/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/shared/StreamOptions.java
@@ -1,0 +1,49 @@
+package dev.langchain4j.community.model.minimax.client.shared;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+@JsonDeserialize(builder = StreamOptions.Builder.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public final class StreamOptions {
+    private final Boolean includeUsage;
+
+    private StreamOptions(Builder builder) {
+        includeUsage = builder.includeUsage;
+    }
+
+    public static StreamOptions of(boolean includeUsage) {
+        return builder().includeUsage(includeUsage).build();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public Boolean getIncludeUsage() {
+        return includeUsage;
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public static final class Builder {
+        private Boolean includeUsage;
+
+        private Builder() {}
+
+        public Builder includeUsage(Boolean val) {
+            includeUsage = val;
+            return this;
+        }
+
+        public StreamOptions build() {
+            return new StreamOptions(this);
+        }
+    }
+}

--- a/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/utils/ExceptionUtil.java
+++ b/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/utils/ExceptionUtil.java
@@ -1,0 +1,14 @@
+package dev.langchain4j.community.model.minimax.client.utils;
+
+import dev.langchain4j.community.model.minimax.client.MiniMaxHttpException;
+import java.io.IOException;
+
+public final class ExceptionUtil {
+    public static RuntimeException toException(retrofit2.Response<?> response) throws IOException {
+        return new MiniMaxHttpException(response.code(), response.errorBody().string());
+    }
+
+    public static RuntimeException toException(okhttp3.Response response) throws IOException {
+        return new MiniMaxHttpException(response.code(), response.body().string());
+    }
+}

--- a/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/utils/JsonUtil.java
+++ b/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/client/utils/JsonUtil.java
@@ -1,0 +1,38 @@
+package dev.langchain4j.community.model.minimax.client.utils;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+public final class JsonUtil {
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
+
+    public static String toJson(Object object) {
+        try {
+            return OBJECT_MAPPER.writeValueAsString(object);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static <T> T toObject(String jsonStr, Class<T> clazz) {
+        try {
+            return OBJECT_MAPPER.readValue(jsonStr, clazz);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static <T> T toObject(String jsonStr, TypeReference<T> typeReference) {
+        try {
+            return OBJECT_MAPPER.readValue(jsonStr, typeReference);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static ObjectMapper getObjectMapper() {
+        return OBJECT_MAPPER;
+    }
+}

--- a/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/spi/MiniMaxChatModelBuilderFactory.java
+++ b/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/spi/MiniMaxChatModelBuilderFactory.java
@@ -1,0 +1,6 @@
+package dev.langchain4j.community.model.minimax.spi;
+
+import dev.langchain4j.community.model.minimax.MiniMaxChatModel;
+import java.util.function.Supplier;
+
+public interface MiniMaxChatModelBuilderFactory extends Supplier<MiniMaxChatModel.MiniMaxChatModelBuilder> {}

--- a/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/spi/MiniMaxStreamingChatModelBuilderFactory.java
+++ b/models/langchain4j-community-minimax/src/main/java/dev/langchain4j/community/model/minimax/spi/MiniMaxStreamingChatModelBuilderFactory.java
@@ -1,0 +1,7 @@
+package dev.langchain4j.community.model.minimax.spi;
+
+import dev.langchain4j.community.model.minimax.MiniMaxStreamingChatModel;
+import java.util.function.Supplier;
+
+public interface MiniMaxStreamingChatModelBuilderFactory
+        extends Supplier<MiniMaxStreamingChatModel.MiniMaxStreamingChatModelBuilder> {}

--- a/models/langchain4j-community-minimax/src/test/java/dev/langchain4j/community/model/minimax/MiniMaxChatModelIT.java
+++ b/models/langchain4j-community-minimax/src/test/java/dev/langchain4j/community/model/minimax/MiniMaxChatModelIT.java
@@ -1,0 +1,205 @@
+package dev.langchain4j.community.model.minimax;
+
+import static dev.langchain4j.data.message.UserMessage.userMessage;
+import static dev.langchain4j.model.output.FinishReason.STOP;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+@EnabledIfEnvironmentVariable(named = "MINIMAX_API_KEY", matches = ".+")
+class MiniMaxChatModelIT {
+
+    private static final String API_KEY = System.getenv("MINIMAX_API_KEY");
+
+    ChatModel chatModel = MiniMaxChatModel.builder()
+            .apiKey(API_KEY)
+            .modelName(MiniMaxChatModelName.MINIMAX_M2_5)
+            .logRequests(true)
+            .logResponses(true)
+            .timeout(Duration.ofSeconds(60))
+            .maxRetries(1)
+            .build();
+
+    @Test
+    void should_chat_and_return_response() {
+        // given
+        UserMessage userMessage = userMessage("What is 1+1? Answer with just the number.");
+
+        // when
+        ChatResponse response = chatModel.chat(userMessage);
+
+        // then
+        assertThat(response.aiMessage().text()).contains("2");
+        assertThat(response.metadata().tokenUsage().inputTokenCount()).isPositive();
+        assertThat(response.metadata().tokenUsage().outputTokenCount()).isPositive();
+        assertThat(response.metadata().finishReason()).isEqualTo(STOP);
+    }
+
+    @Test
+    void should_chat_with_system_message() {
+        // given
+        SystemMessage systemMessage = SystemMessage.from("You are a helpful math tutor. Be concise.");
+        UserMessage userMessage = userMessage("What is the square root of 144?");
+
+        // when
+        ChatResponse response = chatModel.chat(systemMessage, userMessage);
+
+        // then
+        assertThat(response.aiMessage().text()).contains("12");
+    }
+
+    @Test
+    void should_respect_model_name_parameter() {
+        // given
+        ChatModel model = MiniMaxChatModel.builder()
+                .apiKey(API_KEY)
+                .modelName(MiniMaxChatModelName.MINIMAX_M2_5_HIGHSPEED)
+                .timeout(Duration.ofSeconds(60))
+                .maxRetries(1)
+                .build();
+
+        // when
+        ChatResponse response = model.chat(userMessage("Say hello in one word."));
+
+        // then
+        assertThat(response.aiMessage().text()).isNotBlank();
+    }
+
+    @Test
+    void should_use_temperature_parameter() {
+        // given
+        ChatModel model = MiniMaxChatModel.builder()
+                .apiKey(API_KEY)
+                .modelName(MiniMaxChatModelName.MINIMAX_M2_5)
+                .temperature(0.1)
+                .timeout(Duration.ofSeconds(60))
+                .maxRetries(1)
+                .build();
+
+        // when
+        ChatResponse response = model.chat(userMessage("What is 2+2?"));
+
+        // then
+        assertThat(response.aiMessage().text()).contains("4");
+    }
+
+    @Test
+    void should_use_max_tokens_parameter() {
+        // given
+        ChatModel model = MiniMaxChatModel.builder()
+                .apiKey(API_KEY)
+                .modelName(MiniMaxChatModelName.MINIMAX_M2_5)
+                .maxTokens(10)
+                .timeout(Duration.ofSeconds(60))
+                .maxRetries(1)
+                .build();
+
+        // when
+        ChatResponse response = model.chat(userMessage("Tell me a story."));
+
+        // then
+        assertThat(response.aiMessage().text()).isNotBlank();
+        // With max 10 tokens, the response should be very short
+    }
+
+    @Test
+    void should_execute_tool_then_answer() {
+        // given
+        ToolSpecification weatherTool = ToolSpecification.builder()
+                .name("get_weather")
+                .description("Returns the current weather for a given city")
+                .parameters(JsonObjectSchema.builder()
+                        .addStringProperty("city", "The city name")
+                        .required("city")
+                        .build())
+                .build();
+
+        List<ChatMessage> messages = List.of(
+                userMessage("What's the weather in Beijing?"));
+
+        ChatRequest request = ChatRequest.builder()
+                .messages(messages)
+                .parameters(ChatRequestParameters.builder()
+                        .modelName(MiniMaxChatModelName.MINIMAX_M2_5.toString())
+                        .toolSpecifications(List.of(weatherTool))
+                        .build())
+                .build();
+
+        // when
+        ChatResponse response = chatModel.chat(request);
+
+        // then
+        AiMessage aiMessage = response.aiMessage();
+        assertThat(aiMessage.hasToolExecutionRequests()).isTrue();
+        List<ToolExecutionRequest> toolRequests = aiMessage.toolExecutionRequests();
+        assertThat(toolRequests).hasSize(1);
+        assertThat(toolRequests.get(0).name()).isEqualTo("get_weather");
+
+        // Simulate tool execution and continue conversation
+        List<ChatMessage> followUp = List.of(
+                userMessage("What's the weather in Beijing?"),
+                aiMessage,
+                ToolExecutionResultMessage.from(toolRequests.get(0), "{\"temperature\": \"25°C\", \"condition\": \"sunny\"}"));
+
+        ChatRequest followUpRequest = ChatRequest.builder()
+                .messages(followUp)
+                .parameters(ChatRequestParameters.builder()
+                        .modelName(MiniMaxChatModelName.MINIMAX_M2_5.toString())
+                        .build())
+                .build();
+
+        ChatResponse followUpResponse = chatModel.chat(followUpRequest);
+
+        assertThat(followUpResponse.aiMessage().text()).isNotBlank();
+    }
+
+    @Test
+    void should_use_default_base_url() {
+        // given - no baseUrl specified (should default to https://api.minimax.io/v1)
+        ChatModel model = MiniMaxChatModel.builder()
+                .apiKey(API_KEY)
+                .modelName(MiniMaxChatModelName.MINIMAX_M2_5)
+                .timeout(Duration.ofSeconds(60))
+                .maxRetries(1)
+                .build();
+
+        // when
+        ChatResponse response = model.chat(userMessage("Hello"));
+
+        // then
+        assertThat(response.aiMessage().text()).isNotBlank();
+    }
+
+    @Test
+    void should_support_custom_base_url() {
+        // given
+        ChatModel model = MiniMaxChatModel.builder()
+                .baseUrl("https://api.minimax.io/")
+                .apiKey(API_KEY)
+                .modelName(MiniMaxChatModelName.MINIMAX_M2_5)
+                .timeout(Duration.ofSeconds(60))
+                .maxRetries(1)
+                .build();
+
+        // when
+        ChatResponse response = model.chat(userMessage("Hello"));
+
+        // then
+        assertThat(response.aiMessage().text()).isNotBlank();
+    }
+}

--- a/models/langchain4j-community-minimax/src/test/java/dev/langchain4j/community/model/minimax/MiniMaxChatModelTest.java
+++ b/models/langchain4j-community-minimax/src/test/java/dev/langchain4j/community/model/minimax/MiniMaxChatModelTest.java
@@ -1,0 +1,89 @@
+package dev.langchain4j.community.model.minimax;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class MiniMaxChatModelTest {
+
+    @Test
+    void should_create_model_with_builder() {
+        // given/when
+        MiniMaxChatModel model = MiniMaxChatModel.builder()
+                .apiKey("test-key")
+                .modelName("MiniMax-M2.5")
+                .temperature(0.7)
+                .topP(0.9)
+                .maxTokens(1024)
+                .build();
+
+        // then
+        assertThat(model).isNotNull();
+        assertThat(model.defaultRequestParameters().modelName()).isEqualTo("MiniMax-M2.5");
+        assertThat(model.defaultRequestParameters().temperature()).isEqualTo(0.7);
+        assertThat(model.defaultRequestParameters().topP()).isEqualTo(0.9);
+        assertThat(model.defaultRequestParameters().maxOutputTokens()).isEqualTo(1024);
+    }
+
+    @Test
+    void should_create_model_with_enum_model_name() {
+        // given/when
+        MiniMaxChatModel model = MiniMaxChatModel.builder()
+                .apiKey("test-key")
+                .modelName(MiniMaxChatModelName.MINIMAX_M2_7)
+                .build();
+
+        // then
+        assertThat(model.defaultRequestParameters().modelName()).isEqualTo("MiniMax-M2.7");
+    }
+
+    @Test
+    void should_fail_without_model_name() {
+        // given/when/then
+        assertThatThrownBy(() -> MiniMaxChatModel.builder()
+                .apiKey("test-key")
+                .build())
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void should_use_default_base_url() {
+        // should not throw - default baseUrl is applied
+        MiniMaxChatModel model = MiniMaxChatModel.builder()
+                .apiKey("test-key")
+                .modelName(MiniMaxChatModelName.MINIMAX_M2_5)
+                .build();
+
+        assertThat(model).isNotNull();
+    }
+
+    @Test
+    void should_accept_custom_base_url() {
+        // should not throw
+        MiniMaxChatModel model = MiniMaxChatModel.builder()
+                .baseUrl("https://custom-api.example.com/v1")
+                .apiKey("test-key")
+                .modelName(MiniMaxChatModelName.MINIMAX_M2_5)
+                .build();
+
+        assertThat(model).isNotNull();
+    }
+
+    @Test
+    void should_have_correct_model_name_enum_values() {
+        assertThat(MiniMaxChatModelName.MINIMAX_M2_7.toString()).isEqualTo("MiniMax-M2.7");
+        assertThat(MiniMaxChatModelName.MINIMAX_M2_5.toString()).isEqualTo("MiniMax-M2.5");
+        assertThat(MiniMaxChatModelName.MINIMAX_M2_5_HIGHSPEED.toString()).isEqualTo("MiniMax-M2.5-highspeed");
+    }
+
+    @Test
+    void should_return_empty_listeners_by_default() {
+        MiniMaxChatModel model = MiniMaxChatModel.builder()
+                .apiKey("test-key")
+                .modelName(MiniMaxChatModelName.MINIMAX_M2_5)
+                .build();
+
+        assertThat(model.listeners()).isEmpty();
+    }
+}

--- a/models/langchain4j-community-minimax/src/test/java/dev/langchain4j/community/model/minimax/MiniMaxStreamingChatModelIT.java
+++ b/models/langchain4j-community-minimax/src/test/java/dev/langchain4j/community/model/minimax/MiniMaxStreamingChatModelIT.java
@@ -1,0 +1,156 @@
+package dev.langchain4j.community.model.minimax;
+
+import static dev.langchain4j.data.message.UserMessage.userMessage;
+import static dev.langchain4j.model.output.FinishReason.STOP;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import java.util.List;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+@EnabledIfEnvironmentVariable(named = "MINIMAX_API_KEY", matches = ".+")
+class MiniMaxStreamingChatModelIT {
+
+    private static final String API_KEY = System.getenv("MINIMAX_API_KEY");
+
+    MiniMaxStreamingChatModel streamingModel = MiniMaxStreamingChatModel.builder()
+            .apiKey(API_KEY)
+            .modelName(MiniMaxChatModelName.MINIMAX_M2_5)
+            .logRequests(true)
+            .logResponses(true)
+            .timeout(Duration.ofSeconds(60))
+            .build();
+
+    @Test
+    void should_stream_chat_response() throws Exception {
+        // given
+        UserMessage userMessage = userMessage("What is 1+1? Answer with just the number.");
+        CompletableFuture<ChatResponse> future = new CompletableFuture<>();
+        StringBuilder contentBuilder = new StringBuilder();
+
+        // when
+        streamingModel.chat(List.of(userMessage), new StreamingChatResponseHandler() {
+            @Override
+            public void onPartialResponse(String partialResponse) {
+                contentBuilder.append(partialResponse);
+            }
+
+            @Override
+            public void onCompleteResponse(ChatResponse completeResponse) {
+                future.complete(completeResponse);
+            }
+
+            @Override
+            public void onError(Throwable error) {
+                future.completeExceptionally(error);
+            }
+        });
+
+        ChatResponse response = future.get(60, TimeUnit.SECONDS);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.aiMessage().text()).contains("2");
+        assertThat(contentBuilder.toString()).contains("2");
+        assertThat(response.metadata().finishReason()).isEqualTo(STOP);
+    }
+
+    @Test
+    void should_stream_with_system_message() throws Exception {
+        // given
+        CompletableFuture<ChatResponse> future = new CompletableFuture<>();
+
+        // when
+        streamingModel.chat("What is the capital of France? Answer in one word.", new StreamingChatResponseHandler() {
+            @Override
+            public void onPartialResponse(String partialResponse) {
+                // streaming content
+            }
+
+            @Override
+            public void onCompleteResponse(ChatResponse completeResponse) {
+                future.complete(completeResponse);
+            }
+
+            @Override
+            public void onError(Throwable error) {
+                future.completeExceptionally(error);
+            }
+        });
+
+        ChatResponse response = future.get(60, TimeUnit.SECONDS);
+
+        // then
+        assertThat(response.aiMessage().text()).containsIgnoringCase("Paris");
+    }
+
+    @Test
+    void should_stream_with_highspeed_model() throws Exception {
+        // given
+        MiniMaxStreamingChatModel highspeedModel = MiniMaxStreamingChatModel.builder()
+                .apiKey(API_KEY)
+                .modelName(MiniMaxChatModelName.MINIMAX_M2_5_HIGHSPEED)
+                .timeout(Duration.ofSeconds(60))
+                .build();
+
+        CompletableFuture<ChatResponse> future = new CompletableFuture<>();
+
+        // when
+        highspeedModel.chat("Say hello", new StreamingChatResponseHandler() {
+            @Override
+            public void onPartialResponse(String partialResponse) {
+            }
+
+            @Override
+            public void onCompleteResponse(ChatResponse completeResponse) {
+                future.complete(completeResponse);
+            }
+
+            @Override
+            public void onError(Throwable error) {
+                future.completeExceptionally(error);
+            }
+        });
+
+        ChatResponse response = future.get(60, TimeUnit.SECONDS);
+
+        // then
+        assertThat(response.aiMessage().text()).isNotBlank();
+    }
+
+    @Test
+    void should_stream_with_token_usage() throws Exception {
+        // given
+        CompletableFuture<ChatResponse> future = new CompletableFuture<>();
+
+        // when
+        streamingModel.chat("Hello!", new StreamingChatResponseHandler() {
+            @Override
+            public void onPartialResponse(String partialResponse) {
+            }
+
+            @Override
+            public void onCompleteResponse(ChatResponse completeResponse) {
+                future.complete(completeResponse);
+            }
+
+            @Override
+            public void onError(Throwable error) {
+                future.completeExceptionally(error);
+            }
+        });
+
+        ChatResponse response = future.get(60, TimeUnit.SECONDS);
+
+        // then
+        assertThat(response.metadata().tokenUsage()).isNotNull();
+        assertThat(response.metadata().tokenUsage().inputTokenCount()).isPositive();
+        assertThat(response.metadata().tokenUsage().outputTokenCount()).isPositive();
+    }
+}

--- a/models/langchain4j-community-minimax/src/test/java/dev/langchain4j/community/model/minimax/MiniMaxStreamingChatModelTest.java
+++ b/models/langchain4j-community-minimax/src/test/java/dev/langchain4j/community/model/minimax/MiniMaxStreamingChatModelTest.java
@@ -1,0 +1,67 @@
+package dev.langchain4j.community.model.minimax;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class MiniMaxStreamingChatModelTest {
+
+    @Test
+    void should_create_streaming_model_with_builder() {
+        // given/when
+        MiniMaxStreamingChatModel model = MiniMaxStreamingChatModel.builder()
+                .apiKey("test-key")
+                .modelName("MiniMax-M2.5")
+                .temperature(0.7)
+                .topP(0.9)
+                .maxTokens(1024)
+                .build();
+
+        // then
+        assertThat(model).isNotNull();
+        assertThat(model.defaultRequestParameters().modelName()).isEqualTo("MiniMax-M2.5");
+        assertThat(model.defaultRequestParameters().temperature()).isEqualTo(0.7);
+    }
+
+    @Test
+    void should_create_streaming_model_with_enum_model_name() {
+        // given/when
+        MiniMaxStreamingChatModel model = MiniMaxStreamingChatModel.builder()
+                .apiKey("test-key")
+                .modelName(MiniMaxChatModelName.MINIMAX_M2_5_HIGHSPEED)
+                .build();
+
+        // then
+        assertThat(model.defaultRequestParameters().modelName()).isEqualTo("MiniMax-M2.5-highspeed");
+    }
+
+    @Test
+    void should_fail_without_model_name() {
+        // given/when/then
+        assertThatThrownBy(() -> MiniMaxStreamingChatModel.builder()
+                .apiKey("test-key")
+                .build())
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void should_use_default_base_url() {
+        MiniMaxStreamingChatModel model = MiniMaxStreamingChatModel.builder()
+                .apiKey("test-key")
+                .modelName(MiniMaxChatModelName.MINIMAX_M2_5)
+                .build();
+
+        assertThat(model).isNotNull();
+    }
+
+    @Test
+    void should_return_empty_listeners_by_default() {
+        MiniMaxStreamingChatModel model = MiniMaxStreamingChatModel.builder()
+                .apiKey("test-key")
+                .modelName(MiniMaxChatModelName.MINIMAX_M2_5)
+                .build();
+
+        assertThat(model.listeners()).isEmpty();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
         <module>models/langchain4j-community-qianfan</module>
         <module>models/langchain4j-community-xinference</module>
         <module>models/langchain4j-community-zhipu-ai</module>
+        <module>models/langchain4j-community-minimax</module>
         <module>models/langchain4j-community-model-router</module>
 
         <!-- Integration of embedding store -->


### PR DESCRIPTION
## Summary

Add `langchain4j-community-minimax` module — a new model integration for [MiniMax](https://platform.minimaxi.com/), a leading AI company providing powerful large language models via an OpenAI-compatible API.

### Key features:
- **MiniMaxChatModel** — synchronous chat completions
- **MiniMaxStreamingChatModel** — streaming chat completions with SSE
- **Tool/function calling** support
- **MiniMaxChatModelName** enum with MiniMax-M2.7, MiniMax-M2.5, MiniMax-M2.5-highspeed models
- Default base URL: `https://api.minimax.io/`
- Configurable temperature, topP, maxTokens, stop sequences, presencePenalty, frequencyPenalty
- Request/response logging, custom headers, proxy support
- SPI-based builder factory pattern (following existing community module conventions)
- Registered in BOM and root pom.xml

### Implementation approach:
Uses Retrofit + OkHttp (same pattern as `langchain4j-community-xinference`) with a self-contained OpenAI-compatible client. No additional external dependencies beyond what the project already uses.

### Files:
- 48 source files in `models/langchain4j-community-minimax/`
- 4 test files (2 unit test classes, 2 integration test classes)
- Module registered in `pom.xml` and `langchain4j-community-bom/pom.xml`

### Test plan:
- [x] 12 unit tests (builder, model name enum, default params)
- [x] 12 integration tests with real MiniMax API (chat, streaming, system messages, tool calling, token usage, multiple models)
- [x] Maven compile succeeds
- [x] All tests pass

### MiniMax API reference:
- API docs: https://platform.minimaxi.com/document/Models
- Base URL: https://api.minimax.io/v1 (OpenAI-compatible)
- Models: MiniMax-M2.7, MiniMax-M2.5, MiniMax-M2.5-highspeed (204K context)
