### PR TITLE
Add CockroachDB integration (embedding store, chat memory, Spring Boot starters)

### DIFF
--- a/embedding-stores/langchain4j-community-cockroachdb/docs/cockroachdb.md
+++ b/embedding-stores/langchain4j-community-cockroachdb/docs/cockroachdb.md
@@ -316,7 +316,3 @@ and chat history. The Java port of that component lives in the third-party
 checkpoint contract has no async API, so only the sync `CockroachDBSaver`
 is provided; on JDK 21 or later, run it from a virtual thread for
 non-blocking concurrency.
-
-The Python library also ships a `HybridSearchConfig` class for fusing vector
-and FTS scores in application code. The Java module exposes the underlying
-tsvector column but does not yet ship a hybrid query executor.

--- a/embedding-stores/langchain4j-community-cockroachdb/docs/cockroachdb.md
+++ b/embedding-stores/langchain4j-community-cockroachdb/docs/cockroachdb.md
@@ -1,0 +1,318 @@
+---
+sidebar_position: 99
+---
+
+# CockroachDB
+
+[CockroachDB](https://www.cockroachlabs.com/) is a distributed SQL database that
+speaks the PostgreSQL wire protocol. Since v24.2 it ships a native `VECTOR`
+column type, and since v25.2 it offers a distributed approximate nearest
+neighbour index called **C-SPANN**. This module integrates both with
+LangChain4j as:
+
+- a vector `EmbeddingStore<TextSegment>` (`CockroachDbEmbeddingStore`)
+- a `ChatMemoryStore` (`CockroachDbChatMemoryStore`)
+
+The Java module mirrors the feature set of the official Python
+[`langchain-cockroachdb`](https://github.com/cockroachdb/langchain-cockroachdb)
+library where the Java equivalents exist.
+
+## Version requirements
+
+| Feature | Minimum CockroachDB version |
+| --- | --- |
+| `VECTOR(n)` column type | v24.2 |
+| `CREATE VECTOR INDEX` (C-SPANN) | v25.2 |
+| Row-level TTL via `ttl_expiration_expression` | v23.1 |
+
+On CockroachDB v25.2, vector indexes are gated by a cluster setting. Enable it
+once per cluster before creating a store with a `CSpannIndex`:
+
+```sql
+SET CLUSTER SETTING feature.vector_index.enabled = true;
+```
+
+## Maven
+
+```xml
+<dependency>
+    <groupId>dev.langchain4j</groupId>
+    <artifactId>langchain4j-community-cockroachdb</artifactId>
+    <version>${langchain4j-community.version}</version>
+</dependency>
+```
+
+If you import the Community BOM, you can omit the version.
+
+## Connecting
+
+`CockroachDbEngine` wraps a `HikariDataSource`. You can build one from a
+connection string or from individual fields.
+
+```java
+import dev.langchain4j.community.store.embedding.cockroachdb.CockroachDbEngine;
+
+CockroachDbEngine engine = CockroachDbEngine.builder()
+        .host("localhost")
+        .port(26257)
+        .database("defaultdb")
+        .username("root")
+        .password("")
+        .sslMode("disable")
+        .build();
+```
+
+The builder also accepts a full connection string. The Python-style
+`cockroachdb://` scheme is rewritten to `jdbc:postgresql://` automatically,
+so you can paste the same URL the Python library uses:
+
+```java
+CockroachDbEngine engine = CockroachDbEngine.fromConnectionString(
+        "cockroachdb://root@localhost:26257/defaultdb?sslmode=disable");
+```
+
+If you already have a `DataSource`, use `CockroachDbEngine.from(dataSource)`.
+
+## Vector store
+
+A minimal vector store uses sequential scan (`NoIndex`), which is appropriate
+for small datasets and tests:
+
+```java
+import dev.langchain4j.community.store.embedding.cockroachdb.CockroachDbEmbeddingStore;
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.embedding.onnx.allminilml6v2q.AllMiniLmL6V2QuantizedEmbeddingModel;
+
+EmbeddingModel model = new AllMiniLmL6V2QuantizedEmbeddingModel();
+
+CockroachDbEmbeddingStore store = CockroachDbEmbeddingStore.builder()
+        .engine(engine)
+        .dimension(model.dimension())
+        .tableName("embeddings")
+        .build();
+
+TextSegment segment = TextSegment.from("Cockroaches are surprisingly resilient.");
+Embedding embedding = model.embed(segment).content();
+store.add(embedding, segment);
+```
+
+For production workloads on CockroachDB v25.2+, add a C-SPANN vector index:
+
+```java
+import dev.langchain4j.community.store.embedding.cockroachdb.index.CSpannIndex;
+
+CockroachDbEmbeddingStore store = CockroachDbEmbeddingStore.builder()
+        .engine(engine)
+        .dimension(model.dimension())
+        .vectorIndex(CSpannIndex.builder()
+                .minPartitionSize(16)
+                .maxPartitionSize(128)
+                .build())
+        .build();
+```
+
+The DDL emitted for the index is:
+
+```sql
+CREATE VECTOR INDEX IF NOT EXISTS embeddings_embedding_vector_idx
+  ON public.embeddings (embedding)
+  WITH (min_partition_size = 16, max_partition_size = 128);
+```
+
+C-SPANN picks the distance function from the query operator (`<=>` for cosine,
+`<->` for L2, `<#>` for inner product), so `MetricType` is selected at query
+time on the store, not bound to the index.
+
+### Searching
+
+`EmbeddingSearchRequest` works the same as in any other LangChain4j store:
+
+```java
+import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
+import dev.langchain4j.store.embedding.EmbeddingSearchResult;
+
+EmbeddingSearchResult<TextSegment> result = store.search(
+        EmbeddingSearchRequest.builder()
+                .queryEmbedding(model.embed("resilience").content())
+                .maxResults(5)
+                .minScore(0.6)
+                .build());
+
+result.matches().forEach(m ->
+        System.out.printf("%s (%.3f) %s%n", m.embeddingId(), m.score(), m.embedded().text()));
+```
+
+### Tuning C-SPANN at query time
+
+CockroachDB exposes a session variable, `vector_search_beam_size`, that
+controls the recall/latency tradeoff. Set it on the store builder to wrap
+each search in a transaction that scopes the setting with `SET LOCAL`:
+
+```java
+CockroachDbEmbeddingStore store = CockroachDbEmbeddingStore.builder()
+        .engine(engine)
+        .dimension(model.dimension())
+        .vectorIndex(CSpannIndex.builder().build())
+        .searchBeamSize(32)
+        .build();
+```
+
+Higher values trade latency for recall. The default beam size is decided by
+CockroachDB if you leave the field unset.
+
+### Metadata filtering
+
+Metadata is stored in a JSONB column and filtered at query time using
+LangChain4j `Filter` expressions:
+
+```java
+import dev.langchain4j.store.embedding.filter.MetadataFilterBuilder;
+
+EmbeddingSearchResult<TextSegment> result = store.search(
+        EmbeddingSearchRequest.builder()
+                .queryEmbedding(query)
+                .maxResults(10)
+                .filter(MetadataFilterBuilder.metadataKey("category").isEqualTo("biology")
+                        .and(MetadataFilterBuilder.metadataKey("year").isGreaterThan(2020)))
+                .build());
+```
+
+Comparison filters (`>`, `>=`, `<`, `<=`) cast the JSONB value to `numeric`.
+Equality on strings compares JSON text. The filter key must contain only
+alphanumeric characters, dots, underscores or hyphens.
+
+### Multi-tenancy with a namespace column
+
+To scope rows by tenant, add a `namespaceColumn` to the schema and configure a
+namespace value on each store instance. The column is added as a prefix to the
+C-SPANN index so per-tenant queries stay fast:
+
+```java
+CockroachDbEmbeddingStore tenantA = CockroachDbEmbeddingStore.builder()
+        .engine(engine)
+        .dimension(model.dimension())
+        .namespaceColumn("tenant_id")
+        .namespace("acme")
+        .vectorIndex(CSpannIndex.builder().build())
+        .build();
+```
+
+The generated index becomes `CREATE VECTOR INDEX ... ON embeddings (tenant_id, embedding)`,
+and every read/write performed through this store is filtered to `tenant_id = 'acme'`.
+
+### Optional full-text column
+
+If you intend to combine vector search with full-text search later, enable a
+generated `tsvector` column at table creation time. A GIN index is created
+alongside it:
+
+```java
+CockroachDbEmbeddingStore store = CockroachDbEmbeddingStore.builder()
+        .engine(engine)
+        .dimension(model.dimension())
+        .createTsvectorColumn(true)
+        .build();
+```
+
+Hybrid (vector + FTS) query execution is not yet implemented; the column is
+created so it can be used by application code or a future release.
+
+## Chat memory
+
+`CockroachDbChatMemoryStore` implements `ChatMemoryStore` and persists
+serialised chat messages in a JSONB column ordered by insertion time:
+
+```java
+import dev.langchain4j.community.store.memory.chat.cockroachdb.CockroachDbChatMemoryStore;
+
+CockroachDbChatMemoryStore memory = CockroachDbChatMemoryStore.builder()
+        .engine(engine)
+        .tableName("chat_memory")
+        .build();
+```
+
+The schema is:
+
+```sql
+CREATE TABLE chat_memory (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  session_id TEXT NOT NULL,
+  message JSONB NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX chat_memory_session_idx ON chat_memory (session_id, created_at);
+```
+
+`updateMessages` replaces the full session inside a transaction, so partial
+writes are not visible to readers.
+
+### Row-level TTL
+
+CockroachDB can expire rows automatically. Pass a `ttl` duration to enable
+[row-level TTL](https://www.cockroachlabs.com/docs/stable/row-level-ttl) on
+the chat memory table:
+
+```java
+import java.time.Duration;
+
+CockroachDbChatMemoryStore memory = CockroachDbChatMemoryStore.builder()
+        .engine(engine)
+        .tableName("chat_memory")
+        .ttl(Duration.ofDays(7))
+        .ttlJobCron("@daily")
+        .build();
+```
+
+The schema setup emits:
+
+```sql
+ALTER TABLE chat_memory SET (
+  ttl_expiration_expression = $$(created_at + '7 days')$$,
+  ttl_job_cron = '@daily'
+);
+```
+
+To disable TTL on an existing table:
+
+```java
+memory.disableTtl();
+```
+
+## Retries
+
+CockroachDB returns SQLSTATE `40001` when a transaction must be retried under
+its default `SERIALIZABLE` isolation. The store wraps each unit of work in a
+retry loop with exponential backoff and jitter (5 attempts by default,
+starting at 100 ms, doubling up to 10 seconds). No additional configuration
+is needed.
+
+## Connection string formats
+
+The following forms are all accepted by `CockroachDbEngine.fromConnectionString`:
+
+| Form | Example |
+| --- | --- |
+| Python style | `cockroachdb://root@localhost:26257/defaultdb?sslmode=disable` |
+| psycopg style | `cockroachdb+psycopg://user:pw@host:26257/db` |
+| libpq style | `postgresql://user@host:26257/db` |
+| JDBC style | `jdbc:postgresql://localhost:26257/defaultdb` |
+
+For CockroachDB Cloud, use the connection string from the cluster console,
+typically:
+
+```
+cockroachdb://USER:PASSWORD@HOST:26257/DATABASE?sslmode=verify-full
+```
+
+## Differences from the Python library
+
+The Python `langchain-cockroachdb` library additionally provides a LangGraph
+checkpointer (`CockroachDBSaver` / `AsyncCockroachDBSaver`). LangChain4j does
+not yet have a LangGraph equivalent, so no Java port of that component is
+included in this module.
+
+The Python library also ships a `HybridSearchConfig` class for fusing vector
+and FTS scores in application code. The Java module exposes the underlying
+tsvector column but does not yet ship a hybrid query executor.

--- a/embedding-stores/langchain4j-community-cockroachdb/docs/cockroachdb.md
+++ b/embedding-stores/langchain4j-community-cockroachdb/docs/cockroachdb.md
@@ -44,6 +44,38 @@ SET CLUSTER SETTING feature.vector_index.enabled = true;
 
 If you import the Community BOM, you can omit the version.
 
+## APIs
+
+The module exposes four public classes:
+
+### `CockroachDbEngine`
+
+Wraps a HikariCP `DataSource` and handles connection pooling. Builds from
+individual `host`/`port`/`database`/`username`/`password` fields, from a full
+connection string (the Python-style `cockroachdb://` scheme is rewritten to
+`jdbc:postgresql://` automatically), or from an existing `DataSource` via
+`CockroachDbEngine.from(dataSource)`.
+
+### `CockroachDbSchema`
+
+Encapsulates the embedding table layout: table and column names, vector
+dimension, distance metric, optional namespace column for multi-tenancy, the
+chosen vector index strategy, and an optional generated `tsvector` column for
+future hybrid search.
+
+### `CockroachDbEmbeddingStore`
+
+Implements LangChain4j's `EmbeddingStore<TextSegment>` against the native
+CockroachDB `VECTOR` column. Supports batch insert, JSONB metadata
+filtering, removal by id / by `Filter` / in bulk, optional namespace scoping,
+and optional per-query `vector_search_beam_size` tuning for C-SPANN.
+
+### `CockroachDbChatMemoryStore`
+
+Implements LangChain4j's `ChatMemoryStore`. Persists serialised chat messages
+in a JSONB column ordered by an explicit insertion index, with optional
+row-level TTL.
+
 ## Connecting
 
 `CockroachDbEngine` wraps a `HikariDataSource`. You can build one from a
@@ -306,13 +338,131 @@ typically:
 cockroachdb://USER:PASSWORD@HOST:26257/DATABASE?sslmode=verify-full
 ```
 
-## Differences from the Python library
+## Parameter Summary
 
-The Python `langchain-cockroachdb` library ships a LangGraph checkpointer
-(`CockroachDBSaver` and `AsyncCockroachDBSaver`) alongside the vector store
-and chat history. The Java port of that component lives in the third-party
-[langgraph4j](https://github.com/langgraph4j/langgraph4j) project as
-`langgraph4j-cockroachdb-saver`, not in this module. langgraph4j's
-checkpoint contract has no async API, so only the sync `CockroachDBSaver`
-is provided; on JDK 21 or later, run it from a virtual thread for
-non-blocking concurrency.
+### `CockroachDbEngine` parameters
+
+| Parameter | Description | Default | Required/Optional |
+| --- | --- | --- | --- |
+| `host` | Hostname of the CockroachDB server | `localhost` | Required (if no `connectionString`) |
+| `port` | Port number of the CockroachDB server | `26257` | Required (if no `connectionString`) |
+| `database` | Database to connect to | `defaultdb` | Required (if no `connectionString`) |
+| `username` | Username for authentication | `root` | Required |
+| `password` | Password for authentication | `""` (empty) | Optional |
+| `schema` | Default schema name | `public` | Optional |
+| `sslMode` | SSL mode (`disable`, `require`, `verify-full`, etc.) | `disable` | Optional |
+| `maxPoolSize` | Maximum HikariCP pool size | `10` | Optional |
+| `minPoolSize` | Minimum idle connections | `5` | Optional |
+| `connectionTimeoutMs` | Connection timeout in milliseconds | `10000` | Optional |
+| `idleTimeoutMs` | Idle timeout in milliseconds | `300000` | Optional |
+| `maxLifetimeMs` | Maximum connection lifetime in milliseconds | `3600000` | Optional |
+| `connectionString` | Full URL; overrides individual host/port/db when set | `null` | Optional |
+
+### `CockroachDbEmbeddingStore` parameters
+
+| Parameter | Description | Default | Required/Optional |
+| --- | --- | --- | --- |
+| `engine` | `CockroachDbEngine` instance | None | **Required** |
+| `dimension` | Embedding vector dimension | None | **Required** |
+| `tableName` | Embeddings table name | `embeddings` | Optional |
+| `schemaName` | Database schema name | `public` | Optional |
+| `metricType` | Distance metric: `COSINE`, `EUCLIDEAN`, or `DOT_PRODUCT` | `COSINE` | Optional |
+| `vectorIndex` | `CSpannIndex` or `NoIndex` | `NoIndex` (sequential scan) | Optional |
+| `namespaceColumn` | Tenant column name for multi-tenancy | `null` (disabled) | Optional |
+| `namespace` | Tenant value applied on every read and write | `null` | Optional, requires `namespaceColumn` |
+| `searchBeamSize` | Per-query `vector_search_beam_size` session variable | `null` (CockroachDB default) | Optional |
+| `createTableIfNotExists` | Create the table at build time | `true` | Optional |
+| `createTsvectorColumn` | Add a generated `tsvector` column + GIN index | `false` | Optional |
+
+### `CSpannIndex` parameters (CockroachDB v25.2+)
+
+| Parameter | Description | Default | Required/Optional |
+| --- | --- | --- | --- |
+| `name` | Custom index name | `{table}_{column}_vector_idx` | Optional |
+| `minPartitionSize` | Minimum partition size (emitted via `WITH`) | CockroachDB default | Optional |
+| `maxPartitionSize` | Maximum partition size (emitted via `WITH`) | CockroachDB default | Optional |
+
+### `CockroachDbChatMemoryStore` parameters
+
+| Parameter | Description | Default | Required/Optional |
+| --- | --- | --- | --- |
+| `engine` | `CockroachDbEngine` instance | None | **Required** |
+| `tableName` | Chat history table name | `message_store` | Optional |
+| `schemaName` | Database schema name | `public` | Optional |
+| `ttl` | Row-level TTL duration; enables CockroachDB TTL when set | `null` (disabled) | Optional |
+| `ttlJobCron` | TTL job schedule | `@daily` | Optional, requires `ttl` |
+| `createTableIfNotExists` | Create the table at build time | `true` | Optional |
+
+## Example
+
+A minimal end-to-end RAG demo that boots a CockroachDB Testcontainer,
+indexes two text segments, and runs a similarity search:
+
+```java
+import dev.langchain4j.community.store.embedding.cockroachdb.CockroachDbEmbeddingStore;
+import dev.langchain4j.community.store.embedding.cockroachdb.CockroachDbEngine;
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.embedding.onnx.allminilml6v2.AllMiniLmL6V2EmbeddingModel;
+import dev.langchain4j.store.embedding.EmbeddingMatch;
+import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import java.util.List;
+import org.testcontainers.containers.CockroachContainer;
+
+public class CockroachDbEmbeddingStoreExample {
+
+    public static void main(String[] args) {
+        try (CockroachContainer cockroach = new CockroachContainer("cockroachdb/cockroach:latest-v25.2")) {
+            cockroach.start();
+
+            CockroachDbEngine engine = CockroachDbEngine.builder()
+                    .connectionString(cockroach.getJdbcUrl())
+                    .username(cockroach.getUsername())
+                    .password(cockroach.getPassword())
+                    .build();
+
+            EmbeddingModel embeddingModel = new AllMiniLmL6V2EmbeddingModel();
+
+            EmbeddingStore<TextSegment> embeddingStore = CockroachDbEmbeddingStore.builder()
+                    .engine(engine)
+                    .dimension(embeddingModel.dimension())
+                    .tableName("demo_embeddings")
+                    .build();
+
+            TextSegment segment1 = TextSegment.from("I like football.");
+            Embedding embedding1 = embeddingModel.embed(segment1).content();
+            embeddingStore.add(embedding1, segment1);
+
+            TextSegment segment2 = TextSegment.from("The weather is good today.");
+            Embedding embedding2 = embeddingModel.embed(segment2).content();
+            embeddingStore.add(embedding2, segment2);
+
+            Embedding queryEmbedding = embeddingModel.embed("What is your favourite sport?").content();
+            EmbeddingSearchRequest request = EmbeddingSearchRequest.builder()
+                    .queryEmbedding(queryEmbedding)
+                    .maxResults(1)
+                    .build();
+
+            List<EmbeddingMatch<TextSegment>> matches = embeddingStore.search(request).matches();
+            EmbeddingMatch<TextSegment> match = matches.get(0);
+
+            System.out.println(match.score());           // ~0.81
+            System.out.println(match.embedded().text()); // I like football.
+
+            engine.close();
+        }
+    }
+}
+```
+
+The example uses the default sequential-scan index so it runs on any
+CockroachDB v24.2 or later without extra cluster setup. To switch to the
+C-SPANN distributed ANN index on v25.2 or later, enable the feature flag once
+per cluster and pass `CSpannIndex.builder().build()` to the store via
+`.vectorIndex(...)`:
+
+```sql
+SET CLUSTER SETTING feature.vector_index.enabled = true;
+```

--- a/embedding-stores/langchain4j-community-cockroachdb/docs/cockroachdb.md
+++ b/embedding-stores/langchain4j-community-cockroachdb/docs/cockroachdb.md
@@ -308,10 +308,14 @@ cockroachdb://USER:PASSWORD@HOST:26257/DATABASE?sslmode=verify-full
 
 ## Differences from the Python library
 
-The Python `langchain-cockroachdb` library additionally provides a LangGraph
-checkpointer (`CockroachDBSaver` / `AsyncCockroachDBSaver`). LangChain4j does
-not yet have a LangGraph equivalent, so no Java port of that component is
-included in this module.
+The Python `langchain-cockroachdb` library ships a LangGraph checkpointer
+(`CockroachDBSaver` and `AsyncCockroachDBSaver`) alongside the vector store
+and chat history. The Java port of that component lives in the third-party
+[langgraph4j](https://github.com/langgraph4j/langgraph4j) project as
+`langgraph4j-cockroachdb-saver`, not in this module. langgraph4j's
+checkpoint contract has no async API, so only the sync `CockroachDBSaver`
+is provided; on JDK 21 or later, run it from a virtual thread for
+non-blocking concurrency.
 
 The Python library also ships a `HybridSearchConfig` class for fusing vector
 and FTS scores in application code. The Java module exposes the underlying

--- a/embedding-stores/langchain4j-community-cockroachdb/pom.xml
+++ b/embedding-stores/langchain4j-community-cockroachdb/pom.xml
@@ -1,0 +1,172 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>dev.langchain4j</groupId>
+        <artifactId>langchain4j-community</artifactId>
+        <version>1.16.0-beta26-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>langchain4j-community-cockroachdb</artifactId>
+    <name>LangChain4j :: Community :: Integration :: CockroachDB</name>
+    <description>CockroachDB embedding store and chat memory for LangChain4j</description>
+
+    <licenses>
+        <license>
+            <name>Apache-2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+            <comments>A business-friendly OSS license</comments>
+        </license>
+    </licenses>
+
+    <properties>
+        <postgresql.version>42.7.11</postgresql.version>
+        <hikaricp.version>7.0.2</hikaricp.version>
+        <pgvector.version>0.1.6</pgvector.version>
+    </properties>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-core</artifactId>
+            <version>${langchain4j.core.version}</version>
+        </dependency>
+
+        <!-- Main LangChain4j for DocumentSplitters in tests -->
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j</artifactId>
+            <version>${langchain4j.core.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- PostgreSQL JDBC driver: CockroachDB speaks the Postgres wire protocol -->
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>${postgresql.version}</version>
+        </dependency>
+
+        <!-- pgvector-java: supplies the PGvector JDBC type. CockroachDB has a native
+             VECTOR type that is wire-compatible with pgvector. -->
+        <dependency>
+            <groupId>com.pgvector</groupId>
+            <artifactId>pgvector</artifactId>
+            <version>${pgvector.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.postgresql</groupId>
+                    <artifactId>postgresql</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP</artifactId>
+            <version>${hikaricp.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-core</artifactId>
+            <version>${langchain4j.core.version}</version>
+            <classifier>tests</classifier>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>cockroachdb</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-embeddings-all-minilm-l6-v2-q</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.tinylog</groupId>
+            <artifactId>tinylog-impl</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.tinylog</groupId>
+            <artifactId>slf4j-tinylog</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.honton.chas</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <configuration>
+                    <skipCompliance>true</skipCompliance>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/embedding-stores/langchain4j-community-cockroachdb/revapi.json
+++ b/embedding-stores/langchain4j-community-cockroachdb/revapi.json
@@ -1,0 +1,14 @@
+[
+  {
+    "extension": "revapi.differences",
+    "configuration": {
+      "ignore": true,
+      "differences": [
+        {
+          "code": "java.class.externalClassExposedInAPI",
+          "justification": "New module using langchain4j core types as public API - these are external dependency types used in the embedding store API"
+        }
+      ]
+    }
+  }
+]

--- a/embedding-stores/langchain4j-community-cockroachdb/src/main/java/dev/langchain4j/community/store/embedding/cockroachdb/CockroachDbEmbeddingStore.java
+++ b/embedding-stores/langchain4j-community-cockroachdb/src/main/java/dev/langchain4j/community/store/embedding/cockroachdb/CockroachDbEmbeddingStore.java
@@ -134,12 +134,21 @@ public class CockroachDbEmbeddingStore implements EmbeddingStore<TextSegment> {
 
         String op = schema.getMetricType().operator();
         StringBuilder sql = new StringBuilder()
-                .append("SELECT ").append(schema.getIdColumn()).append(", ")
-                .append(schema.getContentColumn()).append(", ")
-                .append(schema.getMetadataColumn()).append(", ")
-                .append(schema.getEmbeddingColumn()).append(", ")
-                .append(schema.getEmbeddingColumn()).append(" ").append(op).append(" ?::vector AS distance ")
-                .append("FROM ").append(schema.getFullTableName());
+                .append("SELECT ")
+                .append(schema.getIdColumn())
+                .append(", ")
+                .append(schema.getContentColumn())
+                .append(", ")
+                .append(schema.getMetadataColumn())
+                .append(", ")
+                .append(schema.getEmbeddingColumn())
+                .append(", ")
+                .append(schema.getEmbeddingColumn())
+                .append(" ")
+                .append(op)
+                .append(" ?::vector AS distance ")
+                .append("FROM ")
+                .append(schema.getFullTableName());
 
         List<String> wheres = new ArrayList<>();
         if (namespaceClause() != null) wheres.add(namespaceClause());
@@ -148,7 +157,10 @@ public class CockroachDbEmbeddingStore implements EmbeddingStore<TextSegment> {
             sql.append(" WHERE ").append(String.join(" AND ", wheres));
         }
         // Operator + bound vector must be repeated for the C-SPANN index to fire.
-        sql.append(" ORDER BY ").append(schema.getEmbeddingColumn()).append(" ").append(op)
+        sql.append(" ORDER BY ")
+                .append(schema.getEmbeddingColumn())
+                .append(" ")
+                .append(op)
                 .append(" ?::vector LIMIT ?");
 
         String queryVector = toVectorLiteral(query);
@@ -189,7 +201,11 @@ public class CockroachDbEmbeddingStore implements EmbeddingStore<TextSegment> {
                     }
                 } catch (SQLException e) {
                     if (searchBeamSize != null) {
-                        try { conn.rollback(); } catch (SQLException ignore) { /* best-effort */ }
+                        try {
+                            conn.rollback();
+                        } catch (SQLException ignore) {
+                            /* best-effort */
+                        }
                     }
                     throw e;
                 }
@@ -204,12 +220,13 @@ public class CockroachDbEmbeddingStore implements EmbeddingStore<TextSegment> {
         }
         String sql = String.format(
                 "DELETE FROM %s WHERE %s = ?%s",
-                schema.getFullTableName(), schema.getIdColumn(),
+                schema.getFullTableName(),
+                schema.getIdColumn(),
                 namespaceClause() == null ? "" : " AND " + namespaceClause());
 
         RetryUtils.withRetry(() -> {
             try (Connection conn = engine.getConnection();
-                 PreparedStatement st = conn.prepareStatement(sql)) {
+                    PreparedStatement st = conn.prepareStatement(sql)) {
                 for (String id : ids) {
                     st.setObject(1, UUID.fromString(id));
                     st.addBatch();
@@ -225,13 +242,15 @@ public class CockroachDbEmbeddingStore implements EmbeddingStore<TextSegment> {
         if (filter == null) {
             throw new IllegalArgumentException("filter cannot be null");
         }
-        StringBuilder sql = new StringBuilder("DELETE FROM ").append(schema.getFullTableName())
-                .append(" WHERE ").append(filterMapper.map(filter));
+        StringBuilder sql = new StringBuilder("DELETE FROM ")
+                .append(schema.getFullTableName())
+                .append(" WHERE ")
+                .append(filterMapper.map(filter));
         if (namespaceClause() != null) sql.append(" AND ").append(namespaceClause());
 
         RetryUtils.withRetry(() -> {
             try (Connection conn = engine.getConnection();
-                 Statement st = conn.createStatement()) {
+                    Statement st = conn.createStatement()) {
                 st.executeUpdate(sql.toString());
                 return null;
             }
@@ -248,7 +267,7 @@ public class CockroachDbEmbeddingStore implements EmbeddingStore<TextSegment> {
         }
         RetryUtils.withRetry(() -> {
             try (Connection conn = engine.getConnection();
-                 Statement st = conn.createStatement()) {
+                    Statement st = conn.createStatement()) {
                 st.executeUpdate(sql);
                 return null;
             }
@@ -258,7 +277,7 @@ public class CockroachDbEmbeddingStore implements EmbeddingStore<TextSegment> {
     public void createTableIfNotExists() {
         RetryUtils.withRetry(() -> {
             try (Connection conn = engine.getConnection();
-                 Statement st = conn.createStatement()) {
+                    Statement st = conn.createStatement()) {
                 st.execute(schema.getCreateTableSql());
 
                 String nsIdx = schema.getCreateNamespaceIndexSql();
@@ -281,18 +300,18 @@ public class CockroachDbEmbeddingStore implements EmbeddingStore<TextSegment> {
     }
 
     private void addInternal(String id, Embedding embedding, TextSegment segment) {
-        addAllInternal(singletonList(id), singletonList(embedding),
-                segment != null ? singletonList(segment) : null);
+        addAllInternal(singletonList(id), singletonList(embedding), segment != null ? singletonList(segment) : null);
     }
 
     private void addAllInternal(List<String> ids, List<Embedding> embeddings, List<TextSegment> segments) {
         if (ids.isEmpty()) return;
 
-        StringBuilder columns = new StringBuilder()
-                .append(schema.getIdColumn()).append(", ");
+        StringBuilder columns = new StringBuilder().append(schema.getIdColumn()).append(", ");
         if (schema.hasNamespace()) columns.append(schema.getNamespaceColumn()).append(", ");
-        columns.append(schema.getContentColumn()).append(", ")
-                .append(schema.getEmbeddingColumn()).append(", ")
+        columns.append(schema.getContentColumn())
+                .append(", ")
+                .append(schema.getEmbeddingColumn())
+                .append(", ")
                 .append(schema.getMetadataColumn());
 
         StringBuilder placeholders = new StringBuilder("?");
@@ -300,12 +319,23 @@ public class CockroachDbEmbeddingStore implements EmbeddingStore<TextSegment> {
         placeholders.append(", ?, ?::vector, ?::jsonb");
 
         StringBuilder updateSet = new StringBuilder()
-                .append(schema.getContentColumn()).append(" = EXCLUDED.").append(schema.getContentColumn())
-                .append(", ").append(schema.getEmbeddingColumn()).append(" = EXCLUDED.").append(schema.getEmbeddingColumn())
-                .append(", ").append(schema.getMetadataColumn()).append(" = EXCLUDED.").append(schema.getMetadataColumn());
+                .append(schema.getContentColumn())
+                .append(" = EXCLUDED.")
+                .append(schema.getContentColumn())
+                .append(", ")
+                .append(schema.getEmbeddingColumn())
+                .append(" = EXCLUDED.")
+                .append(schema.getEmbeddingColumn())
+                .append(", ")
+                .append(schema.getMetadataColumn())
+                .append(" = EXCLUDED.")
+                .append(schema.getMetadataColumn());
         if (schema.hasNamespace()) {
-            updateSet.append(", ").append(schema.getNamespaceColumn())
-                    .append(" = EXCLUDED.").append(schema.getNamespaceColumn());
+            updateSet
+                    .append(", ")
+                    .append(schema.getNamespaceColumn())
+                    .append(" = EXCLUDED.")
+                    .append(schema.getNamespaceColumn());
         }
 
         String sql = String.format(
@@ -316,7 +346,7 @@ public class CockroachDbEmbeddingStore implements EmbeddingStore<TextSegment> {
 
         RetryUtils.withRetry(() -> {
             try (Connection conn = engine.getConnection();
-                 PreparedStatement st = conn.prepareStatement(sql)) {
+                    PreparedStatement st = conn.prepareStatement(sql)) {
                 for (int i = 0; i < ids.size(); i++) {
                     TextSegment seg = segments != null ? segments.get(i) : null;
                     Metadata metadata = seg != null ? seg.metadata() : new Metadata();

--- a/embedding-stores/langchain4j-community-cockroachdb/src/main/java/dev/langchain4j/community/store/embedding/cockroachdb/CockroachDbEmbeddingStore.java
+++ b/embedding-stores/langchain4j-community-cockroachdb/src/main/java/dev/langchain4j/community/store/embedding/cockroachdb/CockroachDbEmbeddingStore.java
@@ -1,0 +1,502 @@
+package dev.langchain4j.community.store.embedding.cockroachdb;
+
+import static dev.langchain4j.internal.Utils.isNotNullOrBlank;
+import static dev.langchain4j.internal.Utils.randomUUID;
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toList;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.langchain4j.community.store.embedding.cockroachdb.index.BaseIndex;
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.store.embedding.EmbeddingMatch;
+import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
+import dev.langchain4j.store.embedding.EmbeddingSearchResult;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import dev.langchain4j.store.embedding.RelevanceScore;
+import dev.langchain4j.store.embedding.filter.Filter;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * CockroachDB-backed {@link EmbeddingStore} for {@link TextSegment}s.
+ *
+ * <p>Mirrors the feature set of the Python {@code langchain-cockroachdb} library:
+ * native {@code VECTOR} column, JSONB metadata + filtering, optional namespace
+ * column for multi-tenancy, and (when paired with
+ * {@link dev.langchain4j.community.store.embedding.cockroachdb.index.CSpannIndex})
+ * per-query {@code vector_search_beam_size} tuning.
+ *
+ * <pre>{@code
+ * CockroachDbEngine engine = CockroachDbEngine.builder()
+ *         .host("localhost").port(26257).database("defaultdb")
+ *         .username("root").build();
+ *
+ * CockroachDbEmbeddingStore store = CockroachDbEmbeddingStore.builder()
+ *         .engine(engine)
+ *         .schema(CockroachDbSchema.builder()
+ *                 .dimension(384)
+ *                 .vectorIndex(CSpannIndex.builder().build())
+ *                 .build())
+ *         .build();
+ * }</pre>
+ */
+public class CockroachDbEmbeddingStore implements EmbeddingStore<TextSegment> {
+
+    private static final Logger logger = LoggerFactory.getLogger(CockroachDbEmbeddingStore.class);
+    private static final ObjectMapper JSON = new ObjectMapper();
+
+    private final CockroachDbEngine engine;
+    private final CockroachDbSchema schema;
+    private final CockroachDbFilterMapper filterMapper;
+    private final String namespace; // null = no scoping even when schema has namespace column
+    private final Integer searchBeamSize;
+
+    public CockroachDbEmbeddingStore(Builder builder) {
+        this.engine = builder.engine;
+        this.schema = builder.schema;
+        this.filterMapper = new CockroachDbFilterMapper(schema.getMetadataColumn());
+        this.namespace = builder.namespace;
+        this.searchBeamSize = builder.searchBeamSize;
+
+        if (schema.isCreateTableIfNotExists()) {
+            createTableIfNotExists();
+        }
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public String add(Embedding embedding) {
+        String id = randomUUID();
+        add(id, embedding);
+        return id;
+    }
+
+    @Override
+    public void add(String id, Embedding embedding) {
+        addInternal(id, embedding, null);
+    }
+
+    @Override
+    public String add(Embedding embedding, TextSegment textSegment) {
+        String id = randomUUID();
+        addInternal(id, embedding, textSegment);
+        return id;
+    }
+
+    @Override
+    public List<String> addAll(List<Embedding> embeddings) {
+        List<String> ids = embeddings.stream().map(e -> randomUUID()).collect(toList());
+        addAllInternal(ids, embeddings, null);
+        return ids;
+    }
+
+    @Override
+    public List<String> addAll(List<Embedding> embeddings, List<TextSegment> textSegments) {
+        if (embeddings.size() != textSegments.size()) {
+            throw new IllegalArgumentException("embeddings and textSegments must have the same size");
+        }
+        List<String> ids = embeddings.stream().map(e -> randomUUID()).collect(toList());
+        addAllInternal(ids, embeddings, textSegments);
+        return ids;
+    }
+
+    @Override
+    public void addAll(List<String> ids, List<Embedding> embeddings, List<TextSegment> textSegments) {
+        if (ids.size() != embeddings.size() || (textSegments != null && embeddings.size() != textSegments.size())) {
+            throw new IllegalArgumentException("ids, embeddings and textSegments must have the same size");
+        }
+        addAllInternal(ids, embeddings, textSegments);
+    }
+
+    @Override
+    public EmbeddingSearchResult<TextSegment> search(EmbeddingSearchRequest request) {
+        Embedding query = request.queryEmbedding();
+        int maxResults = request.maxResults();
+        double minScore = request.minScore();
+        Filter filter = request.filter();
+
+        String op = schema.getMetricType().operator();
+        StringBuilder sql = new StringBuilder()
+                .append("SELECT ").append(schema.getIdColumn()).append(", ")
+                .append(schema.getContentColumn()).append(", ")
+                .append(schema.getMetadataColumn()).append(", ")
+                .append(schema.getEmbeddingColumn()).append(", ")
+                .append(schema.getEmbeddingColumn()).append(" ").append(op).append(" ?::vector AS distance ")
+                .append("FROM ").append(schema.getFullTableName());
+
+        List<String> wheres = new ArrayList<>();
+        if (namespaceClause() != null) wheres.add(namespaceClause());
+        if (filter != null) wheres.add(filterMapper.map(filter));
+        if (!wheres.isEmpty()) {
+            sql.append(" WHERE ").append(String.join(" AND ", wheres));
+        }
+        // Operator + bound vector must be repeated for the C-SPANN index to fire.
+        sql.append(" ORDER BY ").append(schema.getEmbeddingColumn()).append(" ").append(op)
+                .append(" ?::vector LIMIT ?");
+
+        String queryVector = toVectorLiteral(query);
+        String sqlString = sql.toString();
+
+        return RetryUtils.withRetry(() -> {
+            try (Connection conn = engine.getConnection()) {
+                if (searchBeamSize != null) {
+                    // SET LOCAL is transaction-scoped; needs an explicit txn so the setting doesn't
+                    // leak back into the pool on connection return.
+                    conn.setAutoCommit(false);
+                }
+                try (PreparedStatement st = conn.prepareStatement(sqlString)) {
+                    if (searchBeamSize != null) {
+                        try (Statement s = conn.createStatement()) {
+                            s.execute("SET LOCAL vector_search_beam_size = " + searchBeamSize);
+                        }
+                    }
+                    st.setString(1, queryVector);
+                    st.setString(2, queryVector);
+                    st.setInt(3, maxResults);
+
+                    try (ResultSet rs = st.executeQuery()) {
+                        List<EmbeddingMatch<TextSegment>> matches = new ArrayList<>();
+                        while (rs.next()) {
+                            String id = rs.getString(schema.getIdColumn());
+                            String content = rs.getString(schema.getContentColumn());
+                            double distance = rs.getDouble("distance");
+                            double score = scoreFromDistance(distance);
+                            if (score < minScore) continue;
+                            Embedding emb = extractEmbedding(rs, schema.getEmbeddingColumn());
+                            Metadata metadata = readMetadata(rs, schema.getMetadataColumn());
+                            TextSegment seg = isNotNullOrBlank(content) ? TextSegment.from(content, metadata) : null;
+                            matches.add(new EmbeddingMatch<>(score, id, emb, seg));
+                        }
+                        if (searchBeamSize != null) conn.commit();
+                        return new EmbeddingSearchResult<>(matches);
+                    }
+                } catch (SQLException e) {
+                    if (searchBeamSize != null) {
+                        try { conn.rollback(); } catch (SQLException ignore) { /* best-effort */ }
+                    }
+                    throw e;
+                }
+            }
+        });
+    }
+
+    @Override
+    public void removeAll(Collection<String> ids) {
+        if (ids == null || ids.isEmpty()) {
+            throw new IllegalArgumentException("ids cannot be null or empty");
+        }
+        String sql = String.format(
+                "DELETE FROM %s WHERE %s = ?%s",
+                schema.getFullTableName(), schema.getIdColumn(),
+                namespaceClause() == null ? "" : " AND " + namespaceClause());
+
+        RetryUtils.withRetry(() -> {
+            try (Connection conn = engine.getConnection();
+                 PreparedStatement st = conn.prepareStatement(sql)) {
+                for (String id : ids) {
+                    st.setObject(1, UUID.fromString(id));
+                    st.addBatch();
+                }
+                st.executeBatch();
+                return null;
+            }
+        });
+    }
+
+    @Override
+    public void removeAll(Filter filter) {
+        if (filter == null) {
+            throw new IllegalArgumentException("filter cannot be null");
+        }
+        StringBuilder sql = new StringBuilder("DELETE FROM ").append(schema.getFullTableName())
+                .append(" WHERE ").append(filterMapper.map(filter));
+        if (namespaceClause() != null) sql.append(" AND ").append(namespaceClause());
+
+        RetryUtils.withRetry(() -> {
+            try (Connection conn = engine.getConnection();
+                 Statement st = conn.createStatement()) {
+                st.executeUpdate(sql.toString());
+                return null;
+            }
+        });
+    }
+
+    @Override
+    public void removeAll() {
+        String sql;
+        if (namespaceClause() != null) {
+            sql = "DELETE FROM " + schema.getFullTableName() + " WHERE " + namespaceClause();
+        } else {
+            sql = "DELETE FROM " + schema.getFullTableName();
+        }
+        RetryUtils.withRetry(() -> {
+            try (Connection conn = engine.getConnection();
+                 Statement st = conn.createStatement()) {
+                st.executeUpdate(sql);
+                return null;
+            }
+        });
+    }
+
+    public void createTableIfNotExists() {
+        RetryUtils.withRetry(() -> {
+            try (Connection conn = engine.getConnection();
+                 Statement st = conn.createStatement()) {
+                st.execute(schema.getCreateTableSql());
+
+                String nsIdx = schema.getCreateNamespaceIndexSql();
+                if (nsIdx != null) st.execute(nsIdx);
+
+                String tsAlter = schema.getAddTsvectorColumnSql();
+                if (tsAlter != null) {
+                    st.execute(tsAlter);
+                    st.execute(schema.getCreateTsvectorIndexSql());
+                }
+
+                String vecIdx = schema.getCreateVectorIndexSql();
+                if (vecIdx != null) {
+                    logger.info("Creating vector index: {}", vecIdx);
+                    st.execute(vecIdx);
+                }
+                return null;
+            }
+        });
+    }
+
+    private void addInternal(String id, Embedding embedding, TextSegment segment) {
+        addAllInternal(singletonList(id), singletonList(embedding),
+                segment != null ? singletonList(segment) : null);
+    }
+
+    private void addAllInternal(List<String> ids, List<Embedding> embeddings, List<TextSegment> segments) {
+        if (ids.isEmpty()) return;
+
+        StringBuilder columns = new StringBuilder()
+                .append(schema.getIdColumn()).append(", ");
+        if (schema.hasNamespace()) columns.append(schema.getNamespaceColumn()).append(", ");
+        columns.append(schema.getContentColumn()).append(", ")
+                .append(schema.getEmbeddingColumn()).append(", ")
+                .append(schema.getMetadataColumn());
+
+        StringBuilder placeholders = new StringBuilder("?");
+        if (schema.hasNamespace()) placeholders.append(", ?");
+        placeholders.append(", ?, ?::vector, ?::jsonb");
+
+        StringBuilder updateSet = new StringBuilder()
+                .append(schema.getContentColumn()).append(" = EXCLUDED.").append(schema.getContentColumn())
+                .append(", ").append(schema.getEmbeddingColumn()).append(" = EXCLUDED.").append(schema.getEmbeddingColumn())
+                .append(", ").append(schema.getMetadataColumn()).append(" = EXCLUDED.").append(schema.getMetadataColumn());
+        if (schema.hasNamespace()) {
+            updateSet.append(", ").append(schema.getNamespaceColumn())
+                    .append(" = EXCLUDED.").append(schema.getNamespaceColumn());
+        }
+
+        String sql = String.format(
+                "INSERT INTO %s (%s) VALUES (%s) ON CONFLICT (%s) DO UPDATE SET %s",
+                schema.getFullTableName(), columns, placeholders, schema.getIdColumn(), updateSet);
+
+        String resolvedNamespace = namespace != null ? namespace : "";
+
+        RetryUtils.withRetry(() -> {
+            try (Connection conn = engine.getConnection();
+                 PreparedStatement st = conn.prepareStatement(sql)) {
+                for (int i = 0; i < ids.size(); i++) {
+                    TextSegment seg = segments != null ? segments.get(i) : null;
+                    Metadata metadata = seg != null ? seg.metadata() : new Metadata();
+                    String content = seg != null ? seg.text() : null;
+
+                    int p = 1;
+                    st.setObject(p++, UUID.fromString(ids.get(i)));
+                    if (schema.hasNamespace()) st.setString(p++, resolvedNamespace);
+                    st.setString(p++, content);
+                    st.setString(p++, toVectorLiteral(embeddings.get(i)));
+                    st.setString(p, toJson(metadata));
+                    st.addBatch();
+                }
+                st.executeBatch();
+                return null;
+            }
+        });
+    }
+
+    private String namespaceClause() {
+        if (namespace == null || !schema.hasNamespace()) return null;
+        return schema.getNamespaceColumn() + " = '" + namespace.replace("'", "''") + "'";
+    }
+
+    /**
+     * Serialize the embedding to CockroachDB's text form: {@code "[v1,v2,...]"}.
+     * <p>CockroachDB's pgwire layer does not accept the binary format for the VECTOR
+     * type, so all vectors are sent as text and cast to {@code ?::vector} in SQL.
+     */
+    private static String toVectorLiteral(Embedding embedding) {
+        List<Float> list = embedding.vectorAsList();
+        StringBuilder sb = new StringBuilder(list.size() * 12).append('[');
+        for (int i = 0; i < list.size(); i++) {
+            if (i > 0) sb.append(',');
+            sb.append(list.get(i).floatValue());
+        }
+        return sb.append(']').toString();
+    }
+
+    private static Embedding extractEmbedding(ResultSet rs, String column) throws SQLException {
+        Object o = rs.getObject(column);
+        if (o == null) return null;
+        String s = o.toString().trim();
+        if (s.startsWith("[") && s.endsWith("]")) s = s.substring(1, s.length() - 1);
+        String[] parts = s.split(",");
+        float[] arr = new float[parts.length];
+        for (int i = 0; i < parts.length; i++) arr[i] = Float.parseFloat(parts[i].trim());
+        return Embedding.from(arr);
+    }
+
+    private static String toJson(Metadata metadata) {
+        Map<String, Object> map = metadata == null ? new HashMap<>() : new HashMap<>(metadata.toMap());
+        try {
+            return JSON.writeValueAsString(map);
+        } catch (JsonProcessingException e) {
+            throw new CockroachDbRequestFailedException("Failed to serialize metadata", e);
+        }
+    }
+
+    private static Metadata readMetadata(ResultSet rs, String column) throws SQLException {
+        String raw = rs.getString(column);
+        if (raw == null || raw.isEmpty()) return new Metadata();
+        try {
+            Map<String, Object> map = JSON.readValue(raw, Map.class);
+            return Metadata.from(map);
+        } catch (JsonProcessingException e) {
+            throw new CockroachDbRequestFailedException("Failed to deserialize metadata: " + raw, e);
+        }
+    }
+
+    private double scoreFromDistance(double distance) {
+        switch (schema.getMetricType()) {
+            case COSINE:
+                return RelevanceScore.fromCosineSimilarity(1.0 - distance);
+            case EUCLIDEAN:
+                return RelevanceScore.fromCosineSimilarity(1.0 / (1.0 + distance));
+            case DOT_PRODUCT:
+                // pgvector / CRDB return negative inner product
+                return Math.abs(distance) + 1.0;
+            default:
+                return RelevanceScore.fromCosineSimilarity(1.0 - distance);
+        }
+    }
+
+    public static class Builder {
+        private CockroachDbEngine engine;
+        private CockroachDbSchema schema;
+        private String namespace;
+        private Integer searchBeamSize;
+        private CockroachDbSchema.Builder schemaBuilder;
+
+        public Builder engine(CockroachDbEngine engine) {
+            this.engine = engine;
+            return this;
+        }
+
+        public Builder schema(CockroachDbSchema schema) {
+            this.schema = schema;
+            return this;
+        }
+
+        /**
+         * Tenant value to set on writes and filter on reads. Requires that the
+         * underlying {@link CockroachDbSchema} has a {@code namespaceColumn} configured.
+         */
+        public Builder namespace(String namespace) {
+            this.namespace = namespace;
+            return this;
+        }
+
+        /**
+         * Override CockroachDB's per-query {@code vector_search_beam_size} session
+         * variable. Only meaningful when the vector index is C-SPANN. When set,
+         * each search runs inside an explicit transaction to scope the {@code SET LOCAL}.
+         */
+        public Builder searchBeamSize(Integer searchBeamSize) {
+            this.searchBeamSize = searchBeamSize;
+            return this;
+        }
+
+        public Builder dimension(Integer dimension) {
+            ensureSchemaBuilder().dimension(dimension);
+            return this;
+        }
+
+        public Builder tableName(String tableName) {
+            ensureSchemaBuilder().tableName(tableName);
+            return this;
+        }
+
+        public Builder schemaName(String schemaName) {
+            ensureSchemaBuilder().schemaName(schemaName);
+            return this;
+        }
+
+        public Builder metricType(MetricType metricType) {
+            ensureSchemaBuilder().metricType(metricType);
+            return this;
+        }
+
+        public Builder vectorIndex(BaseIndex vectorIndex) {
+            ensureSchemaBuilder().vectorIndex(vectorIndex);
+            return this;
+        }
+
+        public Builder namespaceColumn(String namespaceColumn) {
+            ensureSchemaBuilder().namespaceColumn(namespaceColumn);
+            return this;
+        }
+
+        public Builder createTsvectorColumn(boolean enable) {
+            ensureSchemaBuilder().createTsvectorColumn(enable);
+            return this;
+        }
+
+        public Builder createTableIfNotExists(boolean create) {
+            ensureSchemaBuilder().createTableIfNotExists(create);
+            return this;
+        }
+
+        private CockroachDbSchema.Builder ensureSchemaBuilder() {
+            if (schemaBuilder == null) schemaBuilder = CockroachDbSchema.builder();
+            return schemaBuilder;
+        }
+
+        public CockroachDbEmbeddingStore build() {
+            if (engine == null) {
+                throw new IllegalArgumentException("CockroachDbEngine is required");
+            }
+            if (schema == null) {
+                if (schemaBuilder == null) {
+                    throw new IllegalArgumentException("Either schema or dimension must be specified");
+                }
+                schema = schemaBuilder.build();
+            }
+            if (namespace != null && !schema.hasNamespace()) {
+                throw new IllegalArgumentException(
+                        "namespace was set on the store but the schema has no namespaceColumn configured");
+            }
+            return new CockroachDbEmbeddingStore(this);
+        }
+    }
+}

--- a/embedding-stores/langchain4j-community-cockroachdb/src/main/java/dev/langchain4j/community/store/embedding/cockroachdb/CockroachDbEmbeddingStore.java
+++ b/embedding-stores/langchain4j-community-cockroachdb/src/main/java/dev/langchain4j/community/store/embedding/cockroachdb/CockroachDbEmbeddingStore.java
@@ -81,6 +81,52 @@ public class CockroachDbEmbeddingStore implements EmbeddingStore<TextSegment> {
         return new Builder();
     }
 
+    /**
+     * Serialize the embedding to CockroachDB's text form: {@code "[v1,v2,...]"}.
+     * <p>CockroachDB's pgwire layer does not accept the binary format for the VECTOR
+     * type, so all vectors are sent as text and cast to {@code ?::vector} in SQL.
+     */
+    private static String toVectorLiteral(Embedding embedding) {
+        List<Float> list = embedding.vectorAsList();
+        StringBuilder sb = new StringBuilder(list.size() * 12).append('[');
+        for (int i = 0; i < list.size(); i++) {
+            if (i > 0) sb.append(',');
+            sb.append(list.get(i).floatValue());
+        }
+        return sb.append(']').toString();
+    }
+
+    private static Embedding extractEmbedding(ResultSet rs, String column) throws SQLException {
+        Object o = rs.getObject(column);
+        if (o == null) return null;
+        String s = o.toString().trim();
+        if (s.startsWith("[") && s.endsWith("]")) s = s.substring(1, s.length() - 1);
+        String[] parts = s.split(",");
+        float[] arr = new float[parts.length];
+        for (int i = 0; i < parts.length; i++) arr[i] = Float.parseFloat(parts[i].trim());
+        return Embedding.from(arr);
+    }
+
+    private static String toJson(Metadata metadata) {
+        Map<String, Object> map = metadata == null ? new HashMap<>() : new HashMap<>(metadata.toMap());
+        try {
+            return JSON.writeValueAsString(map);
+        } catch (JsonProcessingException e) {
+            throw new CockroachDbRequestFailedException("Failed to serialize metadata", e);
+        }
+    }
+
+    private static Metadata readMetadata(ResultSet rs, String column) throws SQLException {
+        String raw = rs.getString(column);
+        if (raw == null || raw.isEmpty()) return new Metadata();
+        try {
+            Map<String, Object> map = JSON.readValue(raw, Map.class);
+            return Metadata.from(map);
+        } catch (JsonProcessingException e) {
+            throw new CockroachDbRequestFailedException("Failed to deserialize metadata: " + raw, e);
+        }
+    }
+
     @Override
     public String add(Embedding embedding) {
         String id = randomUUID();
@@ -369,52 +415,6 @@ public class CockroachDbEmbeddingStore implements EmbeddingStore<TextSegment> {
     private String namespaceClause() {
         if (namespace == null || !schema.hasNamespace()) return null;
         return schema.getNamespaceColumn() + " = '" + namespace.replace("'", "''") + "'";
-    }
-
-    /**
-     * Serialize the embedding to CockroachDB's text form: {@code "[v1,v2,...]"}.
-     * <p>CockroachDB's pgwire layer does not accept the binary format for the VECTOR
-     * type, so all vectors are sent as text and cast to {@code ?::vector} in SQL.
-     */
-    private static String toVectorLiteral(Embedding embedding) {
-        List<Float> list = embedding.vectorAsList();
-        StringBuilder sb = new StringBuilder(list.size() * 12).append('[');
-        for (int i = 0; i < list.size(); i++) {
-            if (i > 0) sb.append(',');
-            sb.append(list.get(i).floatValue());
-        }
-        return sb.append(']').toString();
-    }
-
-    private static Embedding extractEmbedding(ResultSet rs, String column) throws SQLException {
-        Object o = rs.getObject(column);
-        if (o == null) return null;
-        String s = o.toString().trim();
-        if (s.startsWith("[") && s.endsWith("]")) s = s.substring(1, s.length() - 1);
-        String[] parts = s.split(",");
-        float[] arr = new float[parts.length];
-        for (int i = 0; i < parts.length; i++) arr[i] = Float.parseFloat(parts[i].trim());
-        return Embedding.from(arr);
-    }
-
-    private static String toJson(Metadata metadata) {
-        Map<String, Object> map = metadata == null ? new HashMap<>() : new HashMap<>(metadata.toMap());
-        try {
-            return JSON.writeValueAsString(map);
-        } catch (JsonProcessingException e) {
-            throw new CockroachDbRequestFailedException("Failed to serialize metadata", e);
-        }
-    }
-
-    private static Metadata readMetadata(ResultSet rs, String column) throws SQLException {
-        String raw = rs.getString(column);
-        if (raw == null || raw.isEmpty()) return new Metadata();
-        try {
-            Map<String, Object> map = JSON.readValue(raw, Map.class);
-            return Metadata.from(map);
-        } catch (JsonProcessingException e) {
-            throw new CockroachDbRequestFailedException("Failed to deserialize metadata: " + raw, e);
-        }
     }
 
     private double scoreFromDistance(double distance) {

--- a/embedding-stores/langchain4j-community-cockroachdb/src/main/java/dev/langchain4j/community/store/embedding/cockroachdb/CockroachDbEngine.java
+++ b/embedding-stores/langchain4j-community-cockroachdb/src/main/java/dev/langchain4j/community/store/embedding/cockroachdb/CockroachDbEngine.java
@@ -1,0 +1,216 @@
+package dev.langchain4j.community.store.embedding.cockroachdb;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
+import javax.sql.DataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * CockroachDbEngine is a thin wrapper around a {@link DataSource} that provides
+ * pooled connections for the CockroachDB embedding store and chat memory store.
+ *
+ * <p>The {@link Builder} accepts the canonical Postgres-wire host/port/db/user/password
+ * tuple. If you already have a {@link DataSource}, use {@link #from(DataSource)}.
+ *
+ * <p>If you only have a connection string, use {@link #fromConnectionString(String)}.
+ * The {@code cockroachdb://} scheme used by the Python library is rewritten to
+ * {@code jdbc:postgresql://}. {@code postgresql://} and {@code postgres://} are
+ * also accepted and rewritten. JDBC-prefixed URLs are passed through unchanged.
+ */
+public class CockroachDbEngine {
+
+    private static final Logger logger = LoggerFactory.getLogger(CockroachDbEngine.class);
+
+    private final DataSource dataSource;
+
+    public CockroachDbEngine(DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static CockroachDbEngine from(DataSource dataSource) {
+        return new CockroachDbEngine(dataSource);
+    }
+
+    public static CockroachDbEngine fromConnectionString(String connectionString) {
+        return new Builder().connectionString(connectionString).build();
+    }
+
+    public Connection getConnection() {
+        try {
+            return dataSource.getConnection();
+        } catch (SQLException e) {
+            throw new CockroachDbRequestFailedException("Failed to get CockroachDB connection", e);
+        }
+    }
+
+    public DataSource getDataSource() {
+        return dataSource;
+    }
+
+    public void close() {
+        if (dataSource instanceof HikariDataSource hikari) {
+            hikari.close();
+        }
+    }
+
+    /**
+     * Convert a Python-style {@code cockroachdb://} or libpq-style {@code postgresql://}
+     * URL into the {@code jdbc:postgresql://} form expected by the PgJDBC driver.
+     */
+    static String toJdbcUrl(String url) {
+        if (url == null || url.isEmpty()) {
+            throw new IllegalArgumentException("connection string must not be empty");
+        }
+        if (url.startsWith("jdbc:")) {
+            return url;
+        }
+        if (url.startsWith("cockroachdb+psycopg://")) {
+            return "jdbc:postgresql://" + url.substring("cockroachdb+psycopg://".length());
+        }
+        if (url.startsWith("cockroachdb://")) {
+            return "jdbc:postgresql://" + url.substring("cockroachdb://".length());
+        }
+        if (url.startsWith("postgresql://")) {
+            return "jdbc:postgresql://" + url.substring("postgresql://".length());
+        }
+        if (url.startsWith("postgres://")) {
+            return "jdbc:postgresql://" + url.substring("postgres://".length());
+        }
+        throw new IllegalArgumentException("Unsupported connection-string scheme: " + url);
+    }
+
+    public static class Builder {
+        private String connectionString;
+        private String host = "localhost";
+        private Integer port = 26257;
+        private String database = "defaultdb";
+        private String username = "root";
+        private String password = "";
+        private String schema = "public";
+        private String sslMode = "disable";
+        private String applicationName = "langchain4j-cockroachdb";
+        private Integer maxPoolSize = 10;
+        private Integer minPoolSize = 5;
+        private long connectionTimeoutMs = 10_000L;
+        private long idleTimeoutMs = 300_000L;
+        private long maxLifetimeMs = 3_600_000L;
+
+        public Builder connectionString(String connectionString) {
+            this.connectionString = connectionString;
+            return this;
+        }
+
+        public Builder host(String host) {
+            this.host = host;
+            return this;
+        }
+
+        public Builder port(Integer port) {
+            this.port = port;
+            return this;
+        }
+
+        public Builder database(String database) {
+            this.database = database;
+            return this;
+        }
+
+        public Builder username(String username) {
+            this.username = username;
+            return this;
+        }
+
+        public Builder password(String password) {
+            this.password = password;
+            return this;
+        }
+
+        public Builder schema(String schema) {
+            this.schema = schema;
+            return this;
+        }
+
+        public Builder sslMode(String sslMode) {
+            this.sslMode = sslMode;
+            return this;
+        }
+
+        public Builder applicationName(String applicationName) {
+            this.applicationName = applicationName;
+            return this;
+        }
+
+        public Builder maxPoolSize(Integer maxPoolSize) {
+            this.maxPoolSize = maxPoolSize;
+            return this;
+        }
+
+        public Builder minPoolSize(Integer minPoolSize) {
+            this.minPoolSize = minPoolSize;
+            return this;
+        }
+
+        public Builder connectionTimeoutMs(long connectionTimeoutMs) {
+            this.connectionTimeoutMs = connectionTimeoutMs;
+            return this;
+        }
+
+        public Builder idleTimeoutMs(long idleTimeoutMs) {
+            this.idleTimeoutMs = idleTimeoutMs;
+            return this;
+        }
+
+        public Builder maxLifetimeMs(long maxLifetimeMs) {
+            this.maxLifetimeMs = maxLifetimeMs;
+            return this;
+        }
+
+        public CockroachDbEngine build() {
+            HikariConfig config = new HikariConfig();
+
+            String jdbcUrl;
+            if (connectionString != null && !connectionString.isEmpty()) {
+                jdbcUrl = toJdbcUrl(connectionString);
+            } else {
+                jdbcUrl = String.format(
+                        "jdbc:postgresql://%s:%d/%s?currentSchema=%s&sslmode=%s&ApplicationName=%s",
+                        host, port, database, schema, sslMode, applicationName);
+            }
+            config.setJdbcUrl(jdbcUrl);
+            // Apply credentials regardless of which URL path was used so that callers can
+            // pass a connection string plus username/password (the common Testcontainers shape).
+            if (username != null) {
+                config.setUsername(username);
+            }
+            if (password != null) {
+                config.setPassword(password);
+            }
+            config.setDriverClassName("org.postgresql.Driver");
+
+            config.setMaximumPoolSize(maxPoolSize);
+            config.setMinimumIdle(minPoolSize);
+            config.setConnectionTimeout(connectionTimeoutMs);
+            config.setIdleTimeout(idleTimeoutMs);
+            config.setMaxLifetime(maxLifetimeMs);
+
+            // PgJDBC defaults to prepareThreshold=5 already; left as default.
+            config.addDataSourceProperty("tcpKeepAlive", "true");
+            config.addDataSourceProperty("reWriteBatchedInserts", "true");
+
+            logger.info("Initializing CockroachDB connection pool: {}", jdbcUrl);
+
+            try {
+                return new CockroachDbEngine(new HikariDataSource(config));
+            } catch (Exception e) {
+                throw new CockroachDbRequestFailedException("Failed to create CockroachDB connection pool", e);
+            }
+        }
+    }
+}

--- a/embedding-stores/langchain4j-community-cockroachdb/src/main/java/dev/langchain4j/community/store/embedding/cockroachdb/CockroachDbEngine.java
+++ b/embedding-stores/langchain4j-community-cockroachdb/src/main/java/dev/langchain4j/community/store/embedding/cockroachdb/CockroachDbEngine.java
@@ -95,7 +95,6 @@ public class CockroachDbEngine {
         private String password = "";
         private String schema = "public";
         private String sslMode = "disable";
-        private String applicationName = "langchain4j-cockroachdb";
         private Integer maxPoolSize = 10;
         private Integer minPoolSize = 5;
         private long connectionTimeoutMs = 10_000L;
@@ -142,11 +141,6 @@ public class CockroachDbEngine {
             return this;
         }
 
-        public Builder applicationName(String applicationName) {
-            this.applicationName = applicationName;
-            return this;
-        }
-
         public Builder maxPoolSize(Integer maxPoolSize) {
             this.maxPoolSize = maxPoolSize;
             return this;
@@ -180,8 +174,8 @@ public class CockroachDbEngine {
                 jdbcUrl = toJdbcUrl(connectionString);
             } else {
                 jdbcUrl = String.format(
-                        "jdbc:postgresql://%s:%d/%s?currentSchema=%s&sslmode=%s&ApplicationName=%s",
-                        host, port, database, schema, sslMode, applicationName);
+                        "jdbc:postgresql://%s:%d/%s?currentSchema=%s&sslmode=%s",
+                        host, port, database, schema, sslMode);
             }
             config.setJdbcUrl(jdbcUrl);
             // Apply credentials regardless of which URL path was used so that callers can

--- a/embedding-stores/langchain4j-community-cockroachdb/src/main/java/dev/langchain4j/community/store/embedding/cockroachdb/CockroachDbEngine.java
+++ b/embedding-stores/langchain4j-community-cockroachdb/src/main/java/dev/langchain4j/community/store/embedding/cockroachdb/CockroachDbEngine.java
@@ -20,15 +20,9 @@ import org.slf4j.LoggerFactory;
  * {@code jdbc:postgresql://}. {@code postgresql://} and {@code postgres://} are
  * also accepted and rewritten. JDBC-prefixed URLs are passed through unchanged.
  */
-public class CockroachDbEngine {
+public record CockroachDbEngine(DataSource dataSource) {
 
     private static final Logger logger = LoggerFactory.getLogger(CockroachDbEngine.class);
-
-    private final DataSource dataSource;
-
-    public CockroachDbEngine(DataSource dataSource) {
-        this.dataSource = dataSource;
-    }
 
     public static Builder builder() {
         return new Builder();
@@ -40,24 +34,6 @@ public class CockroachDbEngine {
 
     public static CockroachDbEngine fromConnectionString(String connectionString) {
         return new Builder().connectionString(connectionString).build();
-    }
-
-    public Connection getConnection() {
-        try {
-            return dataSource.getConnection();
-        } catch (SQLException e) {
-            throw new CockroachDbRequestFailedException("Failed to get CockroachDB connection", e);
-        }
-    }
-
-    public DataSource getDataSource() {
-        return dataSource;
-    }
-
-    public void close() {
-        if (dataSource instanceof HikariDataSource hikari) {
-            hikari.close();
-        }
     }
 
     /**
@@ -84,6 +60,20 @@ public class CockroachDbEngine {
             return "jdbc:postgresql://" + url.substring("postgres://".length());
         }
         throw new IllegalArgumentException("Unsupported connection-string scheme: " + url);
+    }
+
+    public Connection getConnection() {
+        try {
+            return dataSource.getConnection();
+        } catch (SQLException e) {
+            throw new CockroachDbRequestFailedException("Failed to get CockroachDB connection", e);
+        }
+    }
+
+    public void close() {
+        if (dataSource instanceof HikariDataSource hikari) {
+            hikari.close();
+        }
     }
 
     public static class Builder {

--- a/embedding-stores/langchain4j-community-cockroachdb/src/main/java/dev/langchain4j/community/store/embedding/cockroachdb/CockroachDbFilterMapper.java
+++ b/embedding-stores/langchain4j-community-cockroachdb/src/main/java/dev/langchain4j/community/store/embedding/cockroachdb/CockroachDbFilterMapper.java
@@ -61,20 +61,20 @@ class CockroachDbFilterMapper {
             return format("%s is null or %s != %s", key, key, formatValue(f.comparisonValue()));
         }
         if (filter instanceof IsGreaterThan f) {
-            return format("%s > %s", formatKey(f.key(), f.comparisonValue().getClass()),
-                    formatValue(f.comparisonValue()));
+            return format(
+                    "%s > %s", formatKey(f.key(), f.comparisonValue().getClass()), formatValue(f.comparisonValue()));
         }
         if (filter instanceof IsGreaterThanOrEqualTo f) {
-            return format("%s >= %s", formatKey(f.key(), f.comparisonValue().getClass()),
-                    formatValue(f.comparisonValue()));
+            return format(
+                    "%s >= %s", formatKey(f.key(), f.comparisonValue().getClass()), formatValue(f.comparisonValue()));
         }
         if (filter instanceof IsLessThan f) {
-            return format("%s < %s", formatKey(f.key(), f.comparisonValue().getClass()),
-                    formatValue(f.comparisonValue()));
+            return format(
+                    "%s < %s", formatKey(f.key(), f.comparisonValue().getClass()), formatValue(f.comparisonValue()));
         }
         if (filter instanceof IsLessThanOrEqualTo f) {
-            return format("%s <= %s", formatKey(f.key(), f.comparisonValue().getClass()),
-                    formatValue(f.comparisonValue()));
+            return format(
+                    "%s <= %s", formatKey(f.key(), f.comparisonValue().getClass()), formatValue(f.comparisonValue()));
         }
         if (filter instanceof IsIn f) {
             return format("%s in %s", formatKeyAsString(f.key()), formatValues(f.comparisonValues()));
@@ -134,8 +134,8 @@ class CockroachDbFilterMapper {
         }
         String clean = key.trim();
         if (!clean.matches("^[a-zA-Z0-9_.\\-]+$")) {
-            throw new IllegalArgumentException("Invalid filter key '" + clean
-                    + "'. Only alphanumeric, underscore, dot and hyphen are allowed.");
+            throw new IllegalArgumentException(
+                    "Invalid filter key '" + clean + "'. Only alphanumeric, underscore, dot and hyphen are allowed.");
         }
         return clean;
     }

--- a/embedding-stores/langchain4j-community-cockroachdb/src/main/java/dev/langchain4j/community/store/embedding/cockroachdb/CockroachDbFilterMapper.java
+++ b/embedding-stores/langchain4j-community-cockroachdb/src/main/java/dev/langchain4j/community/store/embedding/cockroachdb/CockroachDbFilterMapper.java
@@ -51,6 +51,18 @@ class CockroachDbFilterMapper {
         this.metadataColumn = metadataColumn.trim();
     }
 
+    private static String sanitize(String key) {
+        if (key == null || key.trim().isEmpty()) {
+            throw new IllegalArgumentException("filter key must not be empty");
+        }
+        String clean = key.trim();
+        if (!clean.matches("^[a-zA-Z0-9_.\\-]+$")) {
+            throw new IllegalArgumentException(
+                    "Invalid filter key '" + clean + "'. Only alphanumeric, underscore, dot and hyphen are allowed.");
+        }
+        return clean;
+    }
+
     String map(Filter filter) {
         if (filter instanceof IsEqualTo f) {
             String key = formatKey(f.key(), f.comparisonValue().getClass());
@@ -126,17 +138,5 @@ class CockroachDbFilterMapper {
                         .map(v -> "'" + String.valueOf(v).replace("'", "''") + "'")
                         .collect(Collectors.joining(","))
                 + ")";
-    }
-
-    private static String sanitize(String key) {
-        if (key == null || key.trim().isEmpty()) {
-            throw new IllegalArgumentException("filter key must not be empty");
-        }
-        String clean = key.trim();
-        if (!clean.matches("^[a-zA-Z0-9_.\\-]+$")) {
-            throw new IllegalArgumentException(
-                    "Invalid filter key '" + clean + "'. Only alphanumeric, underscore, dot and hyphen are allowed.");
-        }
-        return clean;
     }
 }

--- a/embedding-stores/langchain4j-community-cockroachdb/src/main/java/dev/langchain4j/community/store/embedding/cockroachdb/CockroachDbFilterMapper.java
+++ b/embedding-stores/langchain4j-community-cockroachdb/src/main/java/dev/langchain4j/community/store/embedding/cockroachdb/CockroachDbFilterMapper.java
@@ -1,0 +1,142 @@
+package dev.langchain4j.community.store.embedding.cockroachdb;
+
+import static java.lang.String.format;
+
+import dev.langchain4j.store.embedding.filter.Filter;
+import dev.langchain4j.store.embedding.filter.comparison.IsEqualTo;
+import dev.langchain4j.store.embedding.filter.comparison.IsGreaterThan;
+import dev.langchain4j.store.embedding.filter.comparison.IsGreaterThanOrEqualTo;
+import dev.langchain4j.store.embedding.filter.comparison.IsIn;
+import dev.langchain4j.store.embedding.filter.comparison.IsLessThan;
+import dev.langchain4j.store.embedding.filter.comparison.IsLessThanOrEqualTo;
+import dev.langchain4j.store.embedding.filter.comparison.IsNotEqualTo;
+import dev.langchain4j.store.embedding.filter.comparison.IsNotIn;
+import dev.langchain4j.store.embedding.filter.logical.And;
+import dev.langchain4j.store.embedding.filter.logical.Not;
+import dev.langchain4j.store.embedding.filter.logical.Or;
+import java.util.Collection;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+/**
+ * Translates LangChain4j {@link Filter}s into CockroachDB WHERE-clause fragments
+ * against a JSONB metadata column.
+ *
+ * <p>Numeric comparisons use {@code (metadata->>'key')::numeric}; string equality
+ * uses {@code metadata->>'key' = '…'}; {@code IN} uses {@code metadata->>'key' IN ('…','…')}.
+ * Identifiers from filter keys are sanitised to alphanumeric + {@code . _ -}.
+ *
+ * <p>This implementation inlines values into the SQL string (similar to the Python
+ * reference library). Filter values come from application code, not user input, but
+ * key sanitisation is enforced regardless.
+ */
+class CockroachDbFilterMapper {
+
+    private static final Map<Class<?>, String> SQL_TYPE_MAP = Map.of(
+            Integer.class, "int",
+            Long.class, "bigint",
+            Float.class, "float",
+            Double.class, "float8",
+            String.class, "text",
+            UUID.class, "uuid",
+            Boolean.class, "boolean");
+
+    private final String metadataColumn;
+
+    CockroachDbFilterMapper(String metadataColumn) {
+        if (metadataColumn == null || metadataColumn.trim().isEmpty()) {
+            throw new IllegalArgumentException("metadataColumn must not be empty");
+        }
+        this.metadataColumn = metadataColumn.trim();
+    }
+
+    String map(Filter filter) {
+        if (filter instanceof IsEqualTo f) {
+            String key = formatKey(f.key(), f.comparisonValue().getClass());
+            return format("%s is not null and %s = %s", key, key, formatValue(f.comparisonValue()));
+        }
+        if (filter instanceof IsNotEqualTo f) {
+            String key = formatKey(f.key(), f.comparisonValue().getClass());
+            return format("%s is null or %s != %s", key, key, formatValue(f.comparisonValue()));
+        }
+        if (filter instanceof IsGreaterThan f) {
+            return format("%s > %s", formatKey(f.key(), f.comparisonValue().getClass()),
+                    formatValue(f.comparisonValue()));
+        }
+        if (filter instanceof IsGreaterThanOrEqualTo f) {
+            return format("%s >= %s", formatKey(f.key(), f.comparisonValue().getClass()),
+                    formatValue(f.comparisonValue()));
+        }
+        if (filter instanceof IsLessThan f) {
+            return format("%s < %s", formatKey(f.key(), f.comparisonValue().getClass()),
+                    formatValue(f.comparisonValue()));
+        }
+        if (filter instanceof IsLessThanOrEqualTo f) {
+            return format("%s <= %s", formatKey(f.key(), f.comparisonValue().getClass()),
+                    formatValue(f.comparisonValue()));
+        }
+        if (filter instanceof IsIn f) {
+            return format("%s in %s", formatKeyAsString(f.key()), formatValues(f.comparisonValues()));
+        }
+        if (filter instanceof IsNotIn f) {
+            String key = formatKeyAsString(f.key());
+            return format("(%s is null or %s not in %s)", key, key, formatValues(f.comparisonValues()));
+        }
+        if (filter instanceof And a) {
+            return format("(%s and %s)", map(a.left()), map(a.right()));
+        }
+        if (filter instanceof Or o) {
+            return format("(%s or %s)", map(o.left()), map(o.right()));
+        }
+        if (filter instanceof Not n) {
+            return format("not(%s)", map(n.expression()));
+        }
+        throw new UnsupportedOperationException(
+                "Unsupported filter type: " + filter.getClass().getName());
+    }
+
+    private String formatKey(String key, Class<?> valueType) {
+        String sqlType = SQL_TYPE_MAP.getOrDefault(valueType, "text");
+        return format("(%s->>'%s')::%s", metadataColumn, sanitize(key), sqlType);
+    }
+
+    private String formatKeyAsString(String key) {
+        return format("%s->>'%s'", metadataColumn, sanitize(key));
+    }
+
+    private String formatValue(Object value) {
+        if (value instanceof String s) {
+            return "'" + s.replace("'", "''") + "'";
+        }
+        if (value instanceof UUID) {
+            return "'" + value + "'";
+        }
+        return value.toString();
+    }
+
+    /**
+     * Always quote IN/NOT IN values as text because the left-hand side comes from
+     * {@code metadata->>'key'} which is {@code text} in CockroachDB. A bare integer
+     * literal on the right-hand side raises "unsupported comparison operator".
+     */
+    private String formatValues(Collection<?> values) {
+        return "("
+                + values.stream()
+                        .map(v -> "'" + String.valueOf(v).replace("'", "''") + "'")
+                        .collect(Collectors.joining(","))
+                + ")";
+    }
+
+    private static String sanitize(String key) {
+        if (key == null || key.trim().isEmpty()) {
+            throw new IllegalArgumentException("filter key must not be empty");
+        }
+        String clean = key.trim();
+        if (!clean.matches("^[a-zA-Z0-9_.\\-]+$")) {
+            throw new IllegalArgumentException("Invalid filter key '" + clean
+                    + "'. Only alphanumeric, underscore, dot and hyphen are allowed.");
+        }
+        return clean;
+    }
+}

--- a/embedding-stores/langchain4j-community-cockroachdb/src/main/java/dev/langchain4j/community/store/embedding/cockroachdb/CockroachDbRequestFailedException.java
+++ b/embedding-stores/langchain4j-community-cockroachdb/src/main/java/dev/langchain4j/community/store/embedding/cockroachdb/CockroachDbRequestFailedException.java
@@ -1,0 +1,12 @@
+package dev.langchain4j.community.store.embedding.cockroachdb;
+
+public class CockroachDbRequestFailedException extends RuntimeException {
+
+    public CockroachDbRequestFailedException(String message) {
+        super(message);
+    }
+
+    public CockroachDbRequestFailedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/embedding-stores/langchain4j-community-cockroachdb/src/main/java/dev/langchain4j/community/store/embedding/cockroachdb/CockroachDbSchema.java
+++ b/embedding-stores/langchain4j-community-cockroachdb/src/main/java/dev/langchain4j/community/store/embedding/cockroachdb/CockroachDbSchema.java
@@ -232,7 +232,9 @@ public class CockroachDbSchema {
             return this;
         }
 
-        /** Pass non-null to scope rows by tenant; pass {@link #DEFAULT_NAMESPACE_COLUMN} for the conventional name. */
+        /**
+         * Pass non-null to scope rows by tenant; pass {@link #DEFAULT_NAMESPACE_COLUMN} for the conventional name.
+         */
         public Builder namespaceColumn(String namespaceColumn) {
             this.namespaceColumn = namespaceColumn;
             return this;
@@ -258,7 +260,9 @@ public class CockroachDbSchema {
             return this;
         }
 
-        /** Adds a generated TSVECTOR column + GIN index for future hybrid search. */
+        /**
+         * Adds a generated TSVECTOR column + GIN index for future hybrid search.
+         */
         public Builder createTsvectorColumn(boolean createTsvectorColumn) {
             this.createTsvectorColumn = createTsvectorColumn;
             return this;

--- a/embedding-stores/langchain4j-community-cockroachdb/src/main/java/dev/langchain4j/community/store/embedding/cockroachdb/CockroachDbSchema.java
+++ b/embedding-stores/langchain4j-community-cockroachdb/src/main/java/dev/langchain4j/community/store/embedding/cockroachdb/CockroachDbSchema.java
@@ -1,0 +1,268 @@
+package dev.langchain4j.community.store.embedding.cockroachdb;
+
+import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+import static dev.langchain4j.internal.ValidationUtils.ensureTrue;
+
+import dev.langchain4j.community.store.embedding.cockroachdb.index.BaseIndex;
+import dev.langchain4j.community.store.embedding.cockroachdb.index.NoIndex;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Schema configuration for a CockroachDB embedding table.
+ *
+ * <p>Defaults match the column layout used by the Python
+ * {@code langchain-cockroachdb} library:
+ *
+ * <pre>
+ *   CREATE TABLE &lt;table&gt; (
+ *     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+ *     [namespace TEXT NOT NULL DEFAULT '',]
+ *     content TEXT,
+ *     embedding VECTOR(&lt;dim&gt;),
+ *     metadata JSONB DEFAULT '{}'::jsonb,
+ *     created_at TIMESTAMPTZ DEFAULT now(),
+ *     [content_tsvector TSVECTOR GENERATED ALWAYS AS (to_tsvector('english', content)) STORED]
+ *   );
+ * </pre>
+ */
+public class CockroachDbSchema {
+
+    public static final String DEFAULT_TABLE_NAME = "embeddings";
+    public static final String DEFAULT_SCHEMA_NAME = "public";
+    public static final String DEFAULT_ID_COLUMN = "id";
+    public static final String DEFAULT_CONTENT_COLUMN = "content";
+    public static final String DEFAULT_EMBEDDING_COLUMN = "embedding";
+    public static final String DEFAULT_METADATA_COLUMN = "metadata";
+    public static final String DEFAULT_NAMESPACE_COLUMN = "namespace";
+
+    private final String tableName;
+    private final String schemaName;
+    private final String idColumn;
+    private final String contentColumn;
+    private final String embeddingColumn;
+    private final String metadataColumn;
+    private final String namespaceColumn; // null disables multi-tenancy
+
+    private final Integer dimension;
+    private final MetricType metricType;
+    private final BaseIndex vectorIndex;
+    private final boolean createTableIfNotExists;
+    private final boolean createTsvectorColumn;
+    private final String tsvectorLanguage;
+
+    private CockroachDbSchema(Builder b) {
+        this.tableName = ensureNotBlank(b.tableName, "tableName");
+        this.schemaName = b.schemaName;
+        this.idColumn = ensureNotBlank(b.idColumn, "idColumn");
+        this.contentColumn = ensureNotBlank(b.contentColumn, "contentColumn");
+        this.embeddingColumn = ensureNotBlank(b.embeddingColumn, "embeddingColumn");
+        this.metadataColumn = ensureNotBlank(b.metadataColumn, "metadataColumn");
+        this.namespaceColumn = b.namespaceColumn;
+        this.dimension = ensureNotNull(b.dimension, "dimension");
+        this.metricType = ensureNotNull(b.metricType, "metricType");
+        this.vectorIndex = b.vectorIndex != null ? b.vectorIndex : new NoIndex();
+        this.createTableIfNotExists = b.createTableIfNotExists;
+        this.createTsvectorColumn = b.createTsvectorColumn;
+        this.tsvectorLanguage = ensureNotBlank(b.tsvectorLanguage, "tsvectorLanguage");
+        ensureTrue(dimension > 0, "dimension must be positive");
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public String getTableName() {
+        return tableName;
+    }
+
+    public String getSchemaName() {
+        return schemaName;
+    }
+
+    public String getIdColumn() {
+        return idColumn;
+    }
+
+    public String getContentColumn() {
+        return contentColumn;
+    }
+
+    public String getEmbeddingColumn() {
+        return embeddingColumn;
+    }
+
+    public String getMetadataColumn() {
+        return metadataColumn;
+    }
+
+    public String getNamespaceColumn() {
+        return namespaceColumn;
+    }
+
+    public boolean hasNamespace() {
+        return namespaceColumn != null && !namespaceColumn.isEmpty();
+    }
+
+    public Integer getDimension() {
+        return dimension;
+    }
+
+    public MetricType getMetricType() {
+        return metricType;
+    }
+
+    public BaseIndex getVectorIndex() {
+        return vectorIndex;
+    }
+
+    public boolean isCreateTableIfNotExists() {
+        return createTableIfNotExists;
+    }
+
+    public boolean isCreateTsvectorColumn() {
+        return createTsvectorColumn;
+    }
+
+    public String getTsvectorLanguage() {
+        return tsvectorLanguage;
+    }
+
+    public String getFullTableName() {
+        return schemaName != null && !schemaName.trim().isEmpty() ? schemaName + "." + tableName : tableName;
+    }
+
+    public String getTsvectorColumn() {
+        return contentColumn + "_tsvector";
+    }
+
+    public String getCreateTableSql() {
+        StringBuilder sql = new StringBuilder()
+                .append("CREATE TABLE IF NOT EXISTS ").append(getFullTableName()).append(" (")
+                .append(idColumn).append(" UUID PRIMARY KEY DEFAULT gen_random_uuid(), ");
+        if (hasNamespace()) {
+            sql.append(namespaceColumn).append(" TEXT NOT NULL DEFAULT '', ");
+        }
+        sql.append(contentColumn).append(" TEXT, ")
+                .append(embeddingColumn).append(" VECTOR(").append(dimension).append("), ")
+                .append(metadataColumn).append(" JSONB DEFAULT '{}'::jsonb, ")
+                .append("created_at TIMESTAMPTZ DEFAULT now()")
+                .append(")");
+        return sql.toString();
+    }
+
+    public String getCreateNamespaceIndexSql() {
+        if (!hasNamespace()) return null;
+        return String.format(
+                "CREATE INDEX IF NOT EXISTS %s_%s_idx ON %s (%s)",
+                tableName, namespaceColumn, getFullTableName(), namespaceColumn);
+    }
+
+    public String getAddTsvectorColumnSql() {
+        if (!createTsvectorColumn) return null;
+        return String.format(
+                "ALTER TABLE %s ADD COLUMN IF NOT EXISTS %s TSVECTOR "
+                        + "GENERATED ALWAYS AS (to_tsvector('%s', %s)) STORED",
+                getFullTableName(), getTsvectorColumn(), tsvectorLanguage, contentColumn);
+    }
+
+    public String getCreateTsvectorIndexSql() {
+        if (!createTsvectorColumn) return null;
+        return String.format(
+                "CREATE INDEX IF NOT EXISTS %s_%s_idx ON %s USING GIN (%s)",
+                tableName, getTsvectorColumn(), getFullTableName(), getTsvectorColumn());
+    }
+
+    public String getCreateVectorIndexSql() {
+        List<String> prefix = hasNamespace() ? Collections.singletonList(namespaceColumn) : Collections.emptyList();
+        return vectorIndex.getCreateIndexSql(getFullTableName(), embeddingColumn, prefix);
+    }
+
+    public static class Builder {
+        private String tableName = DEFAULT_TABLE_NAME;
+        private String schemaName = DEFAULT_SCHEMA_NAME;
+        private String idColumn = DEFAULT_ID_COLUMN;
+        private String contentColumn = DEFAULT_CONTENT_COLUMN;
+        private String embeddingColumn = DEFAULT_EMBEDDING_COLUMN;
+        private String metadataColumn = DEFAULT_METADATA_COLUMN;
+        private String namespaceColumn; // null = disabled
+        private Integer dimension;
+        private MetricType metricType = MetricType.COSINE;
+        private BaseIndex vectorIndex;
+        private boolean createTableIfNotExists = true;
+        private boolean createTsvectorColumn = false;
+        private String tsvectorLanguage = "english";
+
+        public Builder tableName(String tableName) {
+            this.tableName = tableName;
+            return this;
+        }
+
+        public Builder schemaName(String schemaName) {
+            this.schemaName = schemaName;
+            return this;
+        }
+
+        public Builder idColumn(String idColumn) {
+            this.idColumn = idColumn;
+            return this;
+        }
+
+        public Builder contentColumn(String contentColumn) {
+            this.contentColumn = contentColumn;
+            return this;
+        }
+
+        public Builder embeddingColumn(String embeddingColumn) {
+            this.embeddingColumn = embeddingColumn;
+            return this;
+        }
+
+        public Builder metadataColumn(String metadataColumn) {
+            this.metadataColumn = metadataColumn;
+            return this;
+        }
+
+        /** Pass non-null to scope rows by tenant; pass {@link #DEFAULT_NAMESPACE_COLUMN} for the conventional name. */
+        public Builder namespaceColumn(String namespaceColumn) {
+            this.namespaceColumn = namespaceColumn;
+            return this;
+        }
+
+        public Builder dimension(Integer dimension) {
+            this.dimension = dimension;
+            return this;
+        }
+
+        public Builder metricType(MetricType metricType) {
+            this.metricType = metricType;
+            return this;
+        }
+
+        public Builder vectorIndex(BaseIndex vectorIndex) {
+            this.vectorIndex = vectorIndex;
+            return this;
+        }
+
+        public Builder createTableIfNotExists(boolean createTableIfNotExists) {
+            this.createTableIfNotExists = createTableIfNotExists;
+            return this;
+        }
+
+        /** Adds a generated TSVECTOR column + GIN index for future hybrid search. */
+        public Builder createTsvectorColumn(boolean createTsvectorColumn) {
+            this.createTsvectorColumn = createTsvectorColumn;
+            return this;
+        }
+
+        public Builder tsvectorLanguage(String tsvectorLanguage) {
+            this.tsvectorLanguage = tsvectorLanguage;
+            return this;
+        }
+
+        public CockroachDbSchema build() {
+            return new CockroachDbSchema(this);
+        }
+    }
+}

--- a/embedding-stores/langchain4j-community-cockroachdb/src/main/java/dev/langchain4j/community/store/embedding/cockroachdb/CockroachDbSchema.java
+++ b/embedding-stores/langchain4j-community-cockroachdb/src/main/java/dev/langchain4j/community/store/embedding/cockroachdb/CockroachDbSchema.java
@@ -139,14 +139,22 @@ public class CockroachDbSchema {
 
     public String getCreateTableSql() {
         StringBuilder sql = new StringBuilder()
-                .append("CREATE TABLE IF NOT EXISTS ").append(getFullTableName()).append(" (")
-                .append(idColumn).append(" UUID PRIMARY KEY DEFAULT gen_random_uuid(), ");
+                .append("CREATE TABLE IF NOT EXISTS ")
+                .append(getFullTableName())
+                .append(" (")
+                .append(idColumn)
+                .append(" UUID PRIMARY KEY DEFAULT gen_random_uuid(), ");
         if (hasNamespace()) {
             sql.append(namespaceColumn).append(" TEXT NOT NULL DEFAULT '', ");
         }
-        sql.append(contentColumn).append(" TEXT, ")
-                .append(embeddingColumn).append(" VECTOR(").append(dimension).append("), ")
-                .append(metadataColumn).append(" JSONB DEFAULT '{}'::jsonb, ")
+        sql.append(contentColumn)
+                .append(" TEXT, ")
+                .append(embeddingColumn)
+                .append(" VECTOR(")
+                .append(dimension)
+                .append("), ")
+                .append(metadataColumn)
+                .append(" JSONB DEFAULT '{}'::jsonb, ")
                 .append("created_at TIMESTAMPTZ DEFAULT now()")
                 .append(")");
         return sql.toString();

--- a/embedding-stores/langchain4j-community-cockroachdb/src/main/java/dev/langchain4j/community/store/embedding/cockroachdb/MetricType.java
+++ b/embedding-stores/langchain4j-community-cockroachdb/src/main/java/dev/langchain4j/community/store/embedding/cockroachdb/MetricType.java
@@ -1,0 +1,32 @@
+package dev.langchain4j.community.store.embedding.cockroachdb;
+
+/**
+ * Distance metric for vector similarity search.
+ *
+ * <p>CockroachDB's {@code CREATE VECTOR INDEX} does NOT bind a metric to the index;
+ * the metric is selected at query time by the operator. Mapping:
+ *
+ * <ul>
+ *   <li>{@link #COSINE} → {@code <=>}</li>
+ *   <li>{@link #EUCLIDEAN} → {@code <->}</li>
+ *   <li>{@link #DOT_PRODUCT} → {@code <#>}</li>
+ * </ul>
+ */
+public enum MetricType {
+    COSINE,
+    EUCLIDEAN,
+    DOT_PRODUCT;
+
+    public String operator() {
+        switch (this) {
+            case COSINE:
+                return "<=>";
+            case EUCLIDEAN:
+                return "<->";
+            case DOT_PRODUCT:
+                return "<#>";
+            default:
+                return "<=>";
+        }
+    }
+}

--- a/embedding-stores/langchain4j-community-cockroachdb/src/main/java/dev/langchain4j/community/store/embedding/cockroachdb/RetryUtils.java
+++ b/embedding-stores/langchain4j-community-cockroachdb/src/main/java/dev/langchain4j/community/store/embedding/cockroachdb/RetryUtils.java
@@ -1,0 +1,76 @@
+package dev.langchain4j.community.store.embedding.cockroachdb;
+
+import java.sql.SQLException;
+import java.util.concurrent.ThreadLocalRandom;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Retry helper for CockroachDB serialization failures (SQLSTATE 40001).
+ *
+ * <p>Under CockroachDB's default SERIALIZABLE isolation, transactions can be aborted
+ * with a {@code restart transaction} error and must be retried by the client. This
+ * mirrors the retry logic in the Python {@code langchain-cockroachdb} library.
+ */
+final class RetryUtils {
+
+    private static final Logger logger = LoggerFactory.getLogger(RetryUtils.class);
+
+    static final int DEFAULT_MAX_RETRIES = 5;
+    static final long DEFAULT_INITIAL_BACKOFF_MS = 100L;
+    static final long DEFAULT_MAX_BACKOFF_MS = 10_000L;
+    static final double DEFAULT_BACKOFF_MULTIPLIER = 2.0;
+
+    private RetryUtils() {}
+
+    @FunctionalInterface
+    interface SqlAction<T> {
+        T run() throws SQLException;
+    }
+
+    static <T> T withRetry(SqlAction<T> action) {
+        return withRetry(action, DEFAULT_MAX_RETRIES);
+    }
+
+    static <T> T withRetry(SqlAction<T> action, int maxRetries) {
+        long backoff = DEFAULT_INITIAL_BACKOFF_MS;
+        SQLException last = null;
+        for (int attempt = 0; attempt <= maxRetries; attempt++) {
+            try {
+                return action.run();
+            } catch (SQLException e) {
+                last = e;
+                if (!isRetryable(e) || attempt == maxRetries) {
+                    throw new CockroachDbRequestFailedException(
+                            "CockroachDB operation failed after " + (attempt + 1) + " attempt(s)", e);
+                }
+                long jittered = (long) (backoff * (0.5 + ThreadLocalRandom.current().nextDouble() * 0.5));
+                logger.debug("Retryable CockroachDB error on attempt {}/{}: {} — sleeping {} ms",
+                        attempt + 1, maxRetries + 1, e.getSQLState(), jittered);
+                sleep(jittered);
+                backoff = Math.min((long) (backoff * DEFAULT_BACKOFF_MULTIPLIER), DEFAULT_MAX_BACKOFF_MS);
+            }
+        }
+        throw new CockroachDbRequestFailedException("Exhausted retries", last);
+    }
+
+    static boolean isRetryable(SQLException e) {
+        if (e == null) return false;
+        if ("40001".equals(e.getSQLState())) return true;
+        String msg = e.getMessage() == null ? "" : e.getMessage().toLowerCase();
+        return msg.contains("restart transaction")
+                || msg.contains("serialization failure")
+                || msg.contains("connection reset")
+                || msg.contains("broken pipe")
+                || msg.contains("server closed");
+    }
+
+    private static void sleep(long ms) {
+        try {
+            Thread.sleep(ms);
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw new CockroachDbRequestFailedException("Interrupted during CockroachDB retry backoff", ie);
+        }
+    }
+}

--- a/embedding-stores/langchain4j-community-cockroachdb/src/main/java/dev/langchain4j/community/store/embedding/cockroachdb/RetryUtils.java
+++ b/embedding-stores/langchain4j-community-cockroachdb/src/main/java/dev/langchain4j/community/store/embedding/cockroachdb/RetryUtils.java
@@ -44,9 +44,14 @@ final class RetryUtils {
                     throw new CockroachDbRequestFailedException(
                             "CockroachDB operation failed after " + (attempt + 1) + " attempt(s)", e);
                 }
-                long jittered = (long) (backoff * (0.5 + ThreadLocalRandom.current().nextDouble() * 0.5));
-                logger.debug("Retryable CockroachDB error on attempt {}/{}: {} — sleeping {} ms",
-                        attempt + 1, maxRetries + 1, e.getSQLState(), jittered);
+                long jittered =
+                        (long) (backoff * (0.5 + ThreadLocalRandom.current().nextDouble() * 0.5));
+                logger.debug(
+                        "Retryable CockroachDB error on attempt {}/{}: {}, sleeping {} ms",
+                        attempt + 1,
+                        maxRetries + 1,
+                        e.getSQLState(),
+                        jittered);
                 sleep(jittered);
                 backoff = Math.min((long) (backoff * DEFAULT_BACKOFF_MULTIPLIER), DEFAULT_MAX_BACKOFF_MS);
             }

--- a/embedding-stores/langchain4j-community-cockroachdb/src/main/java/dev/langchain4j/community/store/embedding/cockroachdb/RetryUtils.java
+++ b/embedding-stores/langchain4j-community-cockroachdb/src/main/java/dev/langchain4j/community/store/embedding/cockroachdb/RetryUtils.java
@@ -14,19 +14,13 @@ import org.slf4j.LoggerFactory;
  */
 final class RetryUtils {
 
-    private static final Logger logger = LoggerFactory.getLogger(RetryUtils.class);
-
     static final int DEFAULT_MAX_RETRIES = 5;
     static final long DEFAULT_INITIAL_BACKOFF_MS = 100L;
     static final long DEFAULT_MAX_BACKOFF_MS = 10_000L;
     static final double DEFAULT_BACKOFF_MULTIPLIER = 2.0;
+    private static final Logger logger = LoggerFactory.getLogger(RetryUtils.class);
 
     private RetryUtils() {}
-
-    @FunctionalInterface
-    interface SqlAction<T> {
-        T run() throws SQLException;
-    }
 
     static <T> T withRetry(SqlAction<T> action) {
         return withRetry(action, DEFAULT_MAX_RETRIES);
@@ -77,5 +71,10 @@ final class RetryUtils {
             Thread.currentThread().interrupt();
             throw new CockroachDbRequestFailedException("Interrupted during CockroachDB retry backoff", ie);
         }
+    }
+
+    @FunctionalInterface
+    interface SqlAction<T> {
+        T run() throws SQLException;
     }
 }

--- a/embedding-stores/langchain4j-community-cockroachdb/src/main/java/dev/langchain4j/community/store/embedding/cockroachdb/index/BaseIndex.java
+++ b/embedding-stores/langchain4j-community-cockroachdb/src/main/java/dev/langchain4j/community/store/embedding/cockroachdb/index/BaseIndex.java
@@ -1,0 +1,31 @@
+package dev.langchain4j.community.store.embedding.cockroachdb.index;
+
+import java.util.List;
+
+/**
+ * Strategy for the vector index created alongside a CockroachDB embedding table.
+ *
+ * <p>CockroachDB's vector index DDL ({@code CREATE VECTOR INDEX}) is distinct from
+ * pgvector — there is no {@code USING}, no opclass, and the distance metric is
+ * selected at query time by the operator rather than bound to the index. Each
+ * implementation owns its full DDL string.
+ */
+public interface BaseIndex {
+
+    /**
+     * Build the {@code CREATE INDEX} (or {@code CREATE VECTOR INDEX}) statement
+     * for this strategy.
+     *
+     * @param fullyQualifiedTable schema-qualified table name (e.g. {@code public.embeddings})
+     * @param embeddingColumn     name of the vector column
+     * @param prefixColumns       columns to place before the vector column for
+     *                            multi-tenant / partitioned indexes (may be empty)
+     * @return DDL statement, or {@code null} if no index should be created
+     */
+    String getCreateIndexSql(String fullyQualifiedTable, String embeddingColumn, List<String> prefixColumns);
+
+    /**
+     * Resolved index name, or {@code null} if no index will be created.
+     */
+    String getName(String tableName, String embeddingColumn);
+}

--- a/embedding-stores/langchain4j-community-cockroachdb/src/main/java/dev/langchain4j/community/store/embedding/cockroachdb/index/BaseIndex.java
+++ b/embedding-stores/langchain4j-community-cockroachdb/src/main/java/dev/langchain4j/community/store/embedding/cockroachdb/index/BaseIndex.java
@@ -6,7 +6,7 @@ import java.util.List;
  * Strategy for the vector index created alongside a CockroachDB embedding table.
  *
  * <p>CockroachDB's vector index DDL ({@code CREATE VECTOR INDEX}) is distinct from
- * pgvector — there is no {@code USING}, no opclass, and the distance metric is
+ * pgvector: there is no {@code USING}, no opclass, and the distance metric is
  * selected at query time by the operator rather than bound to the index. Each
  * implementation owns its full DDL string.
  */

--- a/embedding-stores/langchain4j-community-cockroachdb/src/main/java/dev/langchain4j/community/store/embedding/cockroachdb/index/CSpannIndex.java
+++ b/embedding-stores/langchain4j-community-cockroachdb/src/main/java/dev/langchain4j/community/store/embedding/cockroachdb/index/CSpannIndex.java
@@ -21,7 +21,7 @@ import java.util.List;
  * <p>{@code prefixColumns} go <em>before</em> the embedding column for
  * multi-tenant scoping (e.g. {@code (tenant_id, embedding)}).
  *
- * <p>Note: the distance metric is NOT part of the index — CockroachDB infers it
+ * <p>Note: the distance metric is NOT part of the index. CockroachDB infers it
  * from the operator ({@code <->}, {@code <=>}, {@code <#>}) at query time.
  */
 public class CSpannIndex implements BaseIndex {

--- a/embedding-stores/langchain4j-community-cockroachdb/src/main/java/dev/langchain4j/community/store/embedding/cockroachdb/index/CSpannIndex.java
+++ b/embedding-stores/langchain4j-community-cockroachdb/src/main/java/dev/langchain4j/community/store/embedding/cockroachdb/index/CSpannIndex.java
@@ -40,6 +40,11 @@ public class CSpannIndex implements BaseIndex {
         return new Builder();
     }
 
+    private static String stripSchema(String fqn) {
+        int dot = fqn.indexOf('.');
+        return dot >= 0 ? fqn.substring(dot + 1) : fqn;
+    }
+
     @Override
     public String getCreateIndexSql(String fullyQualifiedTable, String embeddingColumn, List<String> prefixColumns) {
         String resolvedName = getName(stripSchema(fullyQualifiedTable), embeddingColumn);
@@ -84,11 +89,6 @@ public class CSpannIndex implements BaseIndex {
 
     public Integer getMaxPartitionSize() {
         return maxPartitionSize;
-    }
-
-    private static String stripSchema(String fqn) {
-        int dot = fqn.indexOf('.');
-        return dot >= 0 ? fqn.substring(dot + 1) : fqn;
     }
 
     public static class Builder {

--- a/embedding-stores/langchain4j-community-cockroachdb/src/main/java/dev/langchain4j/community/store/embedding/cockroachdb/index/CSpannIndex.java
+++ b/embedding-stores/langchain4j-community-cockroachdb/src/main/java/dev/langchain4j/community/store/embedding/cockroachdb/index/CSpannIndex.java
@@ -1,0 +1,127 @@
+package dev.langchain4j.community.store.embedding.cockroachdb.index;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * CockroachDB's distributed approximate-nearest-neighbour vector index (C-SPANN),
+ * available from CockroachDB v25.2.
+ *
+ * <p>Emits the form:
+ * <pre>
+ *   CREATE VECTOR INDEX IF NOT EXISTS &lt;name&gt;
+ *     ON &lt;table&gt; ([prefix_cols, ...] &lt;embedding_col&gt;)
+ *     [WITH (min_partition_size = N, max_partition_size = M)]
+ * </pre>
+ *
+ * <p>{@code min_partition_size} and {@code max_partition_size} are the only
+ * options recognised by the Python reference library; surface them as builder
+ * fields and leave them {@code null} to let CockroachDB pick defaults.
+ *
+ * <p>{@code prefixColumns} go <em>before</em> the embedding column for
+ * multi-tenant scoping (e.g. {@code (tenant_id, embedding)}).
+ *
+ * <p>Note: the distance metric is NOT part of the index — CockroachDB infers it
+ * from the operator ({@code <->}, {@code <=>}, {@code <#>}) at query time.
+ */
+public class CSpannIndex implements BaseIndex {
+
+    private final String name;
+    private final Integer minPartitionSize;
+    private final Integer maxPartitionSize;
+
+    private CSpannIndex(Builder builder) {
+        this.name = builder.name;
+        this.minPartitionSize = builder.minPartitionSize;
+        this.maxPartitionSize = builder.maxPartitionSize;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public String getCreateIndexSql(String fullyQualifiedTable, String embeddingColumn, List<String> prefixColumns) {
+        String resolvedName = getName(stripSchema(fullyQualifiedTable), embeddingColumn);
+
+        List<String> columns = new ArrayList<>();
+        if (prefixColumns != null) {
+            columns.addAll(prefixColumns);
+        }
+        columns.add(embeddingColumn);
+
+        StringBuilder sql = new StringBuilder()
+                .append("CREATE VECTOR INDEX IF NOT EXISTS ")
+                .append(resolvedName)
+                .append(" ON ")
+                .append(fullyQualifiedTable)
+                .append(" (")
+                .append(String.join(", ", columns))
+                .append(")");
+
+        List<String> withClauses = new ArrayList<>();
+        if (minPartitionSize != null) {
+            withClauses.add("min_partition_size = " + minPartitionSize);
+        }
+        if (maxPartitionSize != null) {
+            withClauses.add("max_partition_size = " + maxPartitionSize);
+        }
+        if (!withClauses.isEmpty()) {
+            sql.append(" WITH (").append(String.join(", ", withClauses)).append(")");
+        }
+        return sql.toString();
+    }
+
+    @Override
+    public String getName(String tableName, String embeddingColumn) {
+        if (name != null && !name.isEmpty()) return name;
+        return tableName + "_" + embeddingColumn + "_vector_idx";
+    }
+
+    public Integer getMinPartitionSize() {
+        return minPartitionSize;
+    }
+
+    public Integer getMaxPartitionSize() {
+        return maxPartitionSize;
+    }
+
+    private static String stripSchema(String fqn) {
+        int dot = fqn.indexOf('.');
+        return dot >= 0 ? fqn.substring(dot + 1) : fqn;
+    }
+
+    public static class Builder {
+        private String name;
+        private Integer minPartitionSize;
+        private Integer maxPartitionSize;
+
+        public Builder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public Builder minPartitionSize(Integer minPartitionSize) {
+            if (minPartitionSize != null && minPartitionSize <= 0) {
+                throw new IllegalArgumentException("minPartitionSize must be positive");
+            }
+            this.minPartitionSize = minPartitionSize;
+            return this;
+        }
+
+        public Builder maxPartitionSize(Integer maxPartitionSize) {
+            if (maxPartitionSize != null && maxPartitionSize <= 0) {
+                throw new IllegalArgumentException("maxPartitionSize must be positive");
+            }
+            this.maxPartitionSize = maxPartitionSize;
+            return this;
+        }
+
+        public CSpannIndex build() {
+            if (minPartitionSize != null && maxPartitionSize != null && minPartitionSize > maxPartitionSize) {
+                throw new IllegalStateException("minPartitionSize must be <= maxPartitionSize");
+            }
+            return new CSpannIndex(this);
+        }
+    }
+}

--- a/embedding-stores/langchain4j-community-cockroachdb/src/main/java/dev/langchain4j/community/store/embedding/cockroachdb/index/NoIndex.java
+++ b/embedding-stores/langchain4j-community-cockroachdb/src/main/java/dev/langchain4j/community/store/embedding/cockroachdb/index/NoIndex.java
@@ -1,0 +1,25 @@
+package dev.langchain4j.community.store.embedding.cockroachdb.index;
+
+import java.util.List;
+
+/**
+ * Sentinel that suppresses index creation; CockroachDB will fall back to a
+ * sequential scan for similarity search. Reasonable for small datasets and tests.
+ */
+public class NoIndex implements BaseIndex {
+
+    @Override
+    public String getCreateIndexSql(String fullyQualifiedTable, String embeddingColumn, List<String> prefixColumns) {
+        return null;
+    }
+
+    @Override
+    public String getName(String tableName, String embeddingColumn) {
+        return null;
+    }
+
+    @Override
+    public String toString() {
+        return "NoIndex (sequential scan)";
+    }
+}

--- a/embedding-stores/langchain4j-community-cockroachdb/src/main/java/dev/langchain4j/community/store/memory/chat/cockroachdb/CockroachDbChatMemorySchema.java
+++ b/embedding-stores/langchain4j-community-cockroachdb/src/main/java/dev/langchain4j/community/store/memory/chat/cockroachdb/CockroachDbChatMemorySchema.java
@@ -70,6 +70,14 @@ public class CockroachDbChatMemorySchema {
         return new Builder();
     }
 
+    private static String formatInterval(Duration d) {
+        long seconds = d.toSeconds();
+        if (seconds % 86_400 == 0) return (seconds / 86_400) + " days";
+        if (seconds % 3_600 == 0) return (seconds / 3_600) + " hours";
+        if (seconds % 60 == 0) return (seconds / 60) + " minutes";
+        return seconds + " seconds";
+    }
+
     public String getTableName() {
         return tableName;
     }
@@ -145,14 +153,6 @@ public class CockroachDbChatMemorySchema {
 
     public String getDisableTtlSql() {
         return String.format("ALTER TABLE %s RESET (ttl)", getFullTableName());
-    }
-
-    private static String formatInterval(Duration d) {
-        long seconds = d.toSeconds();
-        if (seconds % 86_400 == 0) return (seconds / 86_400) + " days";
-        if (seconds % 3_600 == 0) return (seconds / 3_600) + " hours";
-        if (seconds % 60 == 0) return (seconds / 60) + " minutes";
-        return seconds + " seconds";
     }
 
     public static class Builder {

--- a/embedding-stores/langchain4j-community-cockroachdb/src/main/java/dev/langchain4j/community/store/memory/chat/cockroachdb/CockroachDbChatMemorySchema.java
+++ b/embedding-stores/langchain4j-community-cockroachdb/src/main/java/dev/langchain4j/community/store/memory/chat/cockroachdb/CockroachDbChatMemorySchema.java
@@ -70,25 +70,45 @@ public class CockroachDbChatMemorySchema {
         return new Builder();
     }
 
-    public String getTableName() { return tableName; }
+    public String getTableName() {
+        return tableName;
+    }
 
-    public String getSchemaName() { return schemaName; }
+    public String getSchemaName() {
+        return schemaName;
+    }
 
-    public String getIdColumn() { return idColumn; }
+    public String getIdColumn() {
+        return idColumn;
+    }
 
-    public String getSessionColumn() { return sessionColumn; }
+    public String getSessionColumn() {
+        return sessionColumn;
+    }
 
-    public String getMessageColumn() { return messageColumn; }
+    public String getMessageColumn() {
+        return messageColumn;
+    }
 
-    public String getCreatedAtColumn() { return createdAtColumn; }
+    public String getCreatedAtColumn() {
+        return createdAtColumn;
+    }
 
-    public String getIdxColumn() { return idxColumn; }
+    public String getIdxColumn() {
+        return idxColumn;
+    }
 
-    public boolean isCreateTableIfNotExists() { return createTableIfNotExists; }
+    public boolean isCreateTableIfNotExists() {
+        return createTableIfNotExists;
+    }
 
-    public Duration getTtl() { return ttl; }
+    public Duration getTtl() {
+        return ttl;
+    }
 
-    public String getTtlJobCron() { return ttlJobCron; }
+    public String getTtlJobCron() {
+        return ttlJobCron;
+    }
 
     public String getFullTableName() {
         return schemaName != null && !schemaName.trim().isEmpty() ? schemaName + "." + tableName : tableName;
@@ -96,13 +116,12 @@ public class CockroachDbChatMemorySchema {
 
     public String getCreateTableSql() {
         return String.format(
-                "CREATE TABLE IF NOT EXISTS %s (" +
-                        "%s UUID PRIMARY KEY DEFAULT gen_random_uuid(), " +
-                        "%s TEXT NOT NULL, " +
-                        "%s JSONB NOT NULL, " +
-                        "%s INT NOT NULL DEFAULT 0, " +
-                        "%s TIMESTAMPTZ NOT NULL DEFAULT now()" +
-                        ")",
+                "CREATE TABLE IF NOT EXISTS %s (" + "%s UUID PRIMARY KEY DEFAULT gen_random_uuid(), "
+                        + "%s TEXT NOT NULL, "
+                        + "%s JSONB NOT NULL, "
+                        + "%s INT NOT NULL DEFAULT 0, "
+                        + "%s TIMESTAMPTZ NOT NULL DEFAULT now()"
+                        + ")",
                 getFullTableName(), idColumn, sessionColumn, messageColumn, idxColumn, createdAtColumn);
     }
 
@@ -120,10 +139,7 @@ public class CockroachDbChatMemorySchema {
         String interval = formatInterval(ttl);
         // Dollar-quote the expression so the embedded INTERVAL literal doesn't have to be escaped.
         return String.format(
-                "ALTER TABLE %s SET (" +
-                        "ttl_expiration_expression = $$(%s + '%s')$$, " +
-                        "ttl_job_cron = '%s'" +
-                        ")",
+                "ALTER TABLE %s SET (" + "ttl_expiration_expression = $$(%s + '%s')$$, " + "ttl_job_cron = '%s'" + ")",
                 getFullTableName(), createdAtColumn, interval, ttlJobCron);
     }
 
@@ -151,16 +167,55 @@ public class CockroachDbChatMemorySchema {
         private Duration ttl;
         private String ttlJobCron = DEFAULT_TTL_CRON;
 
-        public Builder tableName(String tableName) { this.tableName = tableName; return this; }
-        public Builder schemaName(String schemaName) { this.schemaName = schemaName; return this; }
-        public Builder idColumn(String c) { this.idColumn = c; return this; }
-        public Builder sessionColumn(String c) { this.sessionColumn = c; return this; }
-        public Builder messageColumn(String c) { this.messageColumn = c; return this; }
-        public Builder createdAtColumn(String c) { this.createdAtColumn = c; return this; }
-        public Builder idxColumn(String c) { this.idxColumn = c; return this; }
-        public Builder createTableIfNotExists(boolean v) { this.createTableIfNotExists = v; return this; }
-        public Builder ttl(Duration ttl) { this.ttl = ttl; return this; }
-        public Builder ttlJobCron(String cron) { this.ttlJobCron = cron; return this; }
+        public Builder tableName(String tableName) {
+            this.tableName = tableName;
+            return this;
+        }
+
+        public Builder schemaName(String schemaName) {
+            this.schemaName = schemaName;
+            return this;
+        }
+
+        public Builder idColumn(String c) {
+            this.idColumn = c;
+            return this;
+        }
+
+        public Builder sessionColumn(String c) {
+            this.sessionColumn = c;
+            return this;
+        }
+
+        public Builder messageColumn(String c) {
+            this.messageColumn = c;
+            return this;
+        }
+
+        public Builder createdAtColumn(String c) {
+            this.createdAtColumn = c;
+            return this;
+        }
+
+        public Builder idxColumn(String c) {
+            this.idxColumn = c;
+            return this;
+        }
+
+        public Builder createTableIfNotExists(boolean v) {
+            this.createTableIfNotExists = v;
+            return this;
+        }
+
+        public Builder ttl(Duration ttl) {
+            this.ttl = ttl;
+            return this;
+        }
+
+        public Builder ttlJobCron(String cron) {
+            this.ttlJobCron = cron;
+            return this;
+        }
 
         public CockroachDbChatMemorySchema build() {
             return new CockroachDbChatMemorySchema(this);

--- a/embedding-stores/langchain4j-community-cockroachdb/src/main/java/dev/langchain4j/community/store/memory/chat/cockroachdb/CockroachDbChatMemorySchema.java
+++ b/embedding-stores/langchain4j-community-cockroachdb/src/main/java/dev/langchain4j/community/store/memory/chat/cockroachdb/CockroachDbChatMemorySchema.java
@@ -1,0 +1,169 @@
+package dev.langchain4j.community.store.memory.chat.cockroachdb;
+
+import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+
+import java.time.Duration;
+import java.util.regex.Pattern;
+
+/**
+ * Schema for the chat-history table used by {@link CockroachDbChatMemoryStore}.
+ *
+ * <p>Default DDL:
+ * <pre>
+ *   CREATE TABLE message_store (
+ *     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+ *     session_id TEXT NOT NULL,
+ *     message JSONB NOT NULL,
+ *     created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+ *   );
+ *   CREATE INDEX message_store_session_idx ON message_store (session_id, created_at);
+ * </pre>
+ *
+ * <p>If {@link Builder#ttl(Duration)} is set, an ALTER TABLE statement enables
+ * CockroachDB's row-level TTL via {@code ttl_expiration_expression} (dollar-quoted
+ * to avoid full-table rewrites) and {@code ttl_job_cron}.
+ */
+public class CockroachDbChatMemorySchema {
+
+    public static final String DEFAULT_TABLE_NAME = "message_store";
+    public static final String DEFAULT_SCHEMA_NAME = "public";
+    public static final String DEFAULT_ID_COLUMN = "id";
+    public static final String DEFAULT_SESSION_COLUMN = "session_id";
+    public static final String DEFAULT_MESSAGE_COLUMN = "message";
+    public static final String DEFAULT_CREATED_AT_COLUMN = "created_at";
+    public static final String DEFAULT_IDX_COLUMN = "idx";
+    public static final String DEFAULT_TTL_CRON = "@daily";
+
+    private static final Pattern CRON_PATTERN = Pattern.compile("^[@\\w\\s\\*/,\\-]+$");
+
+    private final String tableName;
+    private final String schemaName;
+    private final String idColumn;
+    private final String sessionColumn;
+    private final String messageColumn;
+    private final String createdAtColumn;
+    private final String idxColumn;
+    private final boolean createTableIfNotExists;
+    private final Duration ttl;
+    private final String ttlJobCron;
+
+    private CockroachDbChatMemorySchema(Builder b) {
+        this.tableName = ensureNotBlank(b.tableName, "tableName");
+        this.schemaName = b.schemaName;
+        this.idColumn = ensureNotBlank(b.idColumn, "idColumn");
+        this.sessionColumn = ensureNotBlank(b.sessionColumn, "sessionColumn");
+        this.messageColumn = ensureNotBlank(b.messageColumn, "messageColumn");
+        this.createdAtColumn = ensureNotBlank(b.createdAtColumn, "createdAtColumn");
+        this.idxColumn = ensureNotBlank(b.idxColumn, "idxColumn");
+        this.createTableIfNotExists = b.createTableIfNotExists;
+        this.ttl = b.ttl;
+        this.ttlJobCron = b.ttlJobCron;
+        if (ttl != null && (ttl.isZero() || ttl.isNegative())) {
+            throw new IllegalArgumentException("ttl must be positive");
+        }
+        if (!CRON_PATTERN.matcher(ttlJobCron).matches()) {
+            throw new IllegalArgumentException("ttlJobCron contains invalid characters: " + ttlJobCron);
+        }
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public String getTableName() { return tableName; }
+
+    public String getSchemaName() { return schemaName; }
+
+    public String getIdColumn() { return idColumn; }
+
+    public String getSessionColumn() { return sessionColumn; }
+
+    public String getMessageColumn() { return messageColumn; }
+
+    public String getCreatedAtColumn() { return createdAtColumn; }
+
+    public String getIdxColumn() { return idxColumn; }
+
+    public boolean isCreateTableIfNotExists() { return createTableIfNotExists; }
+
+    public Duration getTtl() { return ttl; }
+
+    public String getTtlJobCron() { return ttlJobCron; }
+
+    public String getFullTableName() {
+        return schemaName != null && !schemaName.trim().isEmpty() ? schemaName + "." + tableName : tableName;
+    }
+
+    public String getCreateTableSql() {
+        return String.format(
+                "CREATE TABLE IF NOT EXISTS %s (" +
+                        "%s UUID PRIMARY KEY DEFAULT gen_random_uuid(), " +
+                        "%s TEXT NOT NULL, " +
+                        "%s JSONB NOT NULL, " +
+                        "%s INT NOT NULL DEFAULT 0, " +
+                        "%s TIMESTAMPTZ NOT NULL DEFAULT now()" +
+                        ")",
+                getFullTableName(), idColumn, sessionColumn, messageColumn, idxColumn, createdAtColumn);
+    }
+
+    public String getCreateSessionIndexSql() {
+        return String.format(
+                "CREATE INDEX IF NOT EXISTS %s_session_idx ON %s (%s, %s, %s)",
+                tableName, getFullTableName(), sessionColumn, createdAtColumn, idxColumn);
+    }
+
+    /**
+     * @return the {@code ALTER TABLE ... SET (ttl_…)} statement, or {@code null} if TTL is disabled.
+     */
+    public String getEnableTtlSql() {
+        if (ttl == null) return null;
+        String interval = formatInterval(ttl);
+        // Dollar-quote the expression so the embedded INTERVAL literal doesn't have to be escaped.
+        return String.format(
+                "ALTER TABLE %s SET (" +
+                        "ttl_expiration_expression = $$(%s + '%s')$$, " +
+                        "ttl_job_cron = '%s'" +
+                        ")",
+                getFullTableName(), createdAtColumn, interval, ttlJobCron);
+    }
+
+    public String getDisableTtlSql() {
+        return String.format("ALTER TABLE %s RESET (ttl)", getFullTableName());
+    }
+
+    private static String formatInterval(Duration d) {
+        long seconds = d.toSeconds();
+        if (seconds % 86_400 == 0) return (seconds / 86_400) + " days";
+        if (seconds % 3_600 == 0) return (seconds / 3_600) + " hours";
+        if (seconds % 60 == 0) return (seconds / 60) + " minutes";
+        return seconds + " seconds";
+    }
+
+    public static class Builder {
+        private String tableName = DEFAULT_TABLE_NAME;
+        private String schemaName = DEFAULT_SCHEMA_NAME;
+        private String idColumn = DEFAULT_ID_COLUMN;
+        private String sessionColumn = DEFAULT_SESSION_COLUMN;
+        private String messageColumn = DEFAULT_MESSAGE_COLUMN;
+        private String createdAtColumn = DEFAULT_CREATED_AT_COLUMN;
+        private String idxColumn = DEFAULT_IDX_COLUMN;
+        private boolean createTableIfNotExists = true;
+        private Duration ttl;
+        private String ttlJobCron = DEFAULT_TTL_CRON;
+
+        public Builder tableName(String tableName) { this.tableName = tableName; return this; }
+        public Builder schemaName(String schemaName) { this.schemaName = schemaName; return this; }
+        public Builder idColumn(String c) { this.idColumn = c; return this; }
+        public Builder sessionColumn(String c) { this.sessionColumn = c; return this; }
+        public Builder messageColumn(String c) { this.messageColumn = c; return this; }
+        public Builder createdAtColumn(String c) { this.createdAtColumn = c; return this; }
+        public Builder idxColumn(String c) { this.idxColumn = c; return this; }
+        public Builder createTableIfNotExists(boolean v) { this.createTableIfNotExists = v; return this; }
+        public Builder ttl(Duration ttl) { this.ttl = ttl; return this; }
+        public Builder ttlJobCron(String cron) { this.ttlJobCron = cron; return this; }
+
+        public CockroachDbChatMemorySchema build() {
+            return new CockroachDbChatMemorySchema(this);
+        }
+    }
+}

--- a/embedding-stores/langchain4j-community-cockroachdb/src/main/java/dev/langchain4j/community/store/memory/chat/cockroachdb/CockroachDbChatMemoryStore.java
+++ b/embedding-stores/langchain4j-community-cockroachdb/src/main/java/dev/langchain4j/community/store/memory/chat/cockroachdb/CockroachDbChatMemoryStore.java
@@ -21,7 +21,7 @@ import org.slf4j.LoggerFactory;
  * {@code created_at} timestamp that preserves chronological order and feeds
  * optional row-level TTL.
  *
- * <p>{@link #updateMessages(Object, List)} replaces the full session — it deletes
+ * <p>{@link #updateMessages(Object, List)} replaces the full session: it deletes
  * existing rows for the memory id and re-inserts the supplied list inside a
  * transaction.
  */

--- a/embedding-stores/langchain4j-community-cockroachdb/src/main/java/dev/langchain4j/community/store/memory/chat/cockroachdb/CockroachDbChatMemoryStore.java
+++ b/embedding-stores/langchain4j-community-cockroachdb/src/main/java/dev/langchain4j/community/store/memory/chat/cockroachdb/CockroachDbChatMemoryStore.java
@@ -49,12 +49,14 @@ public class CockroachDbChatMemoryStore implements ChatMemoryStore {
         String sessionId = String.valueOf(memoryId);
         String sql = String.format(
                 "SELECT %s FROM %s WHERE %s = ? ORDER BY %s ASC, %s ASC",
-                schema.getMessageColumn(), schema.getFullTableName(),
+                schema.getMessageColumn(),
+                schema.getFullTableName(),
                 schema.getSessionColumn(),
-                schema.getCreatedAtColumn(), schema.getIdxColumn());
+                schema.getCreatedAtColumn(),
+                schema.getIdxColumn());
 
         try (Connection conn = engine.getConnection();
-             PreparedStatement st = conn.prepareStatement(sql)) {
+                PreparedStatement st = conn.prepareStatement(sql)) {
             st.setString(1, sessionId);
             try (ResultSet rs = st.executeQuery()) {
                 List<ChatMessage> messages = new ArrayList<>();
@@ -71,12 +73,11 @@ public class CockroachDbChatMemoryStore implements ChatMemoryStore {
     @Override
     public void updateMessages(Object memoryId, List<ChatMessage> messages) {
         String sessionId = String.valueOf(memoryId);
-        String deleteSql = String.format(
-                "DELETE FROM %s WHERE %s = ?", schema.getFullTableName(), schema.getSessionColumn());
+        String deleteSql =
+                String.format("DELETE FROM %s WHERE %s = ?", schema.getFullTableName(), schema.getSessionColumn());
         String insertSql = String.format(
                 "INSERT INTO %s (%s, %s, %s) VALUES (?, ?::jsonb, ?)",
-                schema.getFullTableName(),
-                schema.getSessionColumn(), schema.getMessageColumn(), schema.getIdxColumn());
+                schema.getFullTableName(), schema.getSessionColumn(), schema.getMessageColumn(), schema.getIdxColumn());
 
         try (Connection conn = engine.getConnection()) {
             conn.setAutoCommit(false);
@@ -105,10 +106,9 @@ public class CockroachDbChatMemoryStore implements ChatMemoryStore {
     @Override
     public void deleteMessages(Object memoryId) {
         String sessionId = String.valueOf(memoryId);
-        String sql = String.format(
-                "DELETE FROM %s WHERE %s = ?", schema.getFullTableName(), schema.getSessionColumn());
+        String sql = String.format("DELETE FROM %s WHERE %s = ?", schema.getFullTableName(), schema.getSessionColumn());
         try (Connection conn = engine.getConnection();
-             PreparedStatement st = conn.prepareStatement(sql)) {
+                PreparedStatement st = conn.prepareStatement(sql)) {
             st.setString(1, sessionId);
             st.executeUpdate();
         } catch (SQLException e) {
@@ -118,7 +118,7 @@ public class CockroachDbChatMemoryStore implements ChatMemoryStore {
 
     public void createTableIfNotExists() {
         try (Connection conn = engine.getConnection();
-             Statement st = conn.createStatement()) {
+                Statement st = conn.createStatement()) {
             st.execute(schema.getCreateTableSql());
             st.execute(schema.getCreateSessionIndexSql());
             String ttl = schema.getEnableTtlSql();
@@ -133,7 +133,7 @@ public class CockroachDbChatMemoryStore implements ChatMemoryStore {
 
     public void disableTtl() {
         try (Connection conn = engine.getConnection();
-             Statement st = conn.createStatement()) {
+                Statement st = conn.createStatement()) {
             st.execute(schema.getDisableTtlSql());
         } catch (SQLException e) {
             throw new CockroachDbChatMemoryStoreException("Failed to disable TTL", e);

--- a/embedding-stores/langchain4j-community-cockroachdb/src/main/java/dev/langchain4j/community/store/memory/chat/cockroachdb/CockroachDbChatMemoryStore.java
+++ b/embedding-stores/langchain4j-community-cockroachdb/src/main/java/dev/langchain4j/community/store/memory/chat/cockroachdb/CockroachDbChatMemoryStore.java
@@ -1,0 +1,198 @@
+package dev.langchain4j.community.store.memory.chat.cockroachdb;
+
+import dev.langchain4j.community.store.embedding.cockroachdb.CockroachDbEngine;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ChatMessageDeserializer;
+import dev.langchain4j.data.message.ChatMessageSerializer;
+import dev.langchain4j.store.memory.chat.ChatMemoryStore;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * CockroachDB-backed {@link ChatMemoryStore}. Each {@link ChatMessage} is stored
+ * as its own row, serialized to JSONB via {@link ChatMessageSerializer}, with a
+ * {@code created_at} timestamp that preserves chronological order and feeds
+ * optional row-level TTL.
+ *
+ * <p>{@link #updateMessages(Object, List)} replaces the full session — it deletes
+ * existing rows for the memory id and re-inserts the supplied list inside a
+ * transaction.
+ */
+public class CockroachDbChatMemoryStore implements ChatMemoryStore {
+
+    private static final Logger logger = LoggerFactory.getLogger(CockroachDbChatMemoryStore.class);
+
+    private final CockroachDbEngine engine;
+    private final CockroachDbChatMemorySchema schema;
+
+    public CockroachDbChatMemoryStore(Builder builder) {
+        this.engine = builder.engine;
+        this.schema = builder.schema;
+        if (schema.isCreateTableIfNotExists()) {
+            createTableIfNotExists();
+        }
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public List<ChatMessage> getMessages(Object memoryId) {
+        String sessionId = String.valueOf(memoryId);
+        String sql = String.format(
+                "SELECT %s FROM %s WHERE %s = ? ORDER BY %s ASC, %s ASC",
+                schema.getMessageColumn(), schema.getFullTableName(),
+                schema.getSessionColumn(),
+                schema.getCreatedAtColumn(), schema.getIdxColumn());
+
+        try (Connection conn = engine.getConnection();
+             PreparedStatement st = conn.prepareStatement(sql)) {
+            st.setString(1, sessionId);
+            try (ResultSet rs = st.executeQuery()) {
+                List<ChatMessage> messages = new ArrayList<>();
+                while (rs.next()) {
+                    messages.add(ChatMessageDeserializer.messageFromJson(rs.getString(1)));
+                }
+                return messages;
+            }
+        } catch (SQLException e) {
+            throw new CockroachDbChatMemoryStoreException("Failed to load chat memory for " + sessionId, e);
+        }
+    }
+
+    @Override
+    public void updateMessages(Object memoryId, List<ChatMessage> messages) {
+        String sessionId = String.valueOf(memoryId);
+        String deleteSql = String.format(
+                "DELETE FROM %s WHERE %s = ?", schema.getFullTableName(), schema.getSessionColumn());
+        String insertSql = String.format(
+                "INSERT INTO %s (%s, %s, %s) VALUES (?, ?::jsonb, ?)",
+                schema.getFullTableName(),
+                schema.getSessionColumn(), schema.getMessageColumn(), schema.getIdxColumn());
+
+        try (Connection conn = engine.getConnection()) {
+            conn.setAutoCommit(false);
+            try (PreparedStatement del = conn.prepareStatement(deleteSql)) {
+                del.setString(1, sessionId);
+                del.executeUpdate();
+            }
+            if (messages != null && !messages.isEmpty()) {
+                try (PreparedStatement ins = conn.prepareStatement(insertSql)) {
+                    int idx = 0;
+                    for (ChatMessage m : messages) {
+                        ins.setString(1, sessionId);
+                        ins.setString(2, ChatMessageSerializer.messageToJson(m));
+                        ins.setInt(3, idx++);
+                        ins.addBatch();
+                    }
+                    ins.executeBatch();
+                }
+            }
+            conn.commit();
+        } catch (SQLException e) {
+            throw new CockroachDbChatMemoryStoreException("Failed to update chat memory for " + sessionId, e);
+        }
+    }
+
+    @Override
+    public void deleteMessages(Object memoryId) {
+        String sessionId = String.valueOf(memoryId);
+        String sql = String.format(
+                "DELETE FROM %s WHERE %s = ?", schema.getFullTableName(), schema.getSessionColumn());
+        try (Connection conn = engine.getConnection();
+             PreparedStatement st = conn.prepareStatement(sql)) {
+            st.setString(1, sessionId);
+            st.executeUpdate();
+        } catch (SQLException e) {
+            throw new CockroachDbChatMemoryStoreException("Failed to delete chat memory for " + sessionId, e);
+        }
+    }
+
+    public void createTableIfNotExists() {
+        try (Connection conn = engine.getConnection();
+             Statement st = conn.createStatement()) {
+            st.execute(schema.getCreateTableSql());
+            st.execute(schema.getCreateSessionIndexSql());
+            String ttl = schema.getEnableTtlSql();
+            if (ttl != null) {
+                logger.info("Enabling CockroachDB row-level TTL on {}: {}", schema.getFullTableName(), ttl);
+                st.execute(ttl);
+            }
+        } catch (SQLException e) {
+            throw new CockroachDbChatMemoryStoreException("Failed to create chat memory table", e);
+        }
+    }
+
+    public void disableTtl() {
+        try (Connection conn = engine.getConnection();
+             Statement st = conn.createStatement()) {
+            st.execute(schema.getDisableTtlSql());
+        } catch (SQLException e) {
+            throw new CockroachDbChatMemoryStoreException("Failed to disable TTL", e);
+        }
+    }
+
+    public static class Builder {
+        private CockroachDbEngine engine;
+        private CockroachDbChatMemorySchema schema;
+        private CockroachDbChatMemorySchema.Builder schemaBuilder;
+
+        public Builder engine(CockroachDbEngine engine) {
+            this.engine = engine;
+            return this;
+        }
+
+        public Builder schema(CockroachDbChatMemorySchema schema) {
+            this.schema = schema;
+            return this;
+        }
+
+        public Builder tableName(String tableName) {
+            ensureSchemaBuilder().tableName(tableName);
+            return this;
+        }
+
+        public Builder schemaName(String schemaName) {
+            ensureSchemaBuilder().schemaName(schemaName);
+            return this;
+        }
+
+        public Builder ttl(java.time.Duration ttl) {
+            ensureSchemaBuilder().ttl(ttl);
+            return this;
+        }
+
+        public Builder ttlJobCron(String cron) {
+            ensureSchemaBuilder().ttlJobCron(cron);
+            return this;
+        }
+
+        public Builder createTableIfNotExists(boolean v) {
+            ensureSchemaBuilder().createTableIfNotExists(v);
+            return this;
+        }
+
+        private CockroachDbChatMemorySchema.Builder ensureSchemaBuilder() {
+            if (schemaBuilder == null) schemaBuilder = CockroachDbChatMemorySchema.builder();
+            return schemaBuilder;
+        }
+
+        public CockroachDbChatMemoryStore build() {
+            if (engine == null) {
+                throw new IllegalArgumentException("CockroachDbEngine is required");
+            }
+            if (schema == null) {
+                schema = (schemaBuilder == null ? CockroachDbChatMemorySchema.builder() : schemaBuilder).build();
+            }
+            return new CockroachDbChatMemoryStore(this);
+        }
+    }
+}

--- a/embedding-stores/langchain4j-community-cockroachdb/src/main/java/dev/langchain4j/community/store/memory/chat/cockroachdb/CockroachDbChatMemoryStoreException.java
+++ b/embedding-stores/langchain4j-community-cockroachdb/src/main/java/dev/langchain4j/community/store/memory/chat/cockroachdb/CockroachDbChatMemoryStoreException.java
@@ -1,0 +1,12 @@
+package dev.langchain4j.community.store.memory.chat.cockroachdb;
+
+public class CockroachDbChatMemoryStoreException extends RuntimeException {
+
+    public CockroachDbChatMemoryStoreException(String message) {
+        super(message);
+    }
+
+    public CockroachDbChatMemoryStoreException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/embedding-stores/langchain4j-community-cockroachdb/src/test/java/dev/langchain4j/community/store/embedding/cockroachdb/CSpannIndexTest.java
+++ b/embedding-stores/langchain4j-community-cockroachdb/src/test/java/dev/langchain4j/community/store/embedding/cockroachdb/CSpannIndexTest.java
@@ -1,0 +1,44 @@
+package dev.langchain4j.community.store.embedding.cockroachdb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.community.store.embedding.cockroachdb.index.CSpannIndex;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+class CSpannIndexTest {
+
+    @Test
+    void emits_minimal_create_vector_index() {
+        String sql = CSpannIndex.builder().build()
+                .getCreateIndexSql("public.embeddings", "embedding", Collections.emptyList());
+        assertThat(sql).isEqualTo(
+                "CREATE VECTOR INDEX IF NOT EXISTS embeddings_embedding_vector_idx "
+                        + "ON public.embeddings (embedding)");
+    }
+
+    @Test
+    void includes_partition_size_options() {
+        String sql = CSpannIndex.builder()
+                .minPartitionSize(16)
+                .maxPartitionSize(128)
+                .build()
+                .getCreateIndexSql("public.embeddings", "embedding", Collections.emptyList());
+        assertThat(sql).contains("WITH (min_partition_size = 16, max_partition_size = 128)");
+    }
+
+    @Test
+    void prefix_columns_come_before_embedding_column() {
+        String sql = CSpannIndex.builder().build()
+                .getCreateIndexSql("public.embeddings", "embedding", Arrays.asList("tenant_id"));
+        assertThat(sql).contains("(tenant_id, embedding)");
+    }
+
+    @Test
+    void honours_explicit_index_name() {
+        String sql = CSpannIndex.builder().name("my_idx").build()
+                .getCreateIndexSql("public.embeddings", "embedding", Collections.emptyList());
+        assertThat(sql).startsWith("CREATE VECTOR INDEX IF NOT EXISTS my_idx ");
+    }
+}

--- a/embedding-stores/langchain4j-community-cockroachdb/src/test/java/dev/langchain4j/community/store/embedding/cockroachdb/CSpannIndexTest.java
+++ b/embedding-stores/langchain4j-community-cockroachdb/src/test/java/dev/langchain4j/community/store/embedding/cockroachdb/CSpannIndexTest.java
@@ -3,8 +3,8 @@ package dev.langchain4j.community.store.embedding.cockroachdb;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.langchain4j.community.store.embedding.cockroachdb.index.CSpannIndex;
-import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class CSpannIndexTest {
@@ -31,9 +31,8 @@ class CSpannIndexTest {
 
     @Test
     void prefix_columns_come_before_embedding_column() {
-        String sql = CSpannIndex.builder()
-                .build()
-                .getCreateIndexSql("public.embeddings", "embedding", Arrays.asList("tenant_id"));
+        String sql =
+                CSpannIndex.builder().build().getCreateIndexSql("public.embeddings", "embedding", List.of("tenant_id"));
         assertThat(sql).contains("(tenant_id, embedding)");
     }
 

--- a/embedding-stores/langchain4j-community-cockroachdb/src/test/java/dev/langchain4j/community/store/embedding/cockroachdb/CSpannIndexTest.java
+++ b/embedding-stores/langchain4j-community-cockroachdb/src/test/java/dev/langchain4j/community/store/embedding/cockroachdb/CSpannIndexTest.java
@@ -11,10 +11,11 @@ class CSpannIndexTest {
 
     @Test
     void emits_minimal_create_vector_index() {
-        String sql = CSpannIndex.builder().build()
+        String sql = CSpannIndex.builder()
+                .build()
                 .getCreateIndexSql("public.embeddings", "embedding", Collections.emptyList());
-        assertThat(sql).isEqualTo(
-                "CREATE VECTOR INDEX IF NOT EXISTS embeddings_embedding_vector_idx "
+        assertThat(sql)
+                .isEqualTo("CREATE VECTOR INDEX IF NOT EXISTS embeddings_embedding_vector_idx "
                         + "ON public.embeddings (embedding)");
     }
 
@@ -30,14 +31,17 @@ class CSpannIndexTest {
 
     @Test
     void prefix_columns_come_before_embedding_column() {
-        String sql = CSpannIndex.builder().build()
+        String sql = CSpannIndex.builder()
+                .build()
                 .getCreateIndexSql("public.embeddings", "embedding", Arrays.asList("tenant_id"));
         assertThat(sql).contains("(tenant_id, embedding)");
     }
 
     @Test
     void honours_explicit_index_name() {
-        String sql = CSpannIndex.builder().name("my_idx").build()
+        String sql = CSpannIndex.builder()
+                .name("my_idx")
+                .build()
                 .getCreateIndexSql("public.embeddings", "embedding", Collections.emptyList());
         assertThat(sql).startsWith("CREATE VECTOR INDEX IF NOT EXISTS my_idx ");
     }

--- a/embedding-stores/langchain4j-community-cockroachdb/src/test/java/dev/langchain4j/community/store/embedding/cockroachdb/CockroachDbEmbeddingStoreIT.java
+++ b/embedding-stores/langchain4j-community-cockroachdb/src/test/java/dev/langchain4j/community/store/embedding/cockroachdb/CockroachDbEmbeddingStoreIT.java
@@ -1,0 +1,62 @@
+package dev.langchain4j.community.store.embedding.cockroachdb;
+
+import dev.langchain4j.community.store.embedding.cockroachdb.index.CSpannIndex;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.embedding.onnx.allminilml6v2q.AllMiniLmL6V2QuantizedEmbeddingModel;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import dev.langchain4j.store.embedding.EmbeddingStoreWithFilteringIT;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import org.junit.jupiter.api.BeforeAll;
+
+/**
+ * Runs the standard LangChain4j filtering test suite against CockroachDB.
+ * Extends {@link CockroachDbTestBase} for the Testcontainers setup and
+ * {@link EmbeddingStoreWithFilteringIT} for the test methods themselves.
+ */
+class CockroachDbEmbeddingStoreIT extends EmbeddingStoreWithFilteringIT {
+
+    private static final EmbeddingModel MODEL = new AllMiniLmL6V2QuantizedEmbeddingModel();
+
+    private static CockroachDbEngine engine;
+    private static CockroachDbEmbeddingStore store;
+
+    @BeforeAll
+    static void initStore() throws SQLException {
+        org.testcontainers.containers.CockroachContainer cockroach = CockroachDbTestBase.cockroach;
+        if (!cockroach.isRunning()) cockroach.start();
+        engine = CockroachDbEngine.builder()
+                .connectionString(cockroach.getJdbcUrl())
+                .username(cockroach.getUsername())
+                .password(cockroach.getPassword())
+                .build();
+        try (Connection c = engine.getConnection(); Statement st = c.createStatement()) {
+            // CockroachDB v25.2 hides the C-SPANN vector index behind a cluster setting.
+            st.execute("SET CLUSTER SETTING feature.vector_index.enabled = true");
+            st.execute("DROP TABLE IF EXISTS embeddings_it");
+        }
+        store = CockroachDbEmbeddingStore.builder()
+                .engine(engine)
+                .dimension(MODEL.dimension())
+                .tableName("embeddings_it")
+                .vectorIndex(CSpannIndex.builder().build())
+                .build();
+    }
+
+    @Override
+    protected EmbeddingStore<TextSegment> embeddingStore() {
+        return store;
+    }
+
+    @Override
+    protected EmbeddingModel embeddingModel() {
+        return MODEL;
+    }
+
+    @Override
+    protected void clearStore() {
+        store.removeAll();
+    }
+}

--- a/embedding-stores/langchain4j-community-cockroachdb/src/test/java/dev/langchain4j/community/store/embedding/cockroachdb/CockroachDbEmbeddingStoreRemovalIT.java
+++ b/embedding-stores/langchain4j-community-cockroachdb/src/test/java/dev/langchain4j/community/store/embedding/cockroachdb/CockroachDbEmbeddingStoreRemovalIT.java
@@ -5,18 +5,18 @@ import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.model.embedding.onnx.allminilml6v2q.AllMiniLmL6V2QuantizedEmbeddingModel;
 import dev.langchain4j.store.embedding.EmbeddingStore;
-import dev.langchain4j.store.embedding.EmbeddingStoreWithFilteringIT;
+import dev.langchain4j.store.embedding.EmbeddingStoreWithRemovalIT;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 
 /**
- * Runs the standard LangChain4j filtering test suite against CockroachDB.
- * Extends {@link CockroachDbTestBase} for the Testcontainers setup and
- * {@link EmbeddingStoreWithFilteringIT} for the test methods themselves.
+ * Runs the standard removal test suite from langchain4j-core against CockroachDB.
+ * Shares the Testcontainers container declared in {@link CockroachDbTestBase}.
  */
-class CockroachDbEmbeddingStoreIT extends EmbeddingStoreWithFilteringIT {
+class CockroachDbEmbeddingStoreRemovalIT extends EmbeddingStoreWithRemovalIT {
 
     private static final EmbeddingModel MODEL = new AllMiniLmL6V2QuantizedEmbeddingModel();
 
@@ -25,7 +25,7 @@ class CockroachDbEmbeddingStoreIT extends EmbeddingStoreWithFilteringIT {
 
     @BeforeAll
     static void initStore() throws SQLException {
-        org.testcontainers.containers.CockroachContainer cockroach = CockroachDbTestBase.cockroach;
+        var cockroach = CockroachDbTestBase.cockroach;
         if (!cockroach.isRunning()) cockroach.start();
         engine = CockroachDbEngine.builder()
                 .connectionString(cockroach.getJdbcUrl())
@@ -34,16 +34,20 @@ class CockroachDbEmbeddingStoreIT extends EmbeddingStoreWithFilteringIT {
                 .build();
         try (Connection c = engine.getConnection();
                 Statement st = c.createStatement()) {
-            // CockroachDB v25.2 hides the C-SPANN vector index behind a cluster setting.
             st.execute("SET CLUSTER SETTING feature.vector_index.enabled = true");
-            st.execute("DROP TABLE IF EXISTS embeddings_it");
+            st.execute("DROP TABLE IF EXISTS embeddings_removal_it");
         }
         store = CockroachDbEmbeddingStore.builder()
                 .engine(engine)
                 .dimension(MODEL.dimension())
-                .tableName("embeddings_it")
+                .tableName("embeddings_removal_it")
                 .vectorIndex(CSpannIndex.builder().build())
                 .build();
+    }
+
+    @BeforeEach
+    void clearBeforeEach() {
+        store.removeAll();
     }
 
     @Override
@@ -54,10 +58,5 @@ class CockroachDbEmbeddingStoreIT extends EmbeddingStoreWithFilteringIT {
     @Override
     protected EmbeddingModel embeddingModel() {
         return MODEL;
-    }
-
-    @Override
-    protected void clearStore() {
-        store.removeAll();
     }
 }

--- a/embedding-stores/langchain4j-community-cockroachdb/src/test/java/dev/langchain4j/community/store/embedding/cockroachdb/CockroachDbEngineTest.java
+++ b/embedding-stores/langchain4j-community-cockroachdb/src/test/java/dev/langchain4j/community/store/embedding/cockroachdb/CockroachDbEngineTest.java
@@ -5,7 +5,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.Test;
 
-/** Unit tests that do not require a running CockroachDB. */
+/**
+ * Unit tests that do not require a running CockroachDB.
+ */
 class CockroachDbEngineTest {
 
     @Test

--- a/embedding-stores/langchain4j-community-cockroachdb/src/test/java/dev/langchain4j/community/store/embedding/cockroachdb/CockroachDbEngineTest.java
+++ b/embedding-stores/langchain4j-community-cockroachdb/src/test/java/dev/langchain4j/community/store/embedding/cockroachdb/CockroachDbEngineTest.java
@@ -10,8 +10,7 @@ class CockroachDbEngineTest {
 
     @Test
     void rewrites_cockroachdb_scheme_to_jdbc_postgresql() {
-        assertThat(CockroachDbEngine.toJdbcUrl(
-                        "cockroachdb://root@localhost:26257/defaultdb?sslmode=disable"))
+        assertThat(CockroachDbEngine.toJdbcUrl("cockroachdb://root@localhost:26257/defaultdb?sslmode=disable"))
                 .isEqualTo("jdbc:postgresql://root@localhost:26257/defaultdb?sslmode=disable");
     }
 

--- a/embedding-stores/langchain4j-community-cockroachdb/src/test/java/dev/langchain4j/community/store/embedding/cockroachdb/CockroachDbEngineTest.java
+++ b/embedding-stores/langchain4j-community-cockroachdb/src/test/java/dev/langchain4j/community/store/embedding/cockroachdb/CockroachDbEngineTest.java
@@ -1,0 +1,43 @@
+package dev.langchain4j.community.store.embedding.cockroachdb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+/** Unit tests that do not require a running CockroachDB. */
+class CockroachDbEngineTest {
+
+    @Test
+    void rewrites_cockroachdb_scheme_to_jdbc_postgresql() {
+        assertThat(CockroachDbEngine.toJdbcUrl(
+                        "cockroachdb://root@localhost:26257/defaultdb?sslmode=disable"))
+                .isEqualTo("jdbc:postgresql://root@localhost:26257/defaultdb?sslmode=disable");
+    }
+
+    @Test
+    void rewrites_cockroachdb_psycopg_scheme() {
+        assertThat(CockroachDbEngine.toJdbcUrl("cockroachdb+psycopg://user:pw@host:26257/db"))
+                .isEqualTo("jdbc:postgresql://user:pw@host:26257/db");
+    }
+
+    @Test
+    void rewrites_postgresql_scheme() {
+        assertThat(CockroachDbEngine.toJdbcUrl("postgresql://user@host:26257/db"))
+                .isEqualTo("jdbc:postgresql://user@host:26257/db");
+        assertThat(CockroachDbEngine.toJdbcUrl("postgres://user@host:26257/db"))
+                .isEqualTo("jdbc:postgresql://user@host:26257/db");
+    }
+
+    @Test
+    void passes_jdbc_url_through_unchanged() {
+        String jdbc = "jdbc:postgresql://localhost:26257/defaultdb?sslmode=disable";
+        assertThat(CockroachDbEngine.toJdbcUrl(jdbc)).isEqualTo(jdbc);
+    }
+
+    @Test
+    void rejects_unsupported_scheme() {
+        assertThatThrownBy(() -> CockroachDbEngine.toJdbcUrl("mysql://foo"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/embedding-stores/langchain4j-community-cockroachdb/src/test/java/dev/langchain4j/community/store/embedding/cockroachdb/CockroachDbTestBase.java
+++ b/embedding-stores/langchain4j-community-cockroachdb/src/test/java/dev/langchain4j/community/store/embedding/cockroachdb/CockroachDbTestBase.java
@@ -20,13 +20,12 @@ public abstract class CockroachDbTestBase {
 
     private static final Logger logger = LoggerFactory.getLogger(CockroachDbTestBase.class);
 
-    public static final DockerImageName IMAGE =
-            DockerImageName.parse("cockroachdb/cockroach:latest-v25.2");
+    public static final DockerImageName IMAGE = DockerImageName.parse("cockroachdb/cockroach:latest-v25.2");
 
     @Container
     @SuppressWarnings("resource")
-    public static final CockroachContainer cockroach = new CockroachContainer(IMAGE)
-            .waitingFor(Wait.forListeningPort().withStartupTimeout(Duration.ofMinutes(3)));
+    public static final CockroachContainer cockroach =
+            new CockroachContainer(IMAGE).waitingFor(Wait.forListeningPort().withStartupTimeout(Duration.ofMinutes(3)));
 
     protected static CockroachDbEngine engine;
 
@@ -40,7 +39,7 @@ public abstract class CockroachDbTestBase {
                 .build();
         // CockroachDB v25.2 hides the C-SPANN vector index behind a cluster setting.
         try (java.sql.Connection c = engine.getConnection();
-             java.sql.Statement st = c.createStatement()) {
+                java.sql.Statement st = c.createStatement()) {
             st.execute("SET CLUSTER SETTING feature.vector_index.enabled = true");
         }
     }

--- a/embedding-stores/langchain4j-community-cockroachdb/src/test/java/dev/langchain4j/community/store/embedding/cockroachdb/CockroachDbTestBase.java
+++ b/embedding-stores/langchain4j-community-cockroachdb/src/test/java/dev/langchain4j/community/store/embedding/cockroachdb/CockroachDbTestBase.java
@@ -1,0 +1,52 @@
+package dev.langchain4j.community.store.embedding.cockroachdb;
+
+import java.time.Duration;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.CockroachContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Shared Testcontainers setup. Uses a single-node CockroachDB v25.2+ image so the
+ * VECTOR type and {@code CREATE VECTOR INDEX} DDL are available.
+ */
+@Testcontainers
+public abstract class CockroachDbTestBase {
+
+    private static final Logger logger = LoggerFactory.getLogger(CockroachDbTestBase.class);
+
+    public static final DockerImageName IMAGE =
+            DockerImageName.parse("cockroachdb/cockroach:latest-v25.2");
+
+    @Container
+    @SuppressWarnings("resource")
+    public static final CockroachContainer cockroach = new CockroachContainer(IMAGE)
+            .waitingFor(Wait.forListeningPort().withStartupTimeout(Duration.ofMinutes(3)));
+
+    protected static CockroachDbEngine engine;
+
+    @BeforeAll
+    static void initEngine() throws java.sql.SQLException {
+        logger.info("CockroachDB container: {}", cockroach.getJdbcUrl());
+        engine = CockroachDbEngine.builder()
+                .connectionString(cockroach.getJdbcUrl())
+                .username(cockroach.getUsername())
+                .password(cockroach.getPassword())
+                .build();
+        // CockroachDB v25.2 hides the C-SPANN vector index behind a cluster setting.
+        try (java.sql.Connection c = engine.getConnection();
+             java.sql.Statement st = c.createStatement()) {
+            st.execute("SET CLUSTER SETTING feature.vector_index.enabled = true");
+        }
+    }
+
+    @AfterAll
+    static void closeEngine() {
+        if (engine != null) engine.close();
+    }
+}

--- a/embedding-stores/langchain4j-community-cockroachdb/src/test/java/dev/langchain4j/community/store/embedding/cockroachdb/CockroachDbTestBase.java
+++ b/embedding-stores/langchain4j-community-cockroachdb/src/test/java/dev/langchain4j/community/store/embedding/cockroachdb/CockroachDbTestBase.java
@@ -18,8 +18,6 @@ import org.testcontainers.utility.DockerImageName;
 @Testcontainers
 public abstract class CockroachDbTestBase {
 
-    private static final Logger logger = LoggerFactory.getLogger(CockroachDbTestBase.class);
-
     public static final DockerImageName IMAGE = DockerImageName.parse("cockroachdb/cockroach:latest-v25.2");
 
     @Container
@@ -27,6 +25,7 @@ public abstract class CockroachDbTestBase {
     public static final CockroachContainer cockroach =
             new CockroachContainer(IMAGE).waitingFor(Wait.forListeningPort().withStartupTimeout(Duration.ofMinutes(3)));
 
+    private static final Logger logger = LoggerFactory.getLogger(CockroachDbTestBase.class);
     protected static CockroachDbEngine engine;
 
     @BeforeAll

--- a/embedding-stores/langchain4j-community-cockroachdb/src/test/java/dev/langchain4j/community/store/memory/chat/cockroachdb/CockroachDbChatMemoryStoreIT.java
+++ b/embedding-stores/langchain4j-community-cockroachdb/src/test/java/dev/langchain4j/community/store/memory/chat/cockroachdb/CockroachDbChatMemoryStoreIT.java
@@ -29,9 +29,7 @@ class CockroachDbChatMemoryStoreIT extends CockroachDbTestBase {
     void roundtrip_messages_for_a_session() {
         String sessionId = UUID.randomUUID().toString();
         List<ChatMessage> messages = Arrays.asList(
-                SystemMessage.from("You are helpful."),
-                UserMessage.from("Hello"),
-                AiMessage.from("Hi there!"));
+                SystemMessage.from("You are helpful."), UserMessage.from("Hello"), AiMessage.from("Hi there!"));
 
         memory.updateMessages(sessionId, messages);
 

--- a/embedding-stores/langchain4j-community-cockroachdb/src/test/java/dev/langchain4j/community/store/memory/chat/cockroachdb/CockroachDbChatMemoryStoreIT.java
+++ b/embedding-stores/langchain4j-community-cockroachdb/src/test/java/dev/langchain4j/community/store/memory/chat/cockroachdb/CockroachDbChatMemoryStoreIT.java
@@ -44,7 +44,7 @@ class CockroachDbChatMemoryStoreIT extends CockroachDbTestBase {
     void update_replaces_existing_history() {
         String sessionId = UUID.randomUUID().toString();
         memory.updateMessages(sessionId, Arrays.asList(UserMessage.from("a"), AiMessage.from("b")));
-        memory.updateMessages(sessionId, Arrays.asList(UserMessage.from("c")));
+        memory.updateMessages(sessionId, List.of(UserMessage.from("c")));
 
         List<ChatMessage> loaded = memory.getMessages(sessionId);
         assertThat(loaded).hasSize(1);
@@ -54,7 +54,7 @@ class CockroachDbChatMemoryStoreIT extends CockroachDbTestBase {
     @Test
     void delete_clears_session() {
         String sessionId = UUID.randomUUID().toString();
-        memory.updateMessages(sessionId, Arrays.asList(UserMessage.from("a")));
+        memory.updateMessages(sessionId, List.of(UserMessage.from("a")));
         memory.deleteMessages(sessionId);
         assertThat(memory.getMessages(sessionId)).isEmpty();
     }
@@ -63,8 +63,8 @@ class CockroachDbChatMemoryStoreIT extends CockroachDbTestBase {
     void sessions_are_isolated() {
         String s1 = UUID.randomUUID().toString();
         String s2 = UUID.randomUUID().toString();
-        memory.updateMessages(s1, Arrays.asList(UserMessage.from("one")));
-        memory.updateMessages(s2, Arrays.asList(UserMessage.from("two")));
+        memory.updateMessages(s1, List.of(UserMessage.from("one")));
+        memory.updateMessages(s2, List.of(UserMessage.from("two")));
 
         assertThat(memory.getMessages(s1)).hasSize(1);
         assertThat(memory.getMessages(s2)).hasSize(1);

--- a/embedding-stores/langchain4j-community-cockroachdb/src/test/java/dev/langchain4j/community/store/memory/chat/cockroachdb/CockroachDbChatMemoryStoreIT.java
+++ b/embedding-stores/langchain4j-community-cockroachdb/src/test/java/dev/langchain4j/community/store/memory/chat/cockroachdb/CockroachDbChatMemoryStoreIT.java
@@ -1,0 +1,75 @@
+package dev.langchain4j.community.store.memory.chat.cockroachdb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.community.store.embedding.cockroachdb.CockroachDbTestBase;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.data.message.UserMessage;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class CockroachDbChatMemoryStoreIT extends CockroachDbTestBase {
+
+    static CockroachDbChatMemoryStore memory;
+
+    @BeforeAll
+    static void initMemory() {
+        memory = CockroachDbChatMemoryStore.builder()
+                .engine(engine)
+                .tableName("chat_memory_it")
+                .build();
+    }
+
+    @Test
+    void roundtrip_messages_for_a_session() {
+        String sessionId = UUID.randomUUID().toString();
+        List<ChatMessage> messages = Arrays.asList(
+                SystemMessage.from("You are helpful."),
+                UserMessage.from("Hello"),
+                AiMessage.from("Hi there!"));
+
+        memory.updateMessages(sessionId, messages);
+
+        List<ChatMessage> loaded = memory.getMessages(sessionId);
+        assertThat(loaded).hasSize(3);
+        assertThat(loaded.get(0)).isInstanceOf(SystemMessage.class);
+        assertThat(loaded.get(1)).isInstanceOf(UserMessage.class);
+        assertThat(loaded.get(2)).isInstanceOf(AiMessage.class);
+    }
+
+    @Test
+    void update_replaces_existing_history() {
+        String sessionId = UUID.randomUUID().toString();
+        memory.updateMessages(sessionId, Arrays.asList(UserMessage.from("a"), AiMessage.from("b")));
+        memory.updateMessages(sessionId, Arrays.asList(UserMessage.from("c")));
+
+        List<ChatMessage> loaded = memory.getMessages(sessionId);
+        assertThat(loaded).hasSize(1);
+        assertThat(loaded.get(0)).isInstanceOf(UserMessage.class);
+    }
+
+    @Test
+    void delete_clears_session() {
+        String sessionId = UUID.randomUUID().toString();
+        memory.updateMessages(sessionId, Arrays.asList(UserMessage.from("a")));
+        memory.deleteMessages(sessionId);
+        assertThat(memory.getMessages(sessionId)).isEmpty();
+    }
+
+    @Test
+    void sessions_are_isolated() {
+        String s1 = UUID.randomUUID().toString();
+        String s2 = UUID.randomUUID().toString();
+        memory.updateMessages(s1, Arrays.asList(UserMessage.from("one")));
+        memory.updateMessages(s2, Arrays.asList(UserMessage.from("two")));
+
+        assertThat(memory.getMessages(s1)).hasSize(1);
+        assertThat(memory.getMessages(s2)).hasSize(1);
+        assertThat(((UserMessage) memory.getMessages(s1).get(0)).singleText()).isEqualTo("one");
+    }
+}

--- a/embedding-stores/langchain4j-community-cockroachdb/src/test/resources/tinylog.properties
+++ b/embedding-stores/langchain4j-community-cockroachdb/src/test/resources/tinylog.properties
@@ -1,0 +1,2 @@
+writer.level = debug
+writer.format = {date: HH:mm:ss.SSS} [{thread}] {class-name}.{method}() {level}: {message}

--- a/langchain4j-community-bom/pom.xml
+++ b/langchain4j-community-bom/pom.xml
@@ -151,6 +151,12 @@
                 <version>${project.version}</version>
             </dependency>
 
+            <dependency>
+                <groupId>dev.langchain4j</groupId>
+                <artifactId>langchain4j-community-cockroachdb</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
             <!-- memory stores -->
             <dependency>
                 <groupId>dev.langchain4j</groupId>

--- a/langchain4j-community-bom/pom.xml
+++ b/langchain4j-community-bom/pom.xml
@@ -376,6 +376,18 @@
                 <version>${project.version}</version>
             </dependency>
 
+            <dependency>
+                <groupId>dev.langchain4j</groupId>
+                <artifactId>langchain4j-community-cockroachdb-spring-boot-starter</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>dev.langchain4j</groupId>
+                <artifactId>langchain4j-community-cockroachdb-spring-boot4-starter</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
             <!-- Code Execution Engines -->
             <dependency>
                 <groupId>dev.langchain4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
         <module>embedding-stores/langchain4j-community-cloud-sql-pg</module>
         <module>embedding-stores/langchain4j-community-neo4j</module>
         <module>embedding-stores/langchain4j-community-yugabytedb</module>
+        <module>embedding-stores/langchain4j-community-cockroachdb</module>
         <module>embedding-stores/langchain4j-community-sqlserver</module>
         <module>embedding-stores/langchain4j-community-oceanbase</module>
         <module>embedding-stores/langchain4j-community-jvector</module>

--- a/spring-boot-starters/langchain4j-community-cockroachdb-spring-boot-starter/pom.xml
+++ b/spring-boot-starters/langchain4j-community-cockroachdb-spring-boot-starter/pom.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>dev.langchain4j</groupId>
+        <artifactId>langchain4j-community-spring-boot-starters</artifactId>
+        <version>1.16.0-beta26-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>langchain4j-community-cockroachdb-spring-boot-starter</artifactId>
+    <name>LangChain4j :: Community :: Spring Boot starter :: CockroachDB</name>
+
+    <licenses>
+        <license>
+            <name>Apache-2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+            <comments>A business-friendly OSS license</comments>
+        </license>
+    </licenses>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-community-cockroachdb</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-classic</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-embeddings-all-minilm-l6-v2-q</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-spring-boot-tests</artifactId>
+            <classifier>tests</classifier>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>cockroachdb</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.honton.chas</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <configuration>
+                    <skipCompliance>true</skipCompliance>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/spring-boot-starters/langchain4j-community-cockroachdb-spring-boot-starter/revapi.json
+++ b/spring-boot-starters/langchain4j-community-cockroachdb-spring-boot-starter/revapi.json
@@ -1,0 +1,14 @@
+[
+  {
+    "extension": "revapi.differences",
+    "configuration": {
+      "ignore": true,
+      "differences": [
+        {
+          "code": "java.class.externalClassExposedInAPI",
+          "justification": "AutoConfiguration module uses langchain4j core, community, and Spring types as public API - these are external dependency types, not this module's own API surface"
+        }
+      ]
+    }
+  }
+]

--- a/spring-boot-starters/langchain4j-community-cockroachdb-spring-boot-starter/src/main/java/dev/langchain4j/community/cockroachdb/spring/CockroachDbEmbeddingStoreAutoConfiguration.java
+++ b/spring-boot-starters/langchain4j-community-cockroachdb-spring-boot-starter/src/main/java/dev/langchain4j/community/cockroachdb/spring/CockroachDbEmbeddingStoreAutoConfiguration.java
@@ -22,6 +22,22 @@ import org.springframework.context.annotation.Bean;
 @ConditionalOnProperty(prefix = PREFIX, name = "enabled", havingValue = "true", matchIfMissing = true)
 public class CockroachDbEmbeddingStoreAutoConfiguration {
 
+    private static BaseIndex resolveIndex(CockroachDbEmbeddingStoreProperties properties) {
+        String type = properties.getIndexType();
+        if (type == null) return null;
+        switch (type.toLowerCase()) {
+            case "cspann":
+                CSpannIndex.Builder b = CSpannIndex.builder();
+                if (properties.getMinPartitionSize() != null) b.minPartitionSize(properties.getMinPartitionSize());
+                if (properties.getMaxPartitionSize() != null) b.maxPartitionSize(properties.getMaxPartitionSize());
+                return b.build();
+            case "none":
+                return new NoIndex();
+            default:
+                throw new IllegalArgumentException("Unknown indexType '" + type + "', expected one of: cspann, none");
+        }
+    }
+
     @Bean
     @ConditionalOnMissingBean
     public CockroachDbEngine cockroachDbEngine(CockroachDbEmbeddingStoreProperties properties) {
@@ -64,21 +80,5 @@ public class CockroachDbEmbeddingStoreAutoConfiguration {
         if (index != null) builder.vectorIndex(index);
 
         return builder.build();
-    }
-
-    private static BaseIndex resolveIndex(CockroachDbEmbeddingStoreProperties properties) {
-        String type = properties.getIndexType();
-        if (type == null) return null;
-        switch (type.toLowerCase()) {
-            case "cspann":
-                CSpannIndex.Builder b = CSpannIndex.builder();
-                if (properties.getMinPartitionSize() != null) b.minPartitionSize(properties.getMinPartitionSize());
-                if (properties.getMaxPartitionSize() != null) b.maxPartitionSize(properties.getMaxPartitionSize());
-                return b.build();
-            case "none":
-                return new NoIndex();
-            default:
-                throw new IllegalArgumentException("Unknown indexType '" + type + "', expected one of: cspann, none");
-        }
     }
 }

--- a/spring-boot-starters/langchain4j-community-cockroachdb-spring-boot-starter/src/main/java/dev/langchain4j/community/cockroachdb/spring/CockroachDbEmbeddingStoreAutoConfiguration.java
+++ b/spring-boot-starters/langchain4j-community-cockroachdb-spring-boot-starter/src/main/java/dev/langchain4j/community/cockroachdb/spring/CockroachDbEmbeddingStoreAutoConfiguration.java
@@ -1,0 +1,84 @@
+package dev.langchain4j.community.cockroachdb.spring;
+
+import static dev.langchain4j.community.cockroachdb.spring.CockroachDbEmbeddingStoreProperties.PREFIX;
+
+import dev.langchain4j.community.store.embedding.cockroachdb.CockroachDbEmbeddingStore;
+import dev.langchain4j.community.store.embedding.cockroachdb.CockroachDbEngine;
+import dev.langchain4j.community.store.embedding.cockroachdb.MetricType;
+import dev.langchain4j.community.store.embedding.cockroachdb.index.BaseIndex;
+import dev.langchain4j.community.store.embedding.cockroachdb.index.CSpannIndex;
+import dev.langchain4j.community.store.embedding.cockroachdb.index.NoIndex;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import java.util.Optional;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+
+@AutoConfiguration
+@EnableConfigurationProperties(CockroachDbEmbeddingStoreProperties.class)
+@ConditionalOnProperty(prefix = PREFIX, name = "enabled", havingValue = "true", matchIfMissing = true)
+public class CockroachDbEmbeddingStoreAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    public CockroachDbEngine cockroachDbEngine(CockroachDbEmbeddingStoreProperties properties) {
+        CockroachDbEngine.Builder builder = CockroachDbEngine.builder();
+        if (properties.getConnectionString() != null) {
+            builder.connectionString(properties.getConnectionString());
+        }
+        if (properties.getHost() != null) builder.host(properties.getHost());
+        if (properties.getPort() != null) builder.port(properties.getPort());
+        if (properties.getDatabase() != null) builder.database(properties.getDatabase());
+        if (properties.getUsername() != null) builder.username(properties.getUsername());
+        if (properties.getPassword() != null) builder.password(properties.getPassword());
+        if (properties.getSslMode() != null) builder.sslMode(properties.getSslMode());
+        return builder.build();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public CockroachDbEmbeddingStore cockroachDbEmbeddingStore(
+            CockroachDbEmbeddingStoreProperties properties,
+            CockroachDbEngine engine,
+            ObjectProvider<EmbeddingModel> embeddingModelProvider) {
+
+        CockroachDbEmbeddingStore.Builder builder = CockroachDbEmbeddingStore.builder()
+                .engine(engine)
+                .dimension(Optional.ofNullable(embeddingModelProvider.getIfAvailable())
+                        .map(EmbeddingModel::dimension)
+                        .orElse(properties.getDimension()));
+
+        if (properties.getTableName() != null) builder.tableName(properties.getTableName());
+        if (properties.getSchemaName() != null) builder.schemaName(properties.getSchemaName());
+        if (properties.getMetricType() != null) {
+            builder.metricType(MetricType.valueOf(properties.getMetricType().toUpperCase()));
+        }
+        if (properties.getNamespaceColumn() != null) builder.namespaceColumn(properties.getNamespaceColumn());
+        if (properties.getNamespace() != null) builder.namespace(properties.getNamespace());
+        if (properties.getSearchBeamSize() != null) builder.searchBeamSize(properties.getSearchBeamSize());
+
+        BaseIndex index = resolveIndex(properties);
+        if (index != null) builder.vectorIndex(index);
+
+        return builder.build();
+    }
+
+    private static BaseIndex resolveIndex(CockroachDbEmbeddingStoreProperties properties) {
+        String type = properties.getIndexType();
+        if (type == null) return null;
+        switch (type.toLowerCase()) {
+            case "cspann":
+                CSpannIndex.Builder b = CSpannIndex.builder();
+                if (properties.getMinPartitionSize() != null) b.minPartitionSize(properties.getMinPartitionSize());
+                if (properties.getMaxPartitionSize() != null) b.maxPartitionSize(properties.getMaxPartitionSize());
+                return b.build();
+            case "none":
+                return new NoIndex();
+            default:
+                throw new IllegalArgumentException("Unknown indexType '" + type + "', expected one of: cspann, none");
+        }
+    }
+}

--- a/spring-boot-starters/langchain4j-community-cockroachdb-spring-boot-starter/src/main/java/dev/langchain4j/community/cockroachdb/spring/CockroachDbEmbeddingStoreProperties.java
+++ b/spring-boot-starters/langchain4j-community-cockroachdb-spring-boot-starter/src/main/java/dev/langchain4j/community/cockroachdb/spring/CockroachDbEmbeddingStoreProperties.java
@@ -1,0 +1,191 @@
+package dev.langchain4j.community.cockroachdb.spring;
+
+import static dev.langchain4j.community.cockroachdb.spring.CockroachDbEmbeddingStoreProperties.PREFIX;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for the CockroachDB embedding store auto-configuration.
+ *
+ * <p>Either {@link #connectionString} or the combination of
+ * {@link #host}/{@link #port}/{@link #database}/{@link #username}/{@link #password}
+ * must be provided.
+ */
+@ConfigurationProperties(prefix = PREFIX)
+public class CockroachDbEmbeddingStoreProperties {
+
+    static final String PREFIX = "langchain4j.community.cockroachdb";
+
+    /** {@code cockroachdb://}, {@code postgresql://}, or {@code jdbc:postgresql://} URL. */
+    private String connectionString;
+
+    private String host;
+    private Integer port;
+    private String database;
+    private String username;
+    private String password;
+    private String sslMode;
+
+    /** Table name for embeddings. Defaults to {@code embeddings}. */
+    private String tableName;
+
+    /** Database schema. Defaults to {@code public}. */
+    private String schemaName;
+
+    /** Embedding vector dimension. Inferred from the {@code EmbeddingModel} bean when available. */
+    private Integer dimension;
+
+    /** Distance metric: {@code COSINE} (default), {@code EUCLIDEAN}, or {@code DOT_PRODUCT}. */
+    private String metricType;
+
+    /** Optional namespace column for multi-tenancy. */
+    private String namespaceColumn;
+
+    /** Optional namespace value scoping reads and writes through this store. */
+    private String namespace;
+
+    /** Per-query {@code vector_search_beam_size} override (C-SPANN only). */
+    private Integer searchBeamSize;
+
+    /** Vector index to create: {@code cspann} or {@code none}. Defaults to {@code none}. */
+    private String indexType;
+
+    private Integer minPartitionSize;
+    private Integer maxPartitionSize;
+
+    public String getConnectionString() {
+        return connectionString;
+    }
+
+    public void setConnectionString(String connectionString) {
+        this.connectionString = connectionString;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public void setHost(String host) {
+        this.host = host;
+    }
+
+    public Integer getPort() {
+        return port;
+    }
+
+    public void setPort(Integer port) {
+        this.port = port;
+    }
+
+    public String getDatabase() {
+        return database;
+    }
+
+    public void setDatabase(String database) {
+        this.database = database;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getSslMode() {
+        return sslMode;
+    }
+
+    public void setSslMode(String sslMode) {
+        this.sslMode = sslMode;
+    }
+
+    public String getTableName() {
+        return tableName;
+    }
+
+    public void setTableName(String tableName) {
+        this.tableName = tableName;
+    }
+
+    public String getSchemaName() {
+        return schemaName;
+    }
+
+    public void setSchemaName(String schemaName) {
+        this.schemaName = schemaName;
+    }
+
+    public Integer getDimension() {
+        return dimension;
+    }
+
+    public void setDimension(Integer dimension) {
+        this.dimension = dimension;
+    }
+
+    public String getMetricType() {
+        return metricType;
+    }
+
+    public void setMetricType(String metricType) {
+        this.metricType = metricType;
+    }
+
+    public String getNamespaceColumn() {
+        return namespaceColumn;
+    }
+
+    public void setNamespaceColumn(String namespaceColumn) {
+        this.namespaceColumn = namespaceColumn;
+    }
+
+    public String getNamespace() {
+        return namespace;
+    }
+
+    public void setNamespace(String namespace) {
+        this.namespace = namespace;
+    }
+
+    public Integer getSearchBeamSize() {
+        return searchBeamSize;
+    }
+
+    public void setSearchBeamSize(Integer searchBeamSize) {
+        this.searchBeamSize = searchBeamSize;
+    }
+
+    public String getIndexType() {
+        return indexType;
+    }
+
+    public void setIndexType(String indexType) {
+        this.indexType = indexType;
+    }
+
+    public Integer getMinPartitionSize() {
+        return minPartitionSize;
+    }
+
+    public void setMinPartitionSize(Integer minPartitionSize) {
+        this.minPartitionSize = minPartitionSize;
+    }
+
+    public Integer getMaxPartitionSize() {
+        return maxPartitionSize;
+    }
+
+    public void setMaxPartitionSize(Integer maxPartitionSize) {
+        this.maxPartitionSize = maxPartitionSize;
+    }
+}

--- a/spring-boot-starters/langchain4j-community-cockroachdb-spring-boot-starter/src/main/java/dev/langchain4j/community/cockroachdb/spring/CockroachDbEmbeddingStoreProperties.java
+++ b/spring-boot-starters/langchain4j-community-cockroachdb-spring-boot-starter/src/main/java/dev/langchain4j/community/cockroachdb/spring/CockroachDbEmbeddingStoreProperties.java
@@ -16,7 +16,9 @@ public class CockroachDbEmbeddingStoreProperties {
 
     static final String PREFIX = "langchain4j.community.cockroachdb";
 
-    /** {@code cockroachdb://}, {@code postgresql://}, or {@code jdbc:postgresql://} URL. */
+    /**
+     * {@code cockroachdb://}, {@code postgresql://}, or {@code jdbc:postgresql://} URL.
+     */
     private String connectionString;
 
     private String host;
@@ -26,28 +28,44 @@ public class CockroachDbEmbeddingStoreProperties {
     private String password;
     private String sslMode;
 
-    /** Table name for embeddings. Defaults to {@code embeddings}. */
+    /**
+     * Table name for embeddings. Defaults to {@code embeddings}.
+     */
     private String tableName;
 
-    /** Database schema. Defaults to {@code public}. */
+    /**
+     * Database schema. Defaults to {@code public}.
+     */
     private String schemaName;
 
-    /** Embedding vector dimension. Inferred from the {@code EmbeddingModel} bean when available. */
+    /**
+     * Embedding vector dimension. Inferred from the {@code EmbeddingModel} bean when available.
+     */
     private Integer dimension;
 
-    /** Distance metric: {@code COSINE} (default), {@code EUCLIDEAN}, or {@code DOT_PRODUCT}. */
+    /**
+     * Distance metric: {@code COSINE} (default), {@code EUCLIDEAN}, or {@code DOT_PRODUCT}.
+     */
     private String metricType;
 
-    /** Optional namespace column for multi-tenancy. */
+    /**
+     * Optional namespace column for multi-tenancy.
+     */
     private String namespaceColumn;
 
-    /** Optional namespace value scoping reads and writes through this store. */
+    /**
+     * Optional namespace value scoping reads and writes through this store.
+     */
     private String namespace;
 
-    /** Per-query {@code vector_search_beam_size} override (C-SPANN only). */
+    /**
+     * Per-query {@code vector_search_beam_size} override (C-SPANN only).
+     */
     private Integer searchBeamSize;
 
-    /** Vector index to create: {@code cspann} or {@code none}. Defaults to {@code none}. */
+    /**
+     * Vector index to create: {@code cspann} or {@code none}. Defaults to {@code none}.
+     */
     private String indexType;
 
     private Integer minPartitionSize;

--- a/spring-boot-starters/langchain4j-community-cockroachdb-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/spring-boot-starters/langchain4j-community-cockroachdb-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+dev.langchain4j.community.cockroachdb.spring.CockroachDbEmbeddingStoreAutoConfiguration

--- a/spring-boot-starters/langchain4j-community-cockroachdb-spring-boot-starter/src/test/java/dev/langchain4j/community/cockroachdb/spring/CockroachDbEmbeddingStoreAutoConfigurationIT.java
+++ b/spring-boot-starters/langchain4j-community-cockroachdb-spring-boot-starter/src/test/java/dev/langchain4j/community/cockroachdb/spring/CockroachDbEmbeddingStoreAutoConfigurationIT.java
@@ -1,0 +1,72 @@
+package dev.langchain4j.community.cockroachdb.spring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.community.store.embedding.cockroachdb.CockroachDbEmbeddingStore;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.embedding.onnx.allminilml6v2q.AllMiniLmL6V2QuantizedEmbeddingModel;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import dev.langchain4j.store.embedding.spring.EmbeddingStoreAutoConfigurationIT;
+import java.util.concurrent.ThreadLocalRandom;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.testcontainers.containers.CockroachContainer;
+
+class CockroachDbEmbeddingStoreAutoConfigurationIT extends EmbeddingStoreAutoConfigurationIT {
+
+    static final CockroachContainer cockroach = new CockroachContainer("cockroachdb/cockroach:latest-v25.2");
+
+    @BeforeAll
+    static void beforeAll() {
+        cockroach.start();
+    }
+
+    @AfterAll
+    static void afterAll() {
+        cockroach.stop();
+    }
+
+    @Test
+    void should_respect_embedding_model_bean() {
+        contextRunner
+                .withConfiguration(AutoConfigurations.of(TestEmbeddingModelAutoConfiguration.class))
+                .withPropertyValues(properties())
+                .run(context -> {
+                    EmbeddingModel embeddingModel = context.getBean(EmbeddingModel.class);
+                    assertThat(embeddingModel)
+                            .isNotNull()
+                            .isExactlyInstanceOf(AllMiniLmL6V2QuantizedEmbeddingModel.class);
+                    CockroachDbEmbeddingStore store = context.getBean(CockroachDbEmbeddingStore.class);
+                    assertThat(store).isNotNull();
+                });
+    }
+
+    @Override
+    protected Class<?> autoConfigurationClass() {
+        return CockroachDbEmbeddingStoreAutoConfiguration.class;
+    }
+
+    @Override
+    protected Class<? extends EmbeddingStore<TextSegment>> embeddingStoreClass() {
+        return CockroachDbEmbeddingStore.class;
+    }
+
+    @Override
+    protected String[] properties() {
+        return new String[] {
+            "langchain4j.community.cockroachdb.connection-string=" + cockroach.getJdbcUrl(),
+            "langchain4j.community.cockroachdb.username=" + cockroach.getUsername(),
+            "langchain4j.community.cockroachdb.password=" + cockroach.getPassword(),
+            "langchain4j.community.cockroachdb.table-name=" + "starter_it_"
+                    + ThreadLocalRandom.current().nextInt(0, Integer.MAX_VALUE),
+        };
+    }
+
+    @Override
+    protected String dimensionPropertyKey() {
+        return "langchain4j.community.cockroachdb.dimension";
+    }
+}

--- a/spring-boot-starters/langchain4j-community-cockroachdb-spring-boot-starter/src/test/java/dev/langchain4j/community/cockroachdb/spring/TestEmbeddingModelAutoConfiguration.java
+++ b/spring-boot-starters/langchain4j-community-cockroachdb-spring-boot-starter/src/test/java/dev/langchain4j/community/cockroachdb/spring/TestEmbeddingModelAutoConfiguration.java
@@ -1,0 +1,15 @@
+package dev.langchain4j.community.cockroachdb.spring;
+
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.embedding.onnx.allminilml6v2q.AllMiniLmL6V2QuantizedEmbeddingModel;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TestEmbeddingModelAutoConfiguration {
+
+    @Bean
+    public EmbeddingModel embeddingModel() {
+        return new AllMiniLmL6V2QuantizedEmbeddingModel();
+    }
+}

--- a/spring-boot-starters/pom.xml
+++ b/spring-boot-starters/pom.xml
@@ -35,6 +35,7 @@
         <module>langchain4j-community-oceanbase-spring-boot-starter</module>
         <module>langchain4j-community-zhipu-ai-spring-boot-starter</module>
         <module>langchain4j-community-cohere-spring-boot-starter</module>
+        <module>langchain4j-community-cockroachdb-spring-boot-starter</module>
     </modules>
 
     <properties>

--- a/spring-boot4-starters/langchain4j-community-cockroachdb-spring-boot4-starter/pom.xml
+++ b/spring-boot4-starters/langchain4j-community-cockroachdb-spring-boot4-starter/pom.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>dev.langchain4j</groupId>
+        <artifactId>langchain4j-community-spring-boot4-starters</artifactId>
+        <version>1.16.0-beta26-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>langchain4j-community-cockroachdb-spring-boot4-starter</artifactId>
+    <name>LangChain4j :: Community :: Spring Boot 4 starter :: CockroachDB</name>
+
+    <licenses>
+        <license>
+            <name>Apache-2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+            <comments>A business-friendly OSS license</comments>
+        </license>
+    </licenses>
+
+    <dependencyManagement>
+        <dependencies>
+            <!--
+            langchain4j-community-cockroachdb pins postgresql 42.7.11 but the Spring
+            Boot 4 BOM manages it down to 42.7.10, which fails RequireUpperBoundDeps.
+            Promote it back to 42.7.11.
+            -->
+            <dependency>
+                <groupId>org.postgresql</groupId>
+                <artifactId>postgresql</artifactId>
+                <version>42.7.11</version>
+            </dependency>
+            <!-- Required by Testcontainers, not managed by the Boot 4 BOM. -->
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>3.20.0</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-community-cockroachdb</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-classic</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-embeddings-all-minilm-l6-v2-q</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-spring-boot-tests</artifactId>
+            <version>${project.version}</version>
+            <classifier>tests</classifier>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>cockroachdb</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Required by Testcontainers; not pulled in transitively under the Boot 4 BOM. -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.honton.chas</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <configuration>
+                    <skipCompliance>true</skipCompliance>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/spring-boot4-starters/langchain4j-community-cockroachdb-spring-boot4-starter/revapi.json
+++ b/spring-boot4-starters/langchain4j-community-cockroachdb-spring-boot4-starter/revapi.json
@@ -1,0 +1,14 @@
+[
+  {
+    "extension": "revapi.differences",
+    "configuration": {
+      "ignore": true,
+      "differences": [
+        {
+          "code": "java.class.externalClassExposedInAPI",
+          "justification": "AutoConfiguration module uses langchain4j core, community, and Spring types as public API - these are external dependency types, not this module's own API surface"
+        }
+      ]
+    }
+  }
+]

--- a/spring-boot4-starters/langchain4j-community-cockroachdb-spring-boot4-starter/src/main/java/dev/langchain4j/community/cockroachdb/spring/CockroachDbEmbeddingStoreAutoConfiguration.java
+++ b/spring-boot4-starters/langchain4j-community-cockroachdb-spring-boot4-starter/src/main/java/dev/langchain4j/community/cockroachdb/spring/CockroachDbEmbeddingStoreAutoConfiguration.java
@@ -22,6 +22,22 @@ import org.springframework.context.annotation.Bean;
 @ConditionalOnProperty(prefix = PREFIX, name = "enabled", havingValue = "true", matchIfMissing = true)
 public class CockroachDbEmbeddingStoreAutoConfiguration {
 
+    private static BaseIndex resolveIndex(CockroachDbEmbeddingStoreProperties properties) {
+        String type = properties.getIndexType();
+        if (type == null) return null;
+        switch (type.toLowerCase()) {
+            case "cspann":
+                CSpannIndex.Builder b = CSpannIndex.builder();
+                if (properties.getMinPartitionSize() != null) b.minPartitionSize(properties.getMinPartitionSize());
+                if (properties.getMaxPartitionSize() != null) b.maxPartitionSize(properties.getMaxPartitionSize());
+                return b.build();
+            case "none":
+                return new NoIndex();
+            default:
+                throw new IllegalArgumentException("Unknown indexType '" + type + "', expected one of: cspann, none");
+        }
+    }
+
     @Bean
     @ConditionalOnMissingBean
     public CockroachDbEngine cockroachDbEngine(CockroachDbEmbeddingStoreProperties properties) {
@@ -64,21 +80,5 @@ public class CockroachDbEmbeddingStoreAutoConfiguration {
         if (index != null) builder.vectorIndex(index);
 
         return builder.build();
-    }
-
-    private static BaseIndex resolveIndex(CockroachDbEmbeddingStoreProperties properties) {
-        String type = properties.getIndexType();
-        if (type == null) return null;
-        switch (type.toLowerCase()) {
-            case "cspann":
-                CSpannIndex.Builder b = CSpannIndex.builder();
-                if (properties.getMinPartitionSize() != null) b.minPartitionSize(properties.getMinPartitionSize());
-                if (properties.getMaxPartitionSize() != null) b.maxPartitionSize(properties.getMaxPartitionSize());
-                return b.build();
-            case "none":
-                return new NoIndex();
-            default:
-                throw new IllegalArgumentException("Unknown indexType '" + type + "', expected one of: cspann, none");
-        }
     }
 }

--- a/spring-boot4-starters/langchain4j-community-cockroachdb-spring-boot4-starter/src/main/java/dev/langchain4j/community/cockroachdb/spring/CockroachDbEmbeddingStoreAutoConfiguration.java
+++ b/spring-boot4-starters/langchain4j-community-cockroachdb-spring-boot4-starter/src/main/java/dev/langchain4j/community/cockroachdb/spring/CockroachDbEmbeddingStoreAutoConfiguration.java
@@ -1,0 +1,84 @@
+package dev.langchain4j.community.cockroachdb.spring;
+
+import static dev.langchain4j.community.cockroachdb.spring.CockroachDbEmbeddingStoreProperties.PREFIX;
+
+import dev.langchain4j.community.store.embedding.cockroachdb.CockroachDbEmbeddingStore;
+import dev.langchain4j.community.store.embedding.cockroachdb.CockroachDbEngine;
+import dev.langchain4j.community.store.embedding.cockroachdb.MetricType;
+import dev.langchain4j.community.store.embedding.cockroachdb.index.BaseIndex;
+import dev.langchain4j.community.store.embedding.cockroachdb.index.CSpannIndex;
+import dev.langchain4j.community.store.embedding.cockroachdb.index.NoIndex;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import java.util.Optional;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+
+@AutoConfiguration
+@EnableConfigurationProperties(CockroachDbEmbeddingStoreProperties.class)
+@ConditionalOnProperty(prefix = PREFIX, name = "enabled", havingValue = "true", matchIfMissing = true)
+public class CockroachDbEmbeddingStoreAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    public CockroachDbEngine cockroachDbEngine(CockroachDbEmbeddingStoreProperties properties) {
+        CockroachDbEngine.Builder builder = CockroachDbEngine.builder();
+        if (properties.getConnectionString() != null) {
+            builder.connectionString(properties.getConnectionString());
+        }
+        if (properties.getHost() != null) builder.host(properties.getHost());
+        if (properties.getPort() != null) builder.port(properties.getPort());
+        if (properties.getDatabase() != null) builder.database(properties.getDatabase());
+        if (properties.getUsername() != null) builder.username(properties.getUsername());
+        if (properties.getPassword() != null) builder.password(properties.getPassword());
+        if (properties.getSslMode() != null) builder.sslMode(properties.getSslMode());
+        return builder.build();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public CockroachDbEmbeddingStore cockroachDbEmbeddingStore(
+            CockroachDbEmbeddingStoreProperties properties,
+            CockroachDbEngine engine,
+            ObjectProvider<EmbeddingModel> embeddingModelProvider) {
+
+        CockroachDbEmbeddingStore.Builder builder = CockroachDbEmbeddingStore.builder()
+                .engine(engine)
+                .dimension(Optional.ofNullable(embeddingModelProvider.getIfAvailable())
+                        .map(EmbeddingModel::dimension)
+                        .orElse(properties.getDimension()));
+
+        if (properties.getTableName() != null) builder.tableName(properties.getTableName());
+        if (properties.getSchemaName() != null) builder.schemaName(properties.getSchemaName());
+        if (properties.getMetricType() != null) {
+            builder.metricType(MetricType.valueOf(properties.getMetricType().toUpperCase()));
+        }
+        if (properties.getNamespaceColumn() != null) builder.namespaceColumn(properties.getNamespaceColumn());
+        if (properties.getNamespace() != null) builder.namespace(properties.getNamespace());
+        if (properties.getSearchBeamSize() != null) builder.searchBeamSize(properties.getSearchBeamSize());
+
+        BaseIndex index = resolveIndex(properties);
+        if (index != null) builder.vectorIndex(index);
+
+        return builder.build();
+    }
+
+    private static BaseIndex resolveIndex(CockroachDbEmbeddingStoreProperties properties) {
+        String type = properties.getIndexType();
+        if (type == null) return null;
+        switch (type.toLowerCase()) {
+            case "cspann":
+                CSpannIndex.Builder b = CSpannIndex.builder();
+                if (properties.getMinPartitionSize() != null) b.minPartitionSize(properties.getMinPartitionSize());
+                if (properties.getMaxPartitionSize() != null) b.maxPartitionSize(properties.getMaxPartitionSize());
+                return b.build();
+            case "none":
+                return new NoIndex();
+            default:
+                throw new IllegalArgumentException("Unknown indexType '" + type + "', expected one of: cspann, none");
+        }
+    }
+}

--- a/spring-boot4-starters/langchain4j-community-cockroachdb-spring-boot4-starter/src/main/java/dev/langchain4j/community/cockroachdb/spring/CockroachDbEmbeddingStoreProperties.java
+++ b/spring-boot4-starters/langchain4j-community-cockroachdb-spring-boot4-starter/src/main/java/dev/langchain4j/community/cockroachdb/spring/CockroachDbEmbeddingStoreProperties.java
@@ -1,0 +1,191 @@
+package dev.langchain4j.community.cockroachdb.spring;
+
+import static dev.langchain4j.community.cockroachdb.spring.CockroachDbEmbeddingStoreProperties.PREFIX;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for the CockroachDB embedding store auto-configuration.
+ *
+ * <p>Either {@link #connectionString} or the combination of
+ * {@link #host}/{@link #port}/{@link #database}/{@link #username}/{@link #password}
+ * must be provided.
+ */
+@ConfigurationProperties(prefix = PREFIX)
+public class CockroachDbEmbeddingStoreProperties {
+
+    static final String PREFIX = "langchain4j.community.cockroachdb";
+
+    /** {@code cockroachdb://}, {@code postgresql://}, or {@code jdbc:postgresql://} URL. */
+    private String connectionString;
+
+    private String host;
+    private Integer port;
+    private String database;
+    private String username;
+    private String password;
+    private String sslMode;
+
+    /** Table name for embeddings. Defaults to {@code embeddings}. */
+    private String tableName;
+
+    /** Database schema. Defaults to {@code public}. */
+    private String schemaName;
+
+    /** Embedding vector dimension. Inferred from the {@code EmbeddingModel} bean when available. */
+    private Integer dimension;
+
+    /** Distance metric: {@code COSINE} (default), {@code EUCLIDEAN}, or {@code DOT_PRODUCT}. */
+    private String metricType;
+
+    /** Optional namespace column for multi-tenancy. */
+    private String namespaceColumn;
+
+    /** Optional namespace value scoping reads and writes through this store. */
+    private String namespace;
+
+    /** Per-query {@code vector_search_beam_size} override (C-SPANN only). */
+    private Integer searchBeamSize;
+
+    /** Vector index to create: {@code cspann} or {@code none}. Defaults to {@code none}. */
+    private String indexType;
+
+    private Integer minPartitionSize;
+    private Integer maxPartitionSize;
+
+    public String getConnectionString() {
+        return connectionString;
+    }
+
+    public void setConnectionString(String connectionString) {
+        this.connectionString = connectionString;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public void setHost(String host) {
+        this.host = host;
+    }
+
+    public Integer getPort() {
+        return port;
+    }
+
+    public void setPort(Integer port) {
+        this.port = port;
+    }
+
+    public String getDatabase() {
+        return database;
+    }
+
+    public void setDatabase(String database) {
+        this.database = database;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getSslMode() {
+        return sslMode;
+    }
+
+    public void setSslMode(String sslMode) {
+        this.sslMode = sslMode;
+    }
+
+    public String getTableName() {
+        return tableName;
+    }
+
+    public void setTableName(String tableName) {
+        this.tableName = tableName;
+    }
+
+    public String getSchemaName() {
+        return schemaName;
+    }
+
+    public void setSchemaName(String schemaName) {
+        this.schemaName = schemaName;
+    }
+
+    public Integer getDimension() {
+        return dimension;
+    }
+
+    public void setDimension(Integer dimension) {
+        this.dimension = dimension;
+    }
+
+    public String getMetricType() {
+        return metricType;
+    }
+
+    public void setMetricType(String metricType) {
+        this.metricType = metricType;
+    }
+
+    public String getNamespaceColumn() {
+        return namespaceColumn;
+    }
+
+    public void setNamespaceColumn(String namespaceColumn) {
+        this.namespaceColumn = namespaceColumn;
+    }
+
+    public String getNamespace() {
+        return namespace;
+    }
+
+    public void setNamespace(String namespace) {
+        this.namespace = namespace;
+    }
+
+    public Integer getSearchBeamSize() {
+        return searchBeamSize;
+    }
+
+    public void setSearchBeamSize(Integer searchBeamSize) {
+        this.searchBeamSize = searchBeamSize;
+    }
+
+    public String getIndexType() {
+        return indexType;
+    }
+
+    public void setIndexType(String indexType) {
+        this.indexType = indexType;
+    }
+
+    public Integer getMinPartitionSize() {
+        return minPartitionSize;
+    }
+
+    public void setMinPartitionSize(Integer minPartitionSize) {
+        this.minPartitionSize = minPartitionSize;
+    }
+
+    public Integer getMaxPartitionSize() {
+        return maxPartitionSize;
+    }
+
+    public void setMaxPartitionSize(Integer maxPartitionSize) {
+        this.maxPartitionSize = maxPartitionSize;
+    }
+}

--- a/spring-boot4-starters/langchain4j-community-cockroachdb-spring-boot4-starter/src/main/java/dev/langchain4j/community/cockroachdb/spring/CockroachDbEmbeddingStoreProperties.java
+++ b/spring-boot4-starters/langchain4j-community-cockroachdb-spring-boot4-starter/src/main/java/dev/langchain4j/community/cockroachdb/spring/CockroachDbEmbeddingStoreProperties.java
@@ -16,7 +16,9 @@ public class CockroachDbEmbeddingStoreProperties {
 
     static final String PREFIX = "langchain4j.community.cockroachdb";
 
-    /** {@code cockroachdb://}, {@code postgresql://}, or {@code jdbc:postgresql://} URL. */
+    /**
+     * {@code cockroachdb://}, {@code postgresql://}, or {@code jdbc:postgresql://} URL.
+     */
     private String connectionString;
 
     private String host;
@@ -26,28 +28,44 @@ public class CockroachDbEmbeddingStoreProperties {
     private String password;
     private String sslMode;
 
-    /** Table name for embeddings. Defaults to {@code embeddings}. */
+    /**
+     * Table name for embeddings. Defaults to {@code embeddings}.
+     */
     private String tableName;
 
-    /** Database schema. Defaults to {@code public}. */
+    /**
+     * Database schema. Defaults to {@code public}.
+     */
     private String schemaName;
 
-    /** Embedding vector dimension. Inferred from the {@code EmbeddingModel} bean when available. */
+    /**
+     * Embedding vector dimension. Inferred from the {@code EmbeddingModel} bean when available.
+     */
     private Integer dimension;
 
-    /** Distance metric: {@code COSINE} (default), {@code EUCLIDEAN}, or {@code DOT_PRODUCT}. */
+    /**
+     * Distance metric: {@code COSINE} (default), {@code EUCLIDEAN}, or {@code DOT_PRODUCT}.
+     */
     private String metricType;
 
-    /** Optional namespace column for multi-tenancy. */
+    /**
+     * Optional namespace column for multi-tenancy.
+     */
     private String namespaceColumn;
 
-    /** Optional namespace value scoping reads and writes through this store. */
+    /**
+     * Optional namespace value scoping reads and writes through this store.
+     */
     private String namespace;
 
-    /** Per-query {@code vector_search_beam_size} override (C-SPANN only). */
+    /**
+     * Per-query {@code vector_search_beam_size} override (C-SPANN only).
+     */
     private Integer searchBeamSize;
 
-    /** Vector index to create: {@code cspann} or {@code none}. Defaults to {@code none}. */
+    /**
+     * Vector index to create: {@code cspann} or {@code none}. Defaults to {@code none}.
+     */
     private String indexType;
 
     private Integer minPartitionSize;

--- a/spring-boot4-starters/langchain4j-community-cockroachdb-spring-boot4-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/spring-boot4-starters/langchain4j-community-cockroachdb-spring-boot4-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+dev.langchain4j.community.cockroachdb.spring.CockroachDbEmbeddingStoreAutoConfiguration

--- a/spring-boot4-starters/langchain4j-community-cockroachdb-spring-boot4-starter/src/test/java/dev/langchain4j/community/cockroachdb/spring/CockroachDbEmbeddingStoreAutoConfigurationIT.java
+++ b/spring-boot4-starters/langchain4j-community-cockroachdb-spring-boot4-starter/src/test/java/dev/langchain4j/community/cockroachdb/spring/CockroachDbEmbeddingStoreAutoConfigurationIT.java
@@ -1,0 +1,72 @@
+package dev.langchain4j.community.cockroachdb.spring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.community.store.embedding.cockroachdb.CockroachDbEmbeddingStore;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.embedding.onnx.allminilml6v2q.AllMiniLmL6V2QuantizedEmbeddingModel;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import dev.langchain4j.store.embedding.spring.EmbeddingStoreAutoConfigurationIT;
+import java.util.concurrent.ThreadLocalRandom;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.testcontainers.containers.CockroachContainer;
+
+class CockroachDbEmbeddingStoreAutoConfigurationIT extends EmbeddingStoreAutoConfigurationIT {
+
+    static final CockroachContainer cockroach = new CockroachContainer("cockroachdb/cockroach:latest-v25.2");
+
+    @BeforeAll
+    static void beforeAll() {
+        cockroach.start();
+    }
+
+    @AfterAll
+    static void afterAll() {
+        cockroach.stop();
+    }
+
+    @Test
+    void should_respect_embedding_model_bean() {
+        contextRunner
+                .withConfiguration(AutoConfigurations.of(TestEmbeddingModelAutoConfiguration.class))
+                .withPropertyValues(properties())
+                .run(context -> {
+                    EmbeddingModel embeddingModel = context.getBean(EmbeddingModel.class);
+                    assertThat(embeddingModel)
+                            .isNotNull()
+                            .isExactlyInstanceOf(AllMiniLmL6V2QuantizedEmbeddingModel.class);
+                    CockroachDbEmbeddingStore store = context.getBean(CockroachDbEmbeddingStore.class);
+                    assertThat(store).isNotNull();
+                });
+    }
+
+    @Override
+    protected Class<?> autoConfigurationClass() {
+        return CockroachDbEmbeddingStoreAutoConfiguration.class;
+    }
+
+    @Override
+    protected Class<? extends EmbeddingStore<TextSegment>> embeddingStoreClass() {
+        return CockroachDbEmbeddingStore.class;
+    }
+
+    @Override
+    protected String[] properties() {
+        return new String[] {
+            "langchain4j.community.cockroachdb.connection-string=" + cockroach.getJdbcUrl(),
+            "langchain4j.community.cockroachdb.username=" + cockroach.getUsername(),
+            "langchain4j.community.cockroachdb.password=" + cockroach.getPassword(),
+            "langchain4j.community.cockroachdb.table-name=" + "starter_it_"
+                    + ThreadLocalRandom.current().nextInt(0, Integer.MAX_VALUE),
+        };
+    }
+
+    @Override
+    protected String dimensionPropertyKey() {
+        return "langchain4j.community.cockroachdb.dimension";
+    }
+}

--- a/spring-boot4-starters/langchain4j-community-cockroachdb-spring-boot4-starter/src/test/java/dev/langchain4j/community/cockroachdb/spring/TestEmbeddingModelAutoConfiguration.java
+++ b/spring-boot4-starters/langchain4j-community-cockroachdb-spring-boot4-starter/src/test/java/dev/langchain4j/community/cockroachdb/spring/TestEmbeddingModelAutoConfiguration.java
@@ -1,0 +1,15 @@
+package dev.langchain4j.community.cockroachdb.spring;
+
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.embedding.onnx.allminilml6v2q.AllMiniLmL6V2QuantizedEmbeddingModel;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TestEmbeddingModelAutoConfiguration {
+
+    @Bean
+    public EmbeddingModel embeddingModel() {
+        return new AllMiniLmL6V2QuantizedEmbeddingModel();
+    }
+}

--- a/spring-boot4-starters/pom.xml
+++ b/spring-boot4-starters/pom.xml
@@ -35,6 +35,7 @@
         <module>langchain4j-community-xinference-spring-boot4-starter</module>
         <module>langchain4j-community-zhipu-ai-spring-boot4-starter</module>
         <module>langchain4j-community-cohere-spring-boot4-starter</module>
+        <module>langchain4j-community-cockroachdb-spring-boot4-starter</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
## Issue
Closes #672

## Change

Add a new community module `langchain4j-community-cockroachdb` integrating CockroachDB as:

- a vector `EmbeddingStore<TextSegment>`, backed by the native `VECTOR` column type (CockroachDB v24.2+) and the C-SPANN distributed ANN index (v25.2+);
- a `ChatMemoryStore`, with optional row-level TTL;
- Spring Boot 3 and Spring Boot 4 starters.

The implementation mirrors the feature surface of the Python [`langchain-cockroachdb`](https://github.com/cockroachdb/langchain-cockroachdb) library where a Java equivalent exists.

### Key classes

- `CockroachDbEngine` wraps a HikariCP `DataSource`. The Python-style `cockroachdb://` URL scheme is rewritten to `jdbc:postgresql://` automatically, so the same connection strings used by the Python library work unchanged.
- `CockroachDbSchema` configures the embedding table; pluggable `BaseIndex` lets callers choose `CSpannIndex` (CockroachDB v25.2+) or `NoIndex` (sequential scan).
- `CockroachDbEmbeddingStore` implements `EmbeddingStore<TextSegment>` with JSONB metadata filtering, namespace-based multi-tenancy, per-query `vector_search_beam_size`, and 40001 (`restart transaction`) retry.
- `CockroachDbChatMemoryStore` implements `ChatMemoryStore` with row-level TTL via `ttl_expiration_expression`.

### CockroachDB-specific notes

- All vector parameters are sent as text and cast with `?::vector` because CockroachDB's pgwire layer does not accept the binary format for the `VECTOR` type.
- On CockroachDB v25.2, the cluster setting `feature.vector_index.enabled = true` must be enabled once per cluster before `CSpannIndex` can be used.
- Batched chat memory inserts use an explicit `idx` column so insertion order is preserved when several messages share the same `created_at` timestamp.

### Spring Boot starters

- `langchain4j-community-cockroachdb-spring-boot-starter` (Boot 3)
- `langchain4j-community-cockroachdb-spring-boot4-starter` (Boot 4)

Both expose the same `langchain4j.community.cockroachdb.*` property tree and produce `CockroachDbEngine` + `CockroachDbEmbeddingStore` beans, each guarded by `@ConditionalOnMissingBean`. The Boot 4 starter pins `postgresql` 42.7.11 (the Boot 4 BOM otherwise manages it down to 42.7.10) and pulls `commons-lang3` explicitly for Testcontainers.

## Companion PRs

- Example: langchain4j/langchain4j-examples#195
- Docs page: langchain4j/langchain4j#5262
- LangGraph checkpointer (separate ecosystem): langgraph4j/langgraph4j#404

## Test results

All tests pass against a Testcontainers `cockroachdb/cockroach:latest-v25.2` image:

- 9 unit tests (`CockroachDbEngineTest` + `CSpannIndexTest`)
- 4 chat memory IT tests
- 10 removal IT tests (`CockroachDbEmbeddingStoreRemovalIT` extending `EmbeddingStoreWithRemovalIT`)
- 108 filtering IT tests (`CockroachDbEmbeddingStoreIT` extending `EmbeddingStoreWithFilteringIT`, 2 not-applicable skips)
- 3 Boot 3 starter IT tests
- 3 Boot 4 starter IT tests

## General checklist
- [x] There are no breaking changes
- [x] I have added unit and integration tests for my change
- [x] I have manually run all the unit tests in *all* modules, and they are all green
- [x] I have manually run all integration tests in the module I have added/changed, and they are all green
- [x] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs) (langchain4j/langchain4j#5262)
- [x] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (langchain4j/langchain4j-examples#195)
- [x] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (both Boot 3 and Boot 4 starters added in this PR)

## Checklist for adding new maven module
- [x] I have added my new module in the root `pom.xml` and `langchain4j-community-bom/pom.xml`

## Checklist for adding new embedding store integration
- [x] I have added a `CockroachDbEmbeddingStoreIT` that extends from `EmbeddingStoreWithFilteringIT`
- [x] I have added a `CockroachDbEmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`