### PR TITLE
Configurable executor for OCI GenAI

### DIFF
--- a/models/langchain4j-community-oci-genai/src/main/java/dev/langchain4j/community/model/oracle/oci/genai/BaseChatModel.java
+++ b/models/langchain4j-community-oci-genai/src/main/java/dev/langchain4j/community/model/oracle/oci/genai/BaseChatModel.java
@@ -8,6 +8,7 @@ import com.oracle.bmc.generativeaiinference.model.BaseChatRequest;
 import com.oracle.bmc.generativeaiinference.model.ChatDetails;
 import com.oracle.bmc.generativeaiinference.model.ServingMode;
 import com.oracle.bmc.http.client.Serializer;
+import dev.langchain4j.internal.DefaultExecutorProvider;
 import dev.langchain4j.model.chat.listener.ChatModelListener;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
@@ -21,7 +22,6 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
@@ -50,7 +50,7 @@ abstract class BaseChatModel<T extends BaseChatModel<T>> implements AutoCloseabl
     private final Condition noActiveOperations = lifecycleLock.newCondition();
     private final Lock syncClientLock = new ReentrantLock();
     private final Lock asyncClientLock = new ReentrantLock();
-    private final ExecutorService streamingExecutor = Executors.newCachedThreadPool();
+    private final ExecutorService streamingExecutor;
     private final AtomicBoolean resourcesClosed = new AtomicBoolean();
     private int activeOperations;
     private volatile boolean closed;
@@ -68,6 +68,9 @@ abstract class BaseChatModel<T extends BaseChatModel<T>> implements AutoCloseabl
         this.asyncClient = builder.genAiAsyncClient;
         this.hasSyncClientConfiguration = builder.hasGenAiClient();
         this.hasAsyncClientConfiguration = builder.hasGenAiAsyncClient();
+        this.streamingExecutor = builder.executorService != null
+                ? builder.executorService
+                : DefaultExecutorProvider.getDefaultExecutorService();
     }
 
     @Override
@@ -267,7 +270,6 @@ abstract class BaseChatModel<T extends BaseChatModel<T>> implements AutoCloseabl
         Throwable closeFailure = null;
         closeFailure = closeClient(syncClientLock, () -> client, () -> client = null, closeFailure);
         closeFailure = closeClient(asyncClientLock, () -> asyncClient, () -> asyncClient = null, closeFailure);
-        closeFailure = captureFailure(closeFailure, streamingExecutor::shutdown);
 
         throwUnchecked(closeFailure);
     }
@@ -431,6 +433,7 @@ abstract class BaseChatModel<T extends BaseChatModel<T>> implements AutoCloseabl
         private List<String> stop;
         private GenerativeAiInferenceClient genAiClient;
         private GenerativeAiInferenceAsyncClient genAiAsyncClient;
+        private ExecutorService executorService;
         private List<ChatModelListener> listeners = List.of();
         private ServingMode.ServingType servingType = ServingMode.ServingType.OnDemand;
         private ChatRequestParameters defaultRequestParameters =
@@ -518,6 +521,11 @@ abstract class BaseChatModel<T extends BaseChatModel<T>> implements AutoCloseabl
          */
         public B genAiAsyncClient(GenerativeAiInferenceAsyncClient genAiAsyncClient) {
             this.genAiAsyncClient = genAiAsyncClient;
+            return self();
+        }
+
+        B executorService(ExecutorService executorService) {
+            this.executorService = executorService;
             return self();
         }
 

