### PR TITLE
feat: set default CLIENT SETNAME for Valkey Spring Boot starter

### DIFF
--- a/spring-boot-starters/langchain4j-community-valkey-spring-boot-starter/src/main/java/dev/langchain4j/community/store/embedding/valkey/spring/ValkeyEmbeddingStoreProperties.java
+++ b/spring-boot-starters/langchain4j-community-valkey-spring-boot-starter/src/main/java/dev/langchain4j/community/store/embedding/valkey/spring/ValkeyEmbeddingStoreProperties.java
@@ -14,7 +14,7 @@ public class ValkeyEmbeddingStoreProperties {
     private String password;
     private Boolean useTls;
     private Integer requestTimeout;
-    private String clientName;
+    private String clientName = "langchain4j_embedding_store_client";
     private String indexName;
     private String prefix;
     private Integer dimension;


### PR DESCRIPTION
## Issue

Fixes #681

## Change

Sets a default `clientName = "langchain4j_embedding_store_client"` in `ValkeyEmbeddingStoreProperties` so that Spring Boot auto-configured connections are identifiable via `CLIENT LIST` out of the box — no explicit configuration required.

Users can still override it via `langchain4j.community.valkey.client-name=my_custom_name` in their `application.properties`.

## Why This Matters

Without a default client name, connections appear anonymous in `CLIENT LIST`, making it impossible to distinguish Langchain4j connections from other clients sharing the same Valkey cluster. This is important for production monitoring with ElastiCache/CloudWatch.

## General checklist

- [x] There are no breaking changes
- [ ] I have added unit and integration tests for my change
- [x] I have manually run all the unit tests in _all_ modules, and they are all green
- [x] I have manually run all integration tests in the module I have added/changed, and they are all green