--- a/models/langchain4j-community-oci-genai/src/main/java/dev/langchain4j/community/model/oracle/oci/genai/OciGenAiCohereStreamingChatModel.java
+++ b/models/langchain4j-community-oci-genai/src/main/java/dev/langchain4j/community/model/oracle/oci/genai/OciGenAiCohereStreamingChatModel.java
@@ -19,6 +19,7 @@ import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -218,6 +219,19 @@ public class OciGenAiCohereStreamingChatModel extends BaseCohereChatModel<OciGen
 
         public Builder genAiAsyncClient(GenerativeAiInferenceAsyncClient genAiAsyncClient) {
             return super.genAiAsyncClient(genAiAsyncClient);
+        }
+
+        /**
+         * Sets the {@link ExecutorService} to use for asynchronous request startup and stream processing.
+         * If not provided, uses {@link dev.langchain4j.internal.DefaultExecutorProvider#getDefaultExecutorService()}.
+         * <p>
+         * If an executor is provided, it will not be shut down when the model is closed.
+         *
+         * @param executorService the executor service to use
+         * @return {@code this}
+         */
+        public Builder executorService(ExecutorService executorService) {
+            return super.executorService(executorService);
         }
 
         public OciGenAiCohereStreamingChatModel build() {

--- a/models/langchain4j-community-oci-genai/src/main/java/dev/langchain4j/community/model/oracle/oci/genai/OciGenAiStreamingChatModel.java
+++ b/models/langchain4j-community-oci-genai/src/main/java/dev/langchain4j/community/model/oracle/oci/genai/OciGenAiStreamingChatModel.java
@@ -12,6 +12,7 @@ import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -142,6 +143,19 @@ public class OciGenAiStreamingChatModel extends BaseGenericChatModel<OciGenAiStr
 
         public Builder genAiAsyncClient(GenerativeAiInferenceAsyncClient genAiAsyncClient) {
             return super.genAiAsyncClient(genAiAsyncClient);
+        }
+
+        /**
+         * Sets the {@link ExecutorService} to use for asynchronous request startup and stream processing.
+         * If not provided, uses {@link dev.langchain4j.internal.DefaultExecutorProvider#getDefaultExecutorService()}.
+         * <p>
+         * If an executor is provided, it will not be shut down when the model is closed.
+         *
+         * @param executorService the executor service to use
+         * @return {@code this}
+         */
+        public Builder executorService(ExecutorService executorService) {
+            return super.executorService(executorService);
         }
 
         public OciGenAiStreamingChatModel build() {

--- a/models/langchain4j-community-oci-genai/src/test/java/dev/langchain4j/community/model/oracle/oci/genai/BaseChatModelTest.java
+++ b/models/langchain4j-community-oci-genai/src/test/java/dev/langchain4j/community/model/oracle/oci/genai/BaseChatModelTest.java
@@ -14,6 +14,7 @@ import com.oracle.bmc.auth.BasicAuthenticationDetailsProvider;
 import com.oracle.bmc.generativeaiinference.GenerativeAiInferenceAsyncClient;
 import com.oracle.bmc.generativeaiinference.GenerativeAiInferenceClient;
 import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.internal.DefaultExecutorProvider;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
@@ -24,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
@@ -219,11 +221,35 @@ class BaseChatModelTest {
         verify(asyncClient).close();
     }
 
+    @Test
+    void streamingModelShouldUseDefaultExecutorServiceWhenNotConfigured() {
+        var syncClient = mock(GenerativeAiInferenceClient.class);
+
+        try (var model = OciGenAiStreamingChatModel.builder()
+                .modelName("test-model")
+                .compartmentId("test-compartment")
+                .genAiClient(syncClient)
+                .build()) {
+
+            assertSame(DefaultExecutorProvider.getDefaultExecutorService(), streamingExecutor(model));
+        }
+    }
+
     private static int activeOperations(BaseChatModel<?> model) {
         try {
             var field = BaseChatModel.class.getDeclaredField("activeOperations");
             field.setAccessible(true);
             return field.getInt(model);
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    private static ExecutorService streamingExecutor(BaseChatModel<?> model) {
+        try {
+            var field = BaseChatModel.class.getDeclaredField("streamingExecutor");
+            field.setAccessible(true);
+            return (ExecutorService) field.get(model);
         } catch (ReflectiveOperationException e) {
             throw new AssertionError(e);
         }

--- a/models/langchain4j-community-oci-genai/src/test/java/dev/langchain4j/community/model/oracle/oci/genai/OciGenAiCohereStreamingChatModelTest.java
+++ b/models/langchain4j-community-oci-genai/src/test/java/dev/langchain4j/community/model/oracle/oci/genai/OciGenAiCohereStreamingChatModelTest.java
@@ -10,23 +10,23 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.oracle.bmc.generativeaiinference.GenerativeAiInferenceAsyncClient;
 import com.oracle.bmc.generativeaiinference.GenerativeAiInferenceClient;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.CompleteToolCall;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
-import dev.langchain4j.service.AiServices;
-import dev.langchain4j.service.TokenStream;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -35,17 +35,18 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Sinks;
 
-class OciGenAiStreamingChatModelTest {
+class OciGenAiCohereStreamingChatModelTest {
 
     private static final long WAIT_TIMEOUT_SECONDS = 10;
 
     private static final String STREAMED_DATA = """
-            data: {"index":0,"message":{"role":"ASSISTANT","content":[{"type":"TEXT","text":"HELLO"}]}}
-            data: {"index":0,"message":{"role":"ASSISTANT","content":[{"type":"TEXT","text":" WORLD"}]}}
-            data: {"finishReason":"stop"}
+            data: {"apiFormat":"COHERE","text":"HELLO"}
+            data: {"apiFormat":"COHERE","text":" WORLD"}
+            """;
+
+    private static final String TOOL_CALL_DATA = """
+            data: {"apiFormat":"COHERE","toolCalls":[{"name":"getWeather","parameters":{"city":"Munich"}}]}
             """;
 
     @Test
@@ -61,7 +62,7 @@ class OciGenAiStreamingChatModelTest {
                         requestScheduled.countDown();
                         try {
                             assertTrue(releaseResponse.await(WAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS));
-                            future.complete(ociResponse());
+                            future.complete(ociResponse(STREAMED_DATA));
                         } catch (Throwable t) {
                             future.completeExceptionally(t);
                         }
@@ -74,7 +75,7 @@ class OciGenAiStreamingChatModelTest {
                 .chat(any(com.oracle.bmc.generativeaiinference.requests.ChatRequest.class), isNull());
 
         var handler = new TestStreamingChatResponseHandler();
-        try (var model = OciGenAiStreamingChatModel.builder()
+        try (var model = OciGenAiCohereStreamingChatModel.builder()
                 .modelName("test-model")
                 .compartmentId("test-compartment")
                 .genAiClient(syncClient)
@@ -91,6 +92,7 @@ class OciGenAiStreamingChatModelTest {
             assertTrue(handler.completed.await(WAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS));
             assertNull(handler.error.get());
             assertThat(handler.partialResponses, contains("HELLO", " WORLD"));
+            assertThat(handler.completeResponses, contains("HELLO WORLD"));
 
             verify(asyncClient).chat(any(com.oracle.bmc.generativeaiinference.requests.ChatRequest.class), isNull());
             verify(syncClient, never()).chat(any(com.oracle.bmc.generativeaiinference.requests.ChatRequest.class));
@@ -106,13 +108,13 @@ class OciGenAiStreamingChatModelTest {
         doAnswer(invocation -> {
                     requestStarted.countDown();
                     assertTrue(releaseResponse.await(WAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS));
-                    return ociResponse();
+                    return ociResponse(STREAMED_DATA);
                 })
                 .when(syncClient)
                 .chat(any(com.oracle.bmc.generativeaiinference.requests.ChatRequest.class));
 
         var handler = new TestStreamingChatResponseHandler();
-        try (var model = OciGenAiStreamingChatModel.builder()
+        try (var model = OciGenAiCohereStreamingChatModel.builder()
                 .modelName("test-model")
                 .compartmentId("test-compartment")
                 .genAiClient(syncClient)
@@ -128,7 +130,7 @@ class OciGenAiStreamingChatModelTest {
             assertTrue(handler.completed.await(WAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS));
             assertNull(handler.error.get());
             assertThat(handler.partialResponses, contains("HELLO", " WORLD"));
-
+            assertThat(handler.completeResponses, contains("HELLO WORLD"));
             verify(syncClient).chat(any(com.oracle.bmc.generativeaiinference.requests.ChatRequest.class));
         }
     }
@@ -136,7 +138,7 @@ class OciGenAiStreamingChatModelTest {
     @Test
     void doChatUsesConfiguredExecutorServiceForAsyncStreaming() throws Exception {
         var asyncClient = mock(GenerativeAiInferenceAsyncClient.class);
-        var executorService = new TrackingExecutorService("oci-generic-async-executor");
+        var executorService = new TrackingExecutorService("oci-cohere-async-executor");
         var requestThread = new AtomicReference<String>();
         var callbackThread = new AtomicReference<String>();
         var completed = new CountDownLatch(1);
@@ -144,13 +146,13 @@ class OciGenAiStreamingChatModelTest {
 
         doAnswer(invocation -> {
                     requestThread.set(Thread.currentThread().getName());
-                    return CompletableFuture.completedFuture(ociResponse());
+                    return CompletableFuture.completedFuture(ociResponse(STREAMED_DATA));
                 })
                 .when(asyncClient)
                 .chat(any(com.oracle.bmc.generativeaiinference.requests.ChatRequest.class), isNull());
 
         try {
-            try (var model = OciGenAiStreamingChatModel.builder()
+            try (var model = OciGenAiCohereStreamingChatModel.builder()
                     .modelName("test-model")
                     .compartmentId("test-compartment")
                     .genAiAsyncClient(asyncClient)
@@ -180,63 +182,8 @@ class OciGenAiStreamingChatModelTest {
                 assertNull(error.get());
             }
 
-            assertTrue(requestThread.get().startsWith("oci-generic-async-executor-"));
-            assertTrue(callbackThread.get().startsWith("oci-generic-async-executor-"));
-            assertFalse(executorService.shutdownWasRequested());
-        } finally {
-            executorService.shutdownDelegateNow();
-        }
-    }
-
-    @Test
-    void doChatUsesConfiguredExecutorServiceForSyncFallback() throws Exception {
-        var syncClient = mock(GenerativeAiInferenceClient.class);
-        var executorService = new TrackingExecutorService("oci-generic-sync-executor");
-        var requestThread = new AtomicReference<String>();
-        var callbackThread = new AtomicReference<String>();
-        var completed = new CountDownLatch(1);
-        var error = new AtomicReference<Throwable>();
-
-        doAnswer(invocation -> {
-                    requestThread.set(Thread.currentThread().getName());
-                    return ociResponse();
-                })
-                .when(syncClient)
-                .chat(any(com.oracle.bmc.generativeaiinference.requests.ChatRequest.class));
-
-        try {
-            try (var model = OciGenAiStreamingChatModel.builder()
-                    .modelName("test-model")
-                    .compartmentId("test-compartment")
-                    .genAiClient(syncClient)
-                    .executorService(executorService)
-                    .build()) {
-
-                model.doChat(chatRequest(), new StreamingChatResponseHandler() {
-                    @Override
-                    public void onPartialResponse(String partialResponse) {
-                        callbackThread.compareAndSet(
-                                null, Thread.currentThread().getName());
-                    }
-
-                    @Override
-                    public void onCompleteResponse(ChatResponse completeResponse) {
-                        completed.countDown();
-                    }
-
-                    @Override
-                    public void onError(Throwable throwable) {
-                        error.set(throwable);
-                        completed.countDown();
-                    }
-                });
-
-                assertTrue(completed.await(WAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS));
-                assertNull(error.get());
-            }
-
-            assertTrue(requestThread.get().startsWith("oci-generic-sync-executor-"));
-            assertTrue(callbackThread.get().startsWith("oci-generic-sync-executor-"));
+            assertTrue(requestThread.get().startsWith("oci-cohere-async-executor-"));
+            assertTrue(callbackThread.get().startsWith("oci-cohere-async-executor-"));
             assertFalse(executorService.shutdownWasRequested());
         } finally {
             executorService.shutdownDelegateNow();
@@ -255,7 +202,7 @@ class OciGenAiStreamingChatModelTest {
                 .chat(any(com.oracle.bmc.generativeaiinference.requests.ChatRequest.class), isNull());
 
         var handler = new TestStreamingChatResponseHandler();
-        try (var model = OciGenAiStreamingChatModel.builder()
+        try (var model = OciGenAiCohereStreamingChatModel.builder()
                 .modelName("test-model")
                 .compartmentId("test-compartment")
                 .genAiAsyncClient(asyncClient)
@@ -269,108 +216,33 @@ class OciGenAiStreamingChatModelTest {
     }
 
     @Test
-    void directHandlerReproducerStreamsBeforeCompletion() throws Exception {
-        var streamScript = new BlockingEventStream();
+    void doChatShouldEmitCompleteToolCallForToolResponse() throws Exception {
+        var handler = new TestStreamingChatResponseHandler();
 
-        try (var model = modelWithAsyncResponse(streamScript.response())) {
-            var handler = new TestStreamingChatResponseHandler();
-
-            CompletableFuture<Void> invokeFuture = CompletableFuture.runAsync(() -> model.chat(chatRequest(), handler));
-            invokeFuture.get(WAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-
-            assertTrue(handler.firstPartial.await(WAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS));
-            assertThat(handler.partialResponses, contains("HELLO"));
-            assertFalse(handler.completed.await(200, TimeUnit.MILLISECONDS));
-
-            streamScript.allowCompletion();
+        try (var model = modelWithAsyncResponse(ociResponse(TOOL_CALL_DATA))) {
+            model.doChat(chatRequest(), handler);
 
             assertTrue(handler.completed.await(WAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS));
-            streamScript.assertCompleted();
             assertNull(handler.error.get());
-            assertThat(handler.partialResponses, contains("HELLO", " WORLD"));
-        }
-    }
-
-    @Test
-    void tokenStreamReproducerStreamsIntoSinkBeforeCompletion() throws Exception {
-        var streamScript = new BlockingEventStream();
-
-        try (var model = modelWithAsyncResponse(streamScript.response())) {
-            TokenStreamAssistant assistant = AiServices.builder(TokenStreamAssistant.class)
-                    .streamingChatModel(model)
-                    .build();
-
-            Sinks.Many<String> sink = Sinks.many().unicast().onBackpressureBuffer();
-            List<String> partialResponses = new CopyOnWriteArrayList<>();
-            CountDownLatch firstPartial = new CountDownLatch(1);
-            CountDownLatch completed = new CountDownLatch(1);
-            AtomicReference<Throwable> error = new AtomicReference<>();
-
-            sink.asFlux()
-                    .doOnNext(token -> {
-                        partialResponses.add(token);
-                        firstPartial.countDown();
-                    })
-                    .doOnComplete(completed::countDown)
-                    .doOnError(error::set)
-                    .subscribe();
-
-            CompletableFuture<Void> startFuture = CompletableFuture.runAsync(() -> assistant
-                    .chat("Hello")
-                    .onPartialResponse(sink::tryEmitNext)
-                    .onCompleteResponse(ignored -> sink.tryEmitComplete())
-                    .onError(sink::tryEmitError)
-                    .start());
-
-            startFuture.get(WAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-            assertTrue(firstPartial.await(WAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS));
-            assertThat(partialResponses, contains("HELLO"));
-            assertFalse(completed.await(200, TimeUnit.MILLISECONDS));
-
-            streamScript.allowCompletion();
-
-            assertTrue(completed.await(WAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS));
-            streamScript.assertCompleted();
-            assertNull(error.get());
-            assertThat(partialResponses, contains("HELLO", " WORLD"));
-        }
-    }
-
-    @Test
-    void fluxReproducerReturnsImmediatelyAndStreamsBeforeCompletion() throws Exception {
-        var streamScript = new BlockingEventStream();
-
-        try (var model = modelWithAsyncResponse(streamScript.response())) {
-            FluxAssistant assistant = AiServices.builder(FluxAssistant.class)
-                    .streamingChatModel(model)
-                    .build();
-
-            CompletableFuture<Flux<String>> fluxFuture = CompletableFuture.supplyAsync(() -> assistant.chat("Hello"));
-            Flux<String> flux = fluxFuture.get(WAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-
-            List<String> partialResponses = new CopyOnWriteArrayList<>();
-            CountDownLatch firstPartial = new CountDownLatch(1);
-            CountDownLatch completed = new CountDownLatch(1);
-            AtomicReference<Throwable> error = new AtomicReference<>();
-
-            flux.doOnNext(token -> {
-                        partialResponses.add(token);
-                        firstPartial.countDown();
-                    })
-                    .doOnComplete(completed::countDown)
-                    .doOnError(error::set)
-                    .subscribe();
-
-            assertTrue(firstPartial.await(WAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS));
-            assertThat(partialResponses, contains("HELLO"));
-            assertFalse(completed.await(200, TimeUnit.MILLISECONDS));
-
-            streamScript.allowCompletion();
-
-            assertTrue(completed.await(WAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS));
-            streamScript.assertCompleted();
-            assertNull(error.get());
-            assertThat(partialResponses, contains("HELLO", " WORLD"));
+            assertTrue(handler.partialResponses.isEmpty());
+            assertThat(handler.completeResponses, contains((String) null));
+            assertThat(
+                    handler.completeToolCalls.stream()
+                            .map(CompleteToolCall::index)
+                            .toList(),
+                    contains(0));
+            assertThat(
+                    handler.completeToolCalls.stream()
+                            .map(CompleteToolCall::toolExecutionRequest)
+                            .map(ToolExecutionRequest::name)
+                            .toList(),
+                    contains("getWeather"));
+            assertThat(
+                    handler.completeToolCalls.stream()
+                            .map(CompleteToolCall::toolExecutionRequest)
+                            .map(ToolExecutionRequest::arguments)
+                            .toList(),
+                    contains("{\"city\":\"Munich\"}"));
         }
     }
 
@@ -396,30 +268,7 @@ class OciGenAiStreamingChatModelTest {
         streamScript.assertCompleted();
         assertNull(handler.error.get());
         assertThat(handler.partialResponses, contains("HELLO", " WORLD"));
-    }
-
-    @Test
-    void tryWithResourcesShouldWaitForSyncFallbackStreamCompletion() throws Exception {
-        var streamScript = new BlockingEventStream();
-        var handler = new TestStreamingChatResponseHandler();
-
-        var invocation = CompletableFuture.runAsync(() -> {
-            try (var model = modelWithSyncResponse(streamScript.response())) {
-                model.doChat(chatRequest(), handler);
-            }
-        });
-
-        assertTrue(handler.firstPartial.await(WAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS));
-        assertFalse(invocation.isDone());
-        assertFalse(handler.completed.await(200, TimeUnit.MILLISECONDS));
-
-        streamScript.allowCompletion();
-
-        invocation.get(WAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-        assertTrue(handler.completed.await(WAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS));
-        streamScript.assertCompleted();
-        assertNull(handler.error.get());
-        assertThat(handler.partialResponses, contains("HELLO", " WORLD"));
+        assertThat(handler.completeResponses, contains("HELLO WORLD"));
     }
 
     @Test
@@ -474,80 +323,17 @@ class OciGenAiStreamingChatModelTest {
         }
     }
 
-    @Test
-    void closeFailureAfterCompletionShouldNotInvokeErrorCallback() throws Exception {
-        var streamScript = new BlockingEventStream();
-        var asyncClient = mock(GenerativeAiInferenceAsyncClient.class);
-        var closeFailure = new RuntimeException("close failed");
-
-        doAnswer(invocation -> {
-                    var future = new CompletableFuture<com.oracle.bmc.generativeaiinference.responses.ChatResponse>();
-                    var worker = new Thread(() -> future.complete(streamScript.response()));
-                    worker.setDaemon(true);
-                    worker.start();
-                    return future;
-                })
-                .when(asyncClient)
-                .chat(any(com.oracle.bmc.generativeaiinference.requests.ChatRequest.class), isNull());
-        doThrow(closeFailure).when(asyncClient).close();
-
-        var model = OciGenAiStreamingChatModel.builder()
-                .modelName("test-model")
-                .compartmentId("test-compartment")
-                .genAiAsyncClient(asyncClient)
-                .build();
-
-        try {
-            var firstPartial = new CountDownLatch(1);
-            var completed = new CountDownLatch(1);
-            var errored = new CountDownLatch(1);
-            var closeInvoked = new AtomicBoolean();
-            var error = new AtomicReference<Throwable>();
-
-            model.doChat(chatRequest(), new StreamingChatResponseHandler() {
-                @Override
-                public void onPartialResponse(String partialResponse) {
-                    if (closeInvoked.compareAndSet(false, true)) {
-                        model.close();
-                    }
-                    firstPartial.countDown();
-                }
-
-                @Override
-                public void onCompleteResponse(ChatResponse completeResponse) {
-                    completed.countDown();
-                }
-
-                @Override
-                public void onError(Throwable throwable) {
-                    error.set(throwable);
-                    errored.countDown();
-                }
-            });
-
-            assertTrue(firstPartial.await(WAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS));
-            streamScript.allowCompletion();
-
-            assertTrue(completed.await(WAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS));
-            streamScript.assertCompleted();
-            assertFalse(errored.await(300, TimeUnit.MILLISECONDS));
-            assertNull(error.get());
-        } finally {
-            model.close();
-        }
-    }
-
     private static ChatRequest chatRequest() {
         return ChatRequest.builder().messages(UserMessage.from("Hello")).build();
     }
 
-    private static com.oracle.bmc.generativeaiinference.responses.ChatResponse ociResponse() {
+    private static com.oracle.bmc.generativeaiinference.responses.ChatResponse ociResponse(String streamedData) {
         return com.oracle.bmc.generativeaiinference.responses.ChatResponse.builder()
-                .eventStream(new ByteArrayInputStream(STREAMED_DATA.getBytes(UTF_8)))
+                .eventStream(new ByteArrayInputStream(streamedData.getBytes(UTF_8)))
                 .build();
     }
 
-    private static OciGenAiStreamingChatModel modelWithAsyncResponse(
+    private static OciGenAiCohereStreamingChatModel modelWithAsyncResponse(
             com.oracle.bmc.generativeaiinference.responses.ChatResponse response) {
         var asyncClient = mock(GenerativeAiInferenceAsyncClient.class);
 
@@ -561,34 +347,11 @@ class OciGenAiStreamingChatModelTest {
                 .when(asyncClient)
                 .chat(any(com.oracle.bmc.generativeaiinference.requests.ChatRequest.class), isNull());
 
-        return OciGenAiStreamingChatModel.builder()
+        return OciGenAiCohereStreamingChatModel.builder()
                 .modelName("test-model")
                 .compartmentId("test-compartment")
                 .genAiAsyncClient(asyncClient)
                 .build();
-    }
-
-    private static OciGenAiStreamingChatModel modelWithSyncResponse(
-            com.oracle.bmc.generativeaiinference.responses.ChatResponse response) {
-        var syncClient = mock(GenerativeAiInferenceClient.class);
-
-        doAnswer(invocation -> response)
-                .when(syncClient)
-                .chat(any(com.oracle.bmc.generativeaiinference.requests.ChatRequest.class));
-
-        return OciGenAiStreamingChatModel.builder()
-                .modelName("test-model")
-                .compartmentId("test-compartment")
-                .genAiClient(syncClient)
-                .build();
-    }
-
-    private interface TokenStreamAssistant {
-        TokenStream chat(String text);
-    }
-
-    private interface FluxAssistant {
-        Flux<String> chat(String text);
     }
 
     private static class BlockingEventStream {
@@ -629,16 +392,11 @@ class OciGenAiStreamingChatModelTest {
 
         private void writeStream(PipedOutputStream output) {
             try (output) {
-                writeLine(
-                        output,
-                        "data: {\"index\":0,\"message\":{\"role\":\"ASSISTANT\",\"content\":[{\"type\":\"TEXT\",\"text\":\"HELLO\"}]}}");
+                writeLine(output, "data: {\"apiFormat\":\"COHERE\",\"text\":\"HELLO\"}");
                 if (!completionAllowed.await(WAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
                     throw new IllegalStateException("Timed out waiting to complete stream");
                 }
-                writeLine(
-                        output,
-                        "data: {\"index\":0,\"message\":{\"role\":\"ASSISTANT\",\"content\":[{\"type\":\"TEXT\",\"text\":\" WORLD\"}]}}");
-                writeLine(output, "data: {\"finishReason\":\"stop\"}");
+                writeLine(output, "data: {\"apiFormat\":\"COHERE\",\"text\":\" WORLD\"}");
             } catch (Throwable t) {
                 writerError.set(t);
             } finally {
@@ -655,6 +413,8 @@ class OciGenAiStreamingChatModelTest {
     private static class TestStreamingChatResponseHandler implements StreamingChatResponseHandler {
 
         private final List<String> partialResponses = new CopyOnWriteArrayList<>();
+        private final List<String> completeResponses = new CopyOnWriteArrayList<>();
+        private final List<CompleteToolCall> completeToolCalls = new ArrayList<>();
         private final CountDownLatch firstPartial = new CountDownLatch(1);
         private final CountDownLatch completed = new CountDownLatch(1);
         private final AtomicReference<Throwable> error = new AtomicReference<>();
@@ -667,6 +427,7 @@ class OciGenAiStreamingChatModelTest {
 
         @Override
         public void onCompleteResponse(ChatResponse completeResponse) {
+            completeResponses.add(completeResponse.aiMessage().text());
             completed.countDown();
         }
 
@@ -674,6 +435,11 @@ class OciGenAiStreamingChatModelTest {
         public void onError(Throwable throwable) {
             error.set(throwable);
             completed.countDown();
+        }
+
+        @Override
+        public void onCompleteToolCall(CompleteToolCall completeToolCall) {
+            completeToolCalls.add(completeToolCall);
         }
     }
 }

--- a/models/langchain4j-community-oci-genai/src/test/java/dev/langchain4j/community/model/oracle/oci/genai/TrackingExecutorService.java
+++ b/models/langchain4j-community-oci-genai/src/test/java/dev/langchain4j/community/model/oracle/oci/genai/TrackingExecutorService.java
@@ -1,0 +1,65 @@
+package dev.langchain4j.community.model.oracle.oci.genai;
+
+import java.util.List;
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+final class TrackingExecutorService extends AbstractExecutorService {
+
+    private final ExecutorService delegate;
+    private final AtomicBoolean shutdownCalled = new AtomicBoolean();
+    private final AtomicBoolean shutdownNowCalled = new AtomicBoolean();
+
+    TrackingExecutorService(String threadNamePrefix) {
+        var threadCounter = new AtomicInteger();
+        this.delegate = Executors.newSingleThreadExecutor(command -> {
+            var thread = new Thread(command, threadNamePrefix + "-" + threadCounter.incrementAndGet());
+            thread.setDaemon(true);
+            return thread;
+        });
+    }
+
+    boolean shutdownWasRequested() {
+        return shutdownCalled.get() || shutdownNowCalled.get();
+    }
+
+    void shutdownDelegateNow() {
+        delegate.shutdownNow();
+    }
+
+    @Override
+    public void shutdown() {
+        shutdownCalled.set(true);
+        delegate.shutdown();
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+        shutdownNowCalled.set(true);
+        return delegate.shutdownNow();
+    }
+
+    @Override
+    public boolean isShutdown() {
+        return delegate.isShutdown();
+    }
+
+    @Override
+    public boolean isTerminated() {
+        return delegate.isTerminated();
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+        return delegate.awaitTermination(timeout, unit);
+    }
+
+    @Override
+    public void execute(Runnable command) {
+        delegate.execute(command);
+    }
+}


### PR DESCRIPTION
## Issue
Closes #619

## Change
- expose `executorService(ExecutorService)` on OCI GenAI streaming builders
- use `DefaultExecutorProvider.getDefaultExecutorService()` as the default executor instead of a per-model cached thread pool
- avoid shutting down the shared default executor or a caller-provided executor when the model is closed
- add unit coverage for the default executor path and configured executor behavior in both generic and Cohere streaming models
- carry over the new `OciGenAiCohereStreamingChatModelTest` coverage onto this branch

## General checklist
- [X] There are no breaking changes
- [x] I have added unit and integration tests for my change
- [x] I have manually run all the unit tests in _all_ modules, and they are all green
- [x] I have manually run all integration tests in the module I have added/changed, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

## Checklist for adding new maven module
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-community-bom/pom.xml`

## Checklist for adding new embedding store integration
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j