### PR TITLE
Add Hazelcast integration

### DIFF
--- a/chat-memory-stores/langchain4j-community-hazelcast/pom.xml
+++ b/chat-memory-stores/langchain4j-community-hazelcast/pom.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>dev.langchain4j</groupId>
+        <artifactId>langchain4j-community</artifactId>
+        <version>1.17.0-beta27-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>langchain4j-community-hazelcast</artifactId>
+    <name>LangChain4j :: Community :: Integration :: Hazelcast</name>
+    <description>Hazelcast ChatMemoryStore backed by an IMap.</description>
+
+    <properties>
+        <hazelcast.version>5.7.0</hazelcast.version>
+    </properties>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-core</artifactId>
+            <version>${langchain4j.core.version}</version>
+        </dependency>
+
+        <!--
+            Hazelcast is provided: the consumer supplies the jar, so the same store works on either
+            the open-source Community Edition (com.hazelcast:hazelcast) or the commercial Enterprise
+            Edition (com.hazelcast:hazelcast-enterprise) without a clashing duplicate on the classpath.
+        -->
+        <dependency>
+            <groupId>com.hazelcast</groupId>
+            <artifactId>hazelcast</artifactId>
+            <version>${hazelcast.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- test dependencies -->
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- junit-jupiter-params is used by the parameterized validation tests -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <systemProperties>
+                        <java.net.preferIPv4Stack>true</java.net.preferIPv4Stack>
+                    </systemProperties>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.revapi</groupId>
+                <artifactId>revapi-maven-plugin</artifactId>
+                <configuration>
+                    <analysisConfiguration>
+                        <revapi.differences>
+                            <differences>
+                                <!--
+                                    Hazelcast types are an intentionally provided dependency, and
+                                    ChatMessage is part of the ChatMemoryStore API by design.
+                                -->
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.missing.newClass</code>
+                                    <new>missing-class com.hazelcast.core.HazelcastInstance</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.class.externalClassExposedInAPI</code>
+                                    <new>missing-class com.hazelcast.core.HazelcastInstance</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.missing.newClass</code>
+                                    <new>missing-class com.hazelcast.map.IMap</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.class.externalClassExposedInAPI</code>
+                                    <new>missing-class com.hazelcast.map.IMap</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.missing.newClass</code>
+                                    <new>missing-class dev.langchain4j.data.message.ChatMessage</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.class.externalClassExposedInAPI</code>
+                                    <new>missing-class dev.langchain4j.data.message.ChatMessage</new>
+                                </item>
+                            </differences>
+                        </revapi.differences>
+                    </analysisConfiguration>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/chat-memory-stores/langchain4j-community-hazelcast/src/main/java/dev/langchain4j/community/store/memory/chat/hazelcast/HazelcastChatMemoryStore.java
+++ b/chat-memory-stores/langchain4j-community-hazelcast/src/main/java/dev/langchain4j/community/store/memory/chat/hazelcast/HazelcastChatMemoryStore.java
@@ -1,0 +1,236 @@
+package dev.langchain4j.community.store.memory.chat.hazelcast;
+
+import static dev.langchain4j.internal.Utils.isNullOrBlank;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotEmpty;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.map.IMap;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ChatMessageDeserializer;
+import dev.langchain4j.data.message.ChatMessageSerializer;
+import dev.langchain4j.store.memory.chat.ChatMemoryStore;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A {@link ChatMemoryStore} backed by a Hazelcast {@link IMap}.
+ * <p>
+ * The {@link HazelcastChatMemoryStore} supports memory identifiers of any type
+ * whose {@code toString()} produces a valid and stable map key. The key type
+ * must properly implement {@code equals()} and {@code hashCode()}.
+ * <p>
+ * Each chat memory id is stored as a {@link String} key in the {@link IMap};
+ * the value is a JSON-serialised list of {@link ChatMessage}s produced by
+ * {@link ChatMessageSerializer}.
+ * <p>
+ * Hazelcast can operate in two distinct topologies, and the way a
+ * {@link HazelcastInstance} is obtained differs between them:
+ *
+ * <h2>Embedded member (Hazelcast runs inside the application JVM)</h2>
+ * <pre>{@code
+ * HazelcastInstance hz = Hazelcast.newHazelcastInstance(new Config());
+ *
+ * ChatMemoryStore store = HazelcastChatMemoryStore.builder()
+ *         .hazelcastInstance(hz)
+ *         .build();
+ * }</pre>
+ *
+ * <h2>Client/server (Hazelcast runs as a separate cluster)</h2>
+ * <pre>{@code
+ * ClientConfig clientConfig = new ClientConfig();
+ * clientConfig.getNetworkConfig().addAddress("hazelcast-host:5701");
+ * // configure TLS, credentials, etc. as required
+ * HazelcastInstance hzClient = HazelcastClient.newHazelcastClient(clientConfig);
+ *
+ * ChatMemoryStore store = HazelcastChatMemoryStore.builder()
+ *         .hazelcastInstance(hzClient)
+ *         .build();
+ * }</pre>
+ *
+ * <h2>Custom map name</h2>
+ * <pre>{@code
+ * ChatMemoryStore store = HazelcastChatMemoryStore.builder()
+ *         .hazelcastInstance(hz)
+ *         .name("my-chat-memory")
+ *         .build();
+ * }</pre>
+ *
+ * <h2>Pre-configured IMap</h2>
+ * <pre>{@code
+ * IMap<String, String> imap = hz.getMap("my-chat-memory");
+ * ChatMemoryStore store = HazelcastChatMemoryStore.create(imap);
+ * }</pre>
+ */
+public class HazelcastChatMemoryStore implements ChatMemoryStore {
+
+    /**
+     * The default {@link IMap} name.
+     */
+    public static final String DEFAULT_MAP_NAME = "chatMemory";
+
+    /**
+     * The {@link IMap} used to store the chat messages.
+     */
+    protected final IMap<String, String> chatMemory;
+
+    /**
+     * Create a {@link HazelcastChatMemoryStore}.
+     * <p>
+     * This constructor is protected; instances are created via the static
+     * factory method or the builder.
+     *
+     * @param chatMemory the {@link IMap} to store the chat history
+     */
+    protected HazelcastChatMemoryStore(IMap<String, String> chatMemory) {
+        this.chatMemory = ensureNotNull(chatMemory, "chatMemory");
+    }
+
+    @Override
+    public List<ChatMessage> getMessages(Object memoryId) {
+        validateId(memoryId);
+        String json = chatMemory.get(key(memoryId));
+        return json == null ? new ArrayList<>() : ChatMessageDeserializer.messagesFromJson(json);
+    }
+
+    @Override
+    public void updateMessages(Object memoryId, List<ChatMessage> messages) {
+        validateId(memoryId);
+        String json = ChatMessageSerializer.messagesToJson(ensureNotEmpty(messages, "messages"));
+        chatMemory.set(key(memoryId), json);
+    }
+
+    @Override
+    public void deleteMessages(Object memoryId) {
+        validateId(memoryId);
+        chatMemory.delete(key(memoryId));
+    }
+
+    private void validateId(Object memoryId) {
+        ensureNotNull(memoryId, "memoryId");
+    }
+
+    /**
+     * Derive the {@link IMap} key for a memory id. Memory ids of any type are
+     * supported; the key is the id's {@code toString()}, which must be valid and
+     * stable for the id type in use.
+     */
+    private static String key(Object memoryId) {
+        return String.valueOf(memoryId);
+    }
+
+    // -------------------------------------------------------------------------
+    // Static factory
+    // -------------------------------------------------------------------------
+
+    /**
+     * Create a {@link HazelcastChatMemoryStore} that uses a pre-configured
+     * {@link IMap} directly.
+     * <p>
+     * This is the most explicit construction path and works identically
+     * regardless of whether the {@link IMap} was obtained from an embedded
+     * member or a {@link com.hazelcast.client.HazelcastClient}.
+     *
+     * @param map the {@link IMap} used to store chat messages; must not be {@code null}
+     * @return a {@link HazelcastChatMemoryStore}
+     */
+    public static HazelcastChatMemoryStore create(IMap<String, String> map) {
+        return new HazelcastChatMemoryStore(map);
+    }
+
+    /**
+     * Return a {@link Builder} to build a {@link HazelcastChatMemoryStore}.
+     *
+     * @return a {@link Builder}
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    // -------------------------------------------------------------------------
+    // Builder
+    // -------------------------------------------------------------------------
+
+    /**
+     * A builder to create {@link HazelcastChatMemoryStore} instances.
+     * <p>
+     * A {@link HazelcastInstance} <em>must</em> be supplied
+     * explicitly via {@link #hazelcastInstance(HazelcastInstance)}.
+     * The instance can represent either an embedded cluster member
+     * ({@code Hazelcast.newHazelcastInstance(...)}) or a thin client
+     * ({@code HazelcastClient.newHazelcastClient(...)}); the builder does not
+     * distinguish between the two.
+     */
+    public static class Builder {
+
+        /**
+         * The name of the {@link IMap} to contain the serialised
+         * {@link ChatMessage chat messages}.
+         */
+        private String name = DEFAULT_MAP_NAME;
+
+        /**
+         * The {@link HazelcastInstance} used to obtain the
+         * {@link IMap}. Must be set explicitly — there is no implicit fallback
+         * because the correct instance (embedded member vs. client) depends on
+         * the deployment topology and cannot be inferred automatically.
+         */
+        private HazelcastInstance hazelcastInstance;
+
+        /**
+         * Create a {@link Builder}.
+         */
+        protected Builder() {}
+
+        /**
+         * Set the name of the {@link IMap} that will hold the serialised
+         * {@link ChatMessage chat messages}.
+         * <p>
+         * If {@code name} is {@code null} or blank, {@link #DEFAULT_MAP_NAME}
+         * is used instead.
+         *
+         * @param name the map name
+         * @return this builder for fluent method calls
+         */
+        public Builder name(String name) {
+            this.name = isNullOrBlank(name) ? DEFAULT_MAP_NAME : name;
+            return this;
+        }
+
+        /**
+         * Set the {@link HazelcastInstance} used to obtain
+         * the {@link IMap}.
+         * <p>
+         * This is a <strong>required</strong> parameter. Pass either:
+         * <ul>
+         *   <li>an embedded member instance:
+         *       {@code Hazelcast.newHazelcastInstance(config)}, or</li>
+         *   <li>a client instance connecting to an external cluster:
+         *       {@code HazelcastClient.newHazelcastClient(clientConfig)}.</li>
+         * </ul>
+         *
+         * @param hazelcastInstance the Hazelcast instance; must not be {@code null}
+         * @return this builder for fluent method calls
+         */
+        public Builder hazelcastInstance(HazelcastInstance hazelcastInstance) {
+            this.hazelcastInstance = hazelcastInstance;
+            return this;
+        }
+
+        /**
+         * Creates a new {@link HazelcastChatMemoryStore}.
+         *
+         * @return a new {@link HazelcastChatMemoryStore}
+         * @throws IllegalArgumentException if {@code hazelcastInstance} was not set
+         */
+        public HazelcastChatMemoryStore build() {
+            ensureNotNull(
+                    hazelcastInstance,
+                    "hazelcastInstance is required. Supply an embedded member instance "
+                            + "(Hazelcast.newHazelcastInstance) or a client instance "
+                            + "(HazelcastClient.newHazelcastClient) depending on your deployment topology.");
+            IMap<String, String> map = hazelcastInstance.getMap(name);
+            return new HazelcastChatMemoryStore(map);
+        }
+    }
+}

--- a/chat-memory-stores/langchain4j-community-hazelcast/src/test/java/dev/langchain4j/community/store/memory/chat/hazelcast/HazelcastChatMemoryStoreIT.java
+++ b/chat-memory-stores/langchain4j-community-hazelcast/src/test/java/dev/langchain4j/community/store/memory/chat/hazelcast/HazelcastChatMemoryStoreIT.java
@@ -1,0 +1,254 @@
+package dev.langchain4j.community.store.memory.chat.hazelcast;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.JoinConfig;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ChatMessageType;
+import dev.langchain4j.data.message.Content;
+import dev.langchain4j.data.message.ImageContent;
+import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.data.message.UserMessage;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Integration tests for {@link HazelcastChatMemoryStore}.
+ * <p>
+ * All tests run against a single embedded Hazelcast member. Testing with an
+ * embedded member is sufficient because the store only calls {@link com.hazelcast.map.IMap}
+ * methods — the topology behind the map (embedded vs. remote cluster) is
+ * transparent to the store and does not affect its behaviour.
+ */
+class HazelcastChatMemoryStoreIT {
+
+    static HazelcastInstance hazelcastInstance;
+
+    private final String userId = "someUserId";
+
+    private HazelcastChatMemoryStore memoryStore;
+
+    @BeforeAll
+    static void startHazelcast() {
+        Config config = new Config();
+        config.setClusterName("langchain4j-test");
+        JoinConfig join = config.getNetworkConfig().getJoin();
+        join.getMulticastConfig().setEnabled(false);
+        join.getTcpIpConfig().setEnabled(false);
+        hazelcastInstance = Hazelcast.newHazelcastInstance(config);
+    }
+
+    @AfterAll
+    static void stopHazelcast() {
+        if (hazelcastInstance != null) {
+            hazelcastInstance.shutdown();
+        }
+    }
+
+    @BeforeEach
+    void setUp(TestInfo testInfo) {
+        // Use the test display name as the map name so every test gets an isolated map
+        this.memoryStore = HazelcastChatMemoryStore.builder()
+                .hazelcastInstance(hazelcastInstance)
+                .name(testInfo.getDisplayName())
+                .build();
+        memoryStore.deleteMessages(userId);
+        assertThat(memoryStore.getMessages(userId)).isEmpty();
+    }
+
+    // -------------------------------------------------------------------------
+    // Core CRUD behaviour
+    // -------------------------------------------------------------------------
+
+    @Test
+    void should_set_messages_into_hazelcast() {
+        // given
+        assertThat(memoryStore.getMessages(userId)).isEmpty();
+
+        // when
+        String sysMessage = "You are a large language model working with LangChain4j";
+        List<Content> userMsgContents = new ArrayList<>();
+        userMsgContents.add(new ImageContent("someCatImageUrl"));
+
+        List<ChatMessage> chatMessages = new ArrayList<>();
+        chatMessages.add(new SystemMessage(sysMessage));
+        chatMessages.add(new UserMessage("user1", userMsgContents));
+        memoryStore.updateMessages(userId, chatMessages);
+
+        // then
+        List<ChatMessage> messages = memoryStore.getMessages(userId);
+        assertThat(messages).hasSize(2);
+
+        assertThat(messages.get(0).type()).isEqualTo(ChatMessageType.SYSTEM);
+        assertThat(messages.get(1).type()).isEqualTo(ChatMessageType.USER);
+
+        SystemMessage sys = (SystemMessage) messages.get(0);
+        assertThat(sys.text()).isEqualTo(sysMessage);
+
+        UserMessage usr = (UserMessage) messages.get(1);
+        assertThat(usr.contents()).isEqualTo(userMsgContents);
+    }
+
+    @Test
+    void should_delete_messages_from_hazelcast() {
+        // given
+        memoryStore.updateMessages(
+                userId, List.of(new SystemMessage("You are a large language model working with LangChain4j")));
+        assertThat(memoryStore.getMessages(userId)).hasSize(1);
+
+        // when
+        memoryStore.deleteMessages(userId);
+
+        // then
+        assertThat(memoryStore.getMessages(userId)).isEmpty();
+    }
+
+    @Test
+    void should_overwrite_messages_on_update() {
+        memoryStore.updateMessages(userId, List.of(new SystemMessage("First system prompt")));
+        memoryStore.updateMessages(
+                userId,
+                List.of(new SystemMessage("Updated system prompt"), new UserMessage("Hello"), new AiMessage("Hi!")));
+
+        List<ChatMessage> messages = memoryStore.getMessages(userId);
+        assertThat(messages).hasSize(3);
+        assertThat(((SystemMessage) messages.get(0)).text()).isEqualTo("Updated system prompt");
+    }
+
+    @Test
+    void should_isolate_different_memory_ids() {
+        memoryStore.updateMessages("alice", List.of(new UserMessage("Alice's message")));
+        memoryStore.updateMessages("bob", List.of(new UserMessage("Bob's message")));
+
+        assertThat(memoryStore.getMessages("alice")).containsExactly(new UserMessage("Alice's message"));
+        assertThat(memoryStore.getMessages("bob")).containsExactly(new UserMessage("Bob's message"));
+    }
+
+    @Test
+    void should_return_empty_list_for_unknown_memory_id() {
+        assertThat(memoryStore.getMessages("unknown-id")).isEmpty();
+    }
+
+    @Test
+    void should_support_non_string_memory_id() {
+        // given a non-String memory id, the store keys on its toString()
+        Integer memoryId = 42;
+
+        // when
+        memoryStore.updateMessages(memoryId, List.of(new UserMessage("hi")));
+
+        // then it is retrievable by the original id
+        assertThat(memoryStore.getMessages(memoryId)).containsExactly(new UserMessage("hi"));
+        // and by the String form of that id, documenting the String.valueOf(memoryId) coercion
+        assertThat(memoryStore.getMessages("42")).containsExactly(new UserMessage("hi"));
+    }
+
+    @Test
+    void should_delete_non_existent_memory_id_without_error() {
+        memoryStore.deleteMessages("does-not-exist"); // must not throw
+    }
+
+    // -------------------------------------------------------------------------
+    // Null / empty validation
+    // -------------------------------------------------------------------------
+
+    @Test
+    void getMessages_memoryId_null() {
+        assertThatThrownBy(() -> memoryStore.getMessages(null))
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("memoryId cannot be null");
+    }
+
+    @Test
+    void updateMessages_messages_null() {
+        assertThatThrownBy(() -> memoryStore.updateMessages(userId, null))
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("messages cannot be null or empty");
+    }
+
+    @Test
+    void updateMessages_messages_empty() {
+        List<ChatMessage> chatMessages = new ArrayList<>();
+        assertThatThrownBy(() -> memoryStore.updateMessages(userId, chatMessages))
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("messages cannot be null or empty");
+    }
+
+    @Test
+    void updateMessages_memoryId_null() {
+        assertThatThrownBy(() -> memoryStore.updateMessages(
+                        null, List.of(new SystemMessage("You are a large language model working with LangChain4j"))))
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("memoryId cannot be null");
+    }
+
+    @Test
+    void deleteMessages_memoryId_null() {
+        assertThatThrownBy(() -> memoryStore.deleteMessages(null))
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("memoryId cannot be null");
+    }
+
+    // -------------------------------------------------------------------------
+    // Builder and map-name tests
+    // -------------------------------------------------------------------------
+
+    @ParameterizedTest
+    @NullAndEmptySource // null and ""
+    @ValueSource(strings = {"  ", "  \t\n "}) // blank strings
+    void should_use_default_map_name_when_name_is_blank(String name) {
+        HazelcastChatMemoryStore store = HazelcastChatMemoryStore.builder()
+                .hazelcastInstance(hazelcastInstance)
+                .name(name)
+                .build();
+        assertThat(store.chatMemory.getName()).isEqualTo(HazelcastChatMemoryStore.DEFAULT_MAP_NAME);
+    }
+
+    @Test
+    void should_use_custom_name_when_set() {
+        String name = "custom-chat-memory";
+        HazelcastChatMemoryStore store = HazelcastChatMemoryStore.builder()
+                .hazelcastInstance(hazelcastInstance)
+                .name(name)
+                .build();
+        assertThat(store.chatMemory.getName()).isEqualTo(name);
+    }
+
+    @Test
+    void should_accept_pre_configured_imap() {
+        var imap = hazelcastInstance.<String, String>getMap("pre-configured-imap");
+        HazelcastChatMemoryStore store = HazelcastChatMemoryStore.create(imap);
+
+        store.updateMessages("s1", List.of(new UserMessage("direct imap")));
+        assertThat(store.getMessages("s1")).containsExactly(new UserMessage("direct imap"));
+
+        imap.clear();
+    }
+
+    @Test
+    void should_throw_when_hazelcast_instance_not_supplied_to_builder() {
+        assertThatThrownBy(() -> HazelcastChatMemoryStore.builder().build())
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("hazelcastInstance is required");
+    }
+
+    @Test
+    void should_throw_when_null_imap_supplied_to_create() {
+        assertThatThrownBy(() -> HazelcastChatMemoryStore.create(null))
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("chatMemory");
+    }
+}

--- a/embedding-stores/langchain4j-community-hazelcast-enterprise/pom.xml
+++ b/embedding-stores/langchain4j-community-hazelcast-enterprise/pom.xml
@@ -1,0 +1,240 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>dev.langchain4j</groupId>
+        <artifactId>langchain4j-community</artifactId>
+        <version>1.17.0-beta27-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>langchain4j-community-hazelcast-enterprise</artifactId>
+    <name>LangChain4j :: Community :: Integration :: Hazelcast Enterprise</name>
+    <description>Hazelcast Enterprise integration: an EmbeddingStore backed by a VectorCollection and a
+        ChatMemoryStore backed by a CPMap. Also re-exports langchain4j-community-hazelcast so the
+        IMap-based HazelcastChatMemoryStore is available from this single dependency.
+        Requires the Hazelcast Enterprise repository and a valid license key.</description>
+
+    <properties>
+        <hazelcast.version>5.7.0</hazelcast.version>
+    </properties>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-core</artifactId>
+            <version>${langchain4j.core.version}</version>
+        </dependency>
+
+        <!-- Re-exported so Enterprise users also get the IMap-based HazelcastChatMemoryStore -->
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-community-hazelcast</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.hazelcast</groupId>
+            <artifactId>hazelcast-enterprise</artifactId>
+            <version>${hazelcast.version}</version>
+        </dependency>
+
+        <!-- test dependencies -->
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-core</artifactId>
+            <version>${langchain4j.core.version}</version>
+            <classifier>tests</classifier>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-embeddings-all-minilm-l6-v2-q</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- junit-jupiter-params is used by parameterized tests inherited from EmbeddingStore*IT -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <repositories>
+        <!-- Hazelcast Enterprise repository (required for com.hazelcast:hazelcast-enterprise) -->
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>hazelcast-release</id>
+            <name>Hazelcast Release Repository</name>
+            <url>https://repository.hazelcast.com/release/</url>
+        </repository>
+    </repositories>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <systemProperties>
+                        <java.net.preferIPv4Stack>true</java.net.preferIPv4Stack>
+                    </systemProperties>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <configuration>
+                    <usedDependencies>
+                        <!-- re-exported on purpose so Enterprise consumers get the IMap chat store -->
+                        <dependency>dev.langchain4j:langchain4j-community-hazelcast</dependency>
+                    </usedDependencies>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.revapi</groupId>
+                <artifactId>revapi-maven-plugin</artifactId>
+                <configuration>
+                    <analysisConfiguration>
+                        <revapi.differences>
+                            <differences>
+                                <!--
+                                    Hazelcast Enterprise types are an intentionally provided dependency,
+                                    and langchain4j-core types are part of the public EmbeddingStore /
+                                    ChatMemoryStore API by design.
+                                -->
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.missing.newClass</code>
+                                    <new>missing-class com.hazelcast.core.HazelcastInstance</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.class.externalClassExposedInAPI</code>
+                                    <new>missing-class com.hazelcast.core.HazelcastInstance</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.missing.newClass</code>
+                                    <new>missing-class com.hazelcast.cp.CPMap</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.class.externalClassExposedInAPI</code>
+                                    <new>missing-class com.hazelcast.cp.CPMap</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.missing.newClass</code>
+                                    <new>missing-class com.hazelcast.vector.VectorCollection</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.class.externalClassExposedInAPI</code>
+                                    <new>missing-class com.hazelcast.vector.VectorCollection</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.missing.newClass</code>
+                                    <new>missing-class com.hazelcast.config.vector.Metric</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.class.externalClassExposedInAPI</code>
+                                    <new>missing-class com.hazelcast.config.vector.Metric</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.missing.newClass</code>
+                                    <new>missing-class dev.langchain4j.data.message.ChatMessage</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.class.externalClassExposedInAPI</code>
+                                    <new>missing-class dev.langchain4j.data.message.ChatMessage</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.missing.newClass</code>
+                                    <new>missing-class dev.langchain4j.data.embedding.Embedding</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.class.externalClassExposedInAPI</code>
+                                    <new>missing-class dev.langchain4j.data.embedding.Embedding</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.missing.newClass</code>
+                                    <new>missing-class dev.langchain4j.data.segment.TextSegment</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.class.externalClassExposedInAPI</code>
+                                    <new>missing-class dev.langchain4j.data.segment.TextSegment</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.missing.newClass</code>
+                                    <new>missing-class dev.langchain4j.store.embedding.EmbeddingSearchRequest</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.class.externalClassExposedInAPI</code>
+                                    <new>missing-class dev.langchain4j.store.embedding.EmbeddingSearchRequest</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.missing.newClass</code>
+                                    <new>missing-class dev.langchain4j.store.embedding.EmbeddingSearchResult</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.class.externalClassExposedInAPI</code>
+                                    <new>missing-class dev.langchain4j.store.embedding.EmbeddingSearchResult</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.missing.newClass</code>
+                                    <new>missing-class dev.langchain4j.store.embedding.filter.Filter</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.class.externalClassExposedInAPI</code>
+                                    <new>missing-class dev.langchain4j.store.embedding.filter.Filter</new>
+                                </item>
+                            </differences>
+                        </revapi.differences>
+                    </analysisConfiguration>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/embedding-stores/langchain4j-community-hazelcast-enterprise/src/main/java/dev/langchain4j/community/store/embedding/hazelcast/HazelcastEmbeddingStore.java
+++ b/embedding-stores/langchain4j-community-hazelcast-enterprise/src/main/java/dev/langchain4j/community/store/embedding/hazelcast/HazelcastEmbeddingStore.java
@@ -1,0 +1,383 @@
+package dev.langchain4j.community.store.embedding.hazelcast;
+
+import static dev.langchain4j.internal.Utils.isNullOrBlank;
+import static dev.langchain4j.internal.Utils.isNullOrEmpty;
+import static dev.langchain4j.internal.Utils.randomUUID;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotEmpty;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+import static dev.langchain4j.internal.ValidationUtils.ensureTrue;
+
+import com.hazelcast.config.vector.Metric;
+import com.hazelcast.config.vector.VectorCollectionConfig;
+import com.hazelcast.config.vector.VectorIndexConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.vector.SearchOptions;
+import com.hazelcast.vector.SearchResult;
+import com.hazelcast.vector.SearchResults;
+import com.hazelcast.vector.VectorCollection;
+import com.hazelcast.vector.VectorDocument;
+import com.hazelcast.vector.VectorValues;
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.exception.UnsupportedFeatureException;
+import dev.langchain4j.store.embedding.EmbeddingMatch;
+import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
+import dev.langchain4j.store.embedding.EmbeddingSearchResult;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import dev.langchain4j.store.embedding.filter.Filter;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.logging.Logger;
+
+/**
+ * An {@link EmbeddingStore} backed by a Hazelcast Enterprise {@link VectorCollection}.
+ *
+ * <p>Each entry in the {@link VectorCollection} consists of a {@link String} key (the embedding ID)
+ * and a {@link VectorDocument} whose value is a {@link TextSegmentDocument} holding the text and
+ * metadata, and whose vectors are the embedding float array.
+ *
+ * <p><strong>Requirements:</strong> This store depends on <strong>Hazelcast Enterprise</strong>
+ * ({@code com.hazelcast:hazelcast-enterprise}), which <strong>require the Hazelcast Enterprise
+ * repository</strong>.
+ * To build or run against it you must:
+ * <ul>
+ *   <li>add the Hazelcast Enterprise repository ({@code https://repository.hazelcast.com/release/})
+ *       to your {@code ~/.m2/settings.xml} or {@code pom.xml}; and</li>
+ *   <li>provide a valid Hazelcast Enterprise license key (e.g. {@code config.setLicenseKey(...)}
+ *       or the {@code HZ_LICENSEKEY} environment variable).</li>
+ * </ul>
+ * The {@link VectorCollection} must be configured with exactly one vector index whose dimension
+ * matches the embedding model in use. The metric defaults to {@link Metric#COSINE}.
+ *
+ * <h2>Minimal embedded-member example</h2>
+ * <pre>{@code
+ * HazelcastInstance hz = Hazelcast.newHazelcastInstance(new Config());
+ *
+ * EmbeddingStore<TextSegment> store = HazelcastEmbeddingStore.builder()
+ *         .hazelcastInstance(hz)
+ *         .collectionName("embeddings")
+ *         .dimension(384)
+ *         .build();
+ * }</pre>
+ *
+ * <h2>Example with pre-configured VectorCollection</h2>
+ * <pre>{@code
+ * VectorCollectionConfig config = new VectorCollectionConfig("embeddings")
+ *         .addVectorIndexConfig(new VectorIndexConfig()
+ *                 .setDimension(384)
+ *                 .setMetric(Metric.COSINE));
+ * VectorCollection<String, TextSegmentDocument> collection =
+ *         VectorCollection.getCollection(hz, config);
+ *
+ * EmbeddingStore<TextSegment> store = HazelcastEmbeddingStore.create(collection);
+ * }</pre>
+ *
+ * <h2>Limitations</h2>
+ * <ul>
+ *   <li>{@link #removeAll(Filter)} is not supported — Hazelcast {@link VectorCollection} does not
+ *       provide a server-side predicate delete. An {@link UnsupportedFeatureException} is thrown.</li>
+ *   <li>{@link EmbeddingSearchRequest#filter()} (metadata filtering during search) is not supported
+ *       server-side. If a filter is present in the request, a warning is logged and the filter is
+ *       applied client-side after retrieval, which may return fewer results than {@code maxResults}.</li>
+ * </ul>
+ */
+public class HazelcastEmbeddingStore implements EmbeddingStore<TextSegment> {
+
+    private static final Logger log = Logger.getLogger(HazelcastEmbeddingStore.class.getName());
+
+    /**
+     * The default {@link VectorCollection} name.
+     */
+    public static final String DEFAULT_COLLECTION_NAME = "embeddings";
+
+    /**
+     * The {@link VectorCollection} used to store the embeddings.
+     */
+    protected final VectorCollection<String, TextSegmentDocument> collection;
+
+    /**
+     * Creates a {@link HazelcastEmbeddingStore}.
+     *
+     * @param collection the {@link VectorCollection} to store embeddings
+     */
+    protected HazelcastEmbeddingStore(VectorCollection<String, TextSegmentDocument> collection) {
+        this.collection = ensureNotNull(collection, "collection");
+    }
+
+    @Override
+    public String add(Embedding embedding) {
+        String id = randomUUID();
+        add(id, embedding);
+        return id;
+    }
+
+    @Override
+    public void add(String id, Embedding embedding) {
+        ensureNotBlank(id, "id");
+        ensureNotNull(embedding, "embedding");
+        collection
+                .setAsync(id, toDocument(embedding, null))
+                .toCompletableFuture()
+                .join();
+    }
+
+    @Override
+    public String add(Embedding embedding, TextSegment segment) {
+        String id = randomUUID();
+        ensureNotNull(embedding, "embedding");
+        collection
+                .setAsync(id, toDocument(embedding, segment))
+                .toCompletableFuture()
+                .join();
+        return id;
+    }
+
+    @Override
+    public List<String> addAll(List<Embedding> embeddings) {
+        return addAll(embeddings, null);
+    }
+
+    @Override
+    public void addAll(List<String> ids, List<Embedding> embeddings, List<TextSegment> segments) {
+        if (isNullOrEmpty(ids) || isNullOrEmpty(embeddings)) {
+            log.info("Skipped adding empty embeddings");
+            return;
+        }
+
+        boolean hasSegments = segments != null && !segments.isEmpty();
+        ensureTrue(ids.size() == embeddings.size(), "ids size is not equal to embeddings size");
+        if (hasSegments) {
+            ensureTrue(embeddings.size() == segments.size(), "embeddings size is not equal to segments size");
+        }
+
+        Map<String, VectorDocument<TextSegmentDocument>> batch = new HashMap<>();
+        for (int i = 0; i < embeddings.size(); i++) {
+            TextSegment segment = hasSegments ? segments.get(i) : null;
+            batch.put(ids.get(i), toDocument(embeddings.get(i), segment));
+        }
+        collection.putAllAsync(batch).toCompletableFuture().join();
+    }
+
+    @Override
+    public void remove(String id) {
+        ensureNotBlank(id, "id");
+        collection.deleteAsync(id).toCompletableFuture().join();
+    }
+
+    @Override
+    public void removeAll(Collection<String> ids) {
+        ensureNotEmpty(ids, "ids");
+        List<CompletableFuture<Void>> futures = new ArrayList<>();
+        for (String id : ids) {
+            futures.add(collection.deleteAsync(id).toCompletableFuture());
+        }
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+    }
+
+    /**
+     * Not supported. {@link VectorCollection} does not provide a server-side predicate delete.
+     *
+     * @throws UnsupportedFeatureException always
+     */
+    @Override
+    public void removeAll(Filter filter) {
+        throw new UnsupportedFeatureException("removeAll(Filter) is not supported by HazelcastEmbeddingStore. "
+                + "Hazelcast VectorCollection does not provide a server-side predicate delete.");
+    }
+
+    /**
+     * Removes all embeddings from the underlying {@link VectorCollection}.
+     * <p>
+     * Only the entries are cleared; the collection and its index configuration are preserved,
+     * so this store remains usable afterwards.
+     */
+    @Override
+    public void removeAll() {
+        collection.clearAsync().toCompletableFuture().join();
+    }
+
+    @Override
+    public EmbeddingSearchResult<TextSegment> search(EmbeddingSearchRequest request) {
+        ensureNotNull(request, "request");
+
+        if (request.filter() != null) {
+            log.warning("HazelcastEmbeddingStore: EmbeddingSearchRequest.filter() is not supported "
+                    + "server-side by Hazelcast VectorCollection. The filter will be applied "
+                    + "client-side after retrieval, which may return fewer than maxResults matches.");
+        }
+
+        SearchOptions options = SearchOptions.builder()
+                .limit(request.maxResults())
+                .includeValue()
+                .includeVectors()
+                .build();
+
+        SearchResults<String, TextSegmentDocument> results;
+        try {
+            results = collection
+                    .searchAsync(VectorValues.of(request.queryEmbedding().vector()), options)
+                    .toCompletableFuture()
+                    .join();
+        } catch (Exception e) {
+            throw new RuntimeException("Hazelcast vector search failed", e);
+        }
+
+        double minScore = request.minScore();
+        Filter filter = request.filter();
+
+        List<EmbeddingMatch<TextSegment>> matches = new ArrayList<>();
+        Iterator<? extends SearchResult<String, TextSegmentDocument>> it = results.results();
+        while (it.hasNext()) {
+            SearchResult<String, TextSegmentDocument> result = it.next();
+
+            // Hazelcast already returns a non-negative, normalized similarity in [0, 1]
+            // (cosine "adjusted to be non-negative"), so it is the relevance score directly.
+            double score = result.getScore();
+            if (score < minScore) {
+                continue;
+            }
+
+            TextSegmentDocument doc = result.getValue();
+            TextSegment segment = doc != null ? doc.toTextSegment() : null;
+
+            // client-side metadata filter (best-effort when filter is set)
+            if (filter != null && segment != null) {
+                if (!filter.test(segment.metadata())) {
+                    continue;
+                }
+            }
+
+            VectorValues vectors = result.getVectors();
+            Embedding embedding = vectors instanceof VectorValues.SingleVectorValues singleVectors
+                    ? new Embedding(singleVectors.vector())
+                    : null;
+
+            matches.add(new EmbeddingMatch<>(score, result.getKey(), embedding, segment));
+        }
+
+        return new EmbeddingSearchResult<>(matches);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private VectorDocument<TextSegmentDocument> toDocument(Embedding embedding, TextSegment segment) {
+        return VectorDocument.of(TextSegmentDocument.from(segment), VectorValues.of(embedding.vector()));
+    }
+
+    // -------------------------------------------------------------------------
+    // Static factories
+    // -------------------------------------------------------------------------
+
+    /**
+     * Create a {@link HazelcastEmbeddingStore} that uses a pre-configured
+     * {@link VectorCollection} directly.
+     *
+     * @param collection the {@link VectorCollection}; must not be {@code null}
+     * @return a {@link HazelcastEmbeddingStore}
+     */
+    public static HazelcastEmbeddingStore create(VectorCollection<String, TextSegmentDocument> collection) {
+        return new HazelcastEmbeddingStore(collection);
+    }
+
+    /**
+     * Return a {@link Builder} to build a {@link HazelcastEmbeddingStore}.
+     *
+     * @return a {@link Builder}
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    // -------------------------------------------------------------------------
+    // Builder
+    // -------------------------------------------------------------------------
+
+    /**
+     * A builder to create {@link HazelcastEmbeddingStore} instances.
+     */
+    public static class Builder {
+
+        private HazelcastInstance hazelcastInstance;
+        private String collectionName = DEFAULT_COLLECTION_NAME;
+        private int dimension;
+        private Metric metric = Metric.COSINE;
+
+        protected Builder() {}
+
+        /**
+         * Set the {@link HazelcastInstance}. Required unless a pre-configured
+         * {@link VectorCollection} is supplied via {@link #create(VectorCollection)}.
+         *
+         * @param hazelcastInstance the instance; must not be {@code null}
+         * @return this builder
+         */
+        public Builder hazelcastInstance(HazelcastInstance hazelcastInstance) {
+            this.hazelcastInstance = hazelcastInstance;
+            return this;
+        }
+
+        /**
+         * Set the {@link VectorCollection} name.
+         * Defaults to {@value HazelcastEmbeddingStore#DEFAULT_COLLECTION_NAME}.
+         *
+         * @param collectionName the collection name
+         * @return this builder
+         */
+        public Builder collectionName(String collectionName) {
+            this.collectionName = isNullOrBlank(collectionName) ? DEFAULT_COLLECTION_NAME : collectionName;
+            return this;
+        }
+
+        /**
+         * Set the vector dimension. Must match the embedding model in use.
+         *
+         * @param dimension the number of dimensions; must be positive
+         * @return this builder
+         */
+        public Builder dimension(int dimension) {
+            this.dimension = dimension;
+            return this;
+        }
+
+        /**
+         * Set the similarity metric used by the vector index.
+         * Defaults to {@link Metric#COSINE}.
+         *
+         * @param metric the metric; must not be {@code null}
+         * @return this builder
+         */
+        public Builder metric(Metric metric) {
+            this.metric = ensureNotNull(metric, "metric");
+            return this;
+        }
+
+        /**
+         * Builds the {@link HazelcastEmbeddingStore}.
+         *
+         * @return a new store
+         * @throws IllegalArgumentException if {@code hazelcastInstance} or {@code dimension}
+         *                                  were not set
+         */
+        public HazelcastEmbeddingStore build() {
+            ensureNotNull(hazelcastInstance, "hazelcastInstance");
+            ensureTrue(dimension > 0, "dimension must be a positive integer");
+
+            VectorCollectionConfig config = new VectorCollectionConfig(collectionName)
+                    .addVectorIndexConfig(
+                            new VectorIndexConfig().setDimension(dimension).setMetric(metric));
+
+            VectorCollection<String, TextSegmentDocument> col =
+                    VectorCollection.getCollection(hazelcastInstance, config);
+
+            return new HazelcastEmbeddingStore(col);
+        }
+    }
+}

--- a/embedding-stores/langchain4j-community-hazelcast-enterprise/src/main/java/dev/langchain4j/community/store/embedding/hazelcast/TextSegmentDocument.java
+++ b/embedding-stores/langchain4j-community-hazelcast-enterprise/src/main/java/dev/langchain4j/community/store/embedding/hazelcast/TextSegmentDocument.java
@@ -1,0 +1,56 @@
+package dev.langchain4j.community.store.embedding.hazelcast;
+
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.data.segment.TextSegment;
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Serializable value type stored inside each {@link com.hazelcast.vector.VectorDocument}.
+ * <p>
+ * Holds the optional text and metadata of a {@link TextSegment} in a form that
+ * Hazelcast can serialise across cluster members using standard Java serialisation.
+ * Null metadata values are stripped on construction to avoid deserialisation issues.
+ */
+public class TextSegmentDocument implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final String text;
+    private final Map<String, Object> metadata;
+
+    private TextSegmentDocument(String text, Map<String, Object> metadata) {
+        this.text = text;
+        this.metadata = metadata;
+    }
+
+    /**
+     * Create a {@link TextSegmentDocument} from a {@link TextSegment}.
+     * If {@code segment} is {@code null}, an empty document is returned.
+     *
+     * @param segment the segment to convert, or {@code null}
+     * @return a {@link TextSegmentDocument}
+     */
+    public static TextSegmentDocument from(TextSegment segment) {
+        if (segment == null) {
+            return new TextSegmentDocument(null, Collections.emptyMap());
+        }
+        Map<String, Object> meta = new HashMap<>(segment.metadata().toMap());
+        meta.entrySet().removeIf(e -> e.getValue() == null);
+        return new TextSegmentDocument(segment.text(), meta);
+    }
+
+    /**
+     * Convert back to a {@link TextSegment}, or {@code null} if this document has no text.
+     *
+     * @return a {@link TextSegment}, or {@code null}
+     */
+    public TextSegment toTextSegment() {
+        if (text == null) {
+            return null;
+        }
+        return new TextSegment(text, Metadata.from(metadata));
+    }
+}

--- a/embedding-stores/langchain4j-community-hazelcast-enterprise/src/main/java/dev/langchain4j/community/store/memory/chat/hazelcast/HazelcastCPMapChatMemoryStore.java
+++ b/embedding-stores/langchain4j-community-hazelcast-enterprise/src/main/java/dev/langchain4j/community/store/memory/chat/hazelcast/HazelcastCPMapChatMemoryStore.java
@@ -1,0 +1,204 @@
+package dev.langchain4j.community.store.memory.chat.hazelcast;
+
+import static dev.langchain4j.internal.Utils.isNullOrBlank;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotEmpty;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.cp.CPMap;
+import com.hazelcast.cp.CPSubsystem;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ChatMessageDeserializer;
+import dev.langchain4j.data.message.ChatMessageSerializer;
+import dev.langchain4j.store.memory.chat.ChatMemoryStore;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A {@link ChatMemoryStore} backed by a Hazelcast Enterprise {@link CPMap}.
+ * <p>
+ * Unlike the {@code IMap}-based store, a {@link CPMap} lives in the
+ * <a href="https://docs.hazelcast.com/hazelcast/latest/cp-subsystem/cp-subsystem">CP Subsystem</a>
+ * and is <strong>linearizable</strong> (strongly consistent, backed by Raft). This avoids lost
+ * updates when the same {@code memoryId} is updated concurrently and keeps reads correct during
+ * network partitions — the minority side becomes unavailable rather than returning stale data.
+ *
+ * <p>Each chat memory id is stored as a {@link String} key; the value is a JSON-serialised list of
+ * {@link ChatMessage}s produced by {@link ChatMessageSerializer}.
+ *
+ * <p><strong>Requirements and trade-offs:</strong>
+ * <ul>
+ *   <li>Hazelcast <strong>Enterprise</strong> Edition with a valid license key.</li>
+ *   <li>The CP Subsystem must be enabled, e.g.
+ *       {@code config.getCPSubsystemConfig().setCPMemberCount(3)} (a quorum of at least
+ *       {@code MIN_GROUP_SIZE} = 3 members). The builder fails fast if it is not enabled.</li>
+ *   <li>A {@link CPMap} is <strong>not partitioned</strong>; it must fit within each CP member's
+ *       RAM (see {@code CPMapConfig}, default 100 MB total). It suits many small conversations,
+ *       not unbounded history for very large user populations — prefer the {@code IMap}-based
+ *       store for that.</li>
+ *   <li>A {@link CPMap} has no TTL/eviction: conversations live until {@link #deleteMessages(Object)}
+ *       is called.</li>
+ * </ul>
+ *
+ * <h2>Embedded-member example</h2>
+ * <pre>{@code
+ * Config config = new Config();
+ * config.getCPSubsystemConfig().setCPMemberCount(3); // CP Subsystem must be enabled
+ * HazelcastInstance hz = Hazelcast.newHazelcastInstance(config);
+ *
+ * ChatMemoryStore store = HazelcastCPMapChatMemoryStore.builder()
+ *         .hazelcastInstance(hz)
+ *         .name("chatMemory")
+ *         .build();
+ * }</pre>
+ */
+public class HazelcastCPMapChatMemoryStore implements ChatMemoryStore {
+
+    /**
+     * The default {@link CPMap} name.
+     */
+    public static final String DEFAULT_MAP_NAME = "chatMemory";
+
+    /**
+     * The {@link CPMap} used to store the chat messages.
+     */
+    protected final CPMap<String, String> chatMemory;
+
+    /**
+     * Create a {@link HazelcastCPMapChatMemoryStore}.
+     * <p>
+     * This constructor is protected; instances are created via the static factory method or the
+     * builder.
+     *
+     * @param chatMemory the {@link CPMap} to store the chat history
+     */
+    protected HazelcastCPMapChatMemoryStore(CPMap<String, String> chatMemory) {
+        this.chatMemory = ensureNotNull(chatMemory, "chatMemory");
+    }
+
+    @Override
+    public List<ChatMessage> getMessages(Object memoryId) {
+        validateId(memoryId);
+        String json = chatMemory.get(key(memoryId));
+        return json == null ? new ArrayList<>() : ChatMessageDeserializer.messagesFromJson(json);
+    }
+
+    @Override
+    public void updateMessages(Object memoryId, List<ChatMessage> messages) {
+        validateId(memoryId);
+        String json = ChatMessageSerializer.messagesToJson(ensureNotEmpty(messages, "messages"));
+        chatMemory.set(key(memoryId), json);
+    }
+
+    @Override
+    public void deleteMessages(Object memoryId) {
+        validateId(memoryId);
+        chatMemory.delete(key(memoryId));
+    }
+
+    private void validateId(Object memoryId) {
+        ensureNotNull(memoryId, "memoryId");
+    }
+
+    /**
+     * Derive the {@link CPMap} key for a memory id. Memory ids of any type are supported; the key is
+     * the id's {@code toString()}, which must be valid and stable for the id type in use.
+     */
+    private static String key(Object memoryId) {
+        return String.valueOf(memoryId);
+    }
+
+    // -------------------------------------------------------------------------
+    // Static factory
+    // -------------------------------------------------------------------------
+
+    /**
+     * Create a {@link HazelcastCPMapChatMemoryStore} that uses a pre-configured {@link CPMap}
+     * directly.
+     *
+     * @param map the {@link CPMap} used to store chat messages; must not be {@code null}
+     * @return a {@link HazelcastCPMapChatMemoryStore}
+     */
+    public static HazelcastCPMapChatMemoryStore create(CPMap<String, String> map) {
+        return new HazelcastCPMapChatMemoryStore(map);
+    }
+
+    /**
+     * Return a {@link Builder} to build a {@link HazelcastCPMapChatMemoryStore}.
+     *
+     * @return a {@link Builder}
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    // -------------------------------------------------------------------------
+    // Builder
+    // -------------------------------------------------------------------------
+
+    /**
+     * A builder to create {@link HazelcastCPMapChatMemoryStore} instances.
+     */
+    public static class Builder {
+
+        private String name = DEFAULT_MAP_NAME;
+
+        private HazelcastInstance hazelcastInstance;
+
+        /**
+         * Create a {@link Builder}.
+         */
+        protected Builder() {}
+
+        /**
+         * Set the name of the {@link CPMap} that will hold the serialised chat messages.
+         * <p>
+         * If {@code name} is {@code null} or blank, {@link #DEFAULT_MAP_NAME} is used instead.
+         *
+         * @param name the map name
+         * @return this builder for fluent method calls
+         */
+        public Builder name(String name) {
+            this.name = isNullOrBlank(name) ? DEFAULT_MAP_NAME : name;
+            return this;
+        }
+
+        /**
+         * Set the {@link HazelcastInstance} used to obtain the {@link CPMap}. The instance must have
+         * the CP Subsystem enabled. This is a <strong>required</strong> parameter.
+         *
+         * @param hazelcastInstance the Hazelcast instance; must not be {@code null}
+         * @return this builder for fluent method calls
+         */
+        public Builder hazelcastInstance(HazelcastInstance hazelcastInstance) {
+            this.hazelcastInstance = hazelcastInstance;
+            return this;
+        }
+
+        /**
+         * Creates a new {@link HazelcastCPMapChatMemoryStore}.
+         *
+         * @return a new {@link HazelcastCPMapChatMemoryStore}
+         * @throws IllegalArgumentException if {@code hazelcastInstance} was not set
+         * @throws IllegalStateException if the CP Subsystem is not enabled on the instance
+         */
+        public HazelcastCPMapChatMemoryStore build() {
+            ensureNotNull(
+                    hazelcastInstance,
+                    "hazelcastInstance is required. Supply an Enterprise instance with the CP "
+                            + "Subsystem enabled (config.getCPSubsystemConfig().setCPMemberCount(...)).");
+            CPSubsystem cpSubsystem = hazelcastInstance.getCPSubsystem();
+            CPMap<String, String> map;
+            try {
+                map = cpSubsystem.getMap(name);
+            } catch (RuntimeException e) {
+                throw new IllegalStateException(
+                        "Unable to obtain CPMap '" + name + "'. Ensure this is a Hazelcast Enterprise "
+                                + "instance with the CP Subsystem enabled "
+                                + "(config.getCPSubsystemConfig().setCPMemberCount(...)).",
+                        e);
+            }
+            return new HazelcastCPMapChatMemoryStore(map);
+        }
+    }
+}

--- a/embedding-stores/langchain4j-community-hazelcast-enterprise/src/test/java/dev/langchain4j/community/store/embedding/hazelcast/HazelcastEmbeddingStoreIT.java
+++ b/embedding-stores/langchain4j-community-hazelcast-enterprise/src/test/java/dev/langchain4j/community/store/embedding/hazelcast/HazelcastEmbeddingStoreIT.java
@@ -1,0 +1,129 @@
+package dev.langchain4j.community.store.embedding.hazelcast;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.JoinConfig;
+import com.hazelcast.config.vector.Metric;
+import com.hazelcast.config.vector.VectorCollectionConfig;
+import com.hazelcast.config.vector.VectorIndexConfig;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.vector.VectorCollection;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.exception.UnsupportedFeatureException;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.embedding.onnx.allminilml6v2q.AllMiniLmL6V2QuantizedEmbeddingModel;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import dev.langchain4j.store.embedding.EmbeddingStoreIT;
+import dev.langchain4j.store.embedding.filter.Filter;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+/**
+ * Runs the standard {@link EmbeddingStoreIT} contract suite against {@link HazelcastEmbeddingStore},
+ * plus a few builder/factory tests not covered by the shared suite.
+ * <p>
+ * Requires a Hazelcast Enterprise license key in the {@code HZ_LICENSEKEY} environment variable;
+ * the class is skipped (e.g. in CI) when it is not set. An embedded single-member cluster is used —
+ * no external process needed.
+ */
+@EnabledIfEnvironmentVariable(named = "HZ_LICENSEKEY", matches = ".+")
+class HazelcastEmbeddingStoreIT extends EmbeddingStoreIT {
+
+    /** Dimension of {@link AllMiniLmL6V2QuantizedEmbeddingModel}. */
+    private static final int DIMENSION = 384;
+
+    static HazelcastInstance hazelcastInstance;
+
+    static EmbeddingModel embeddingModel = new AllMiniLmL6V2QuantizedEmbeddingModel();
+
+    static HazelcastEmbeddingStore embeddingStore;
+
+    @BeforeAll
+    static void startHazelcast() {
+        Config config = new Config();
+        config.setClusterName("langchain4j-embedding-it");
+        config.setLicenseKey(System.getenv("HZ_LICENSEKEY"));
+        JoinConfig join = config.getNetworkConfig().getJoin();
+        join.getMulticastConfig().setEnabled(false);
+        join.getTcpIpConfig().setEnabled(false);
+        hazelcastInstance = Hazelcast.newHazelcastInstance(config);
+
+        embeddingStore = HazelcastEmbeddingStore.builder()
+                .hazelcastInstance(hazelcastInstance)
+                .collectionName("embedding-store-it")
+                .dimension(DIMENSION)
+                .metric(Metric.COSINE)
+                .build();
+    }
+
+    @AfterAll
+    static void stopHazelcast() {
+        if (hazelcastInstance != null) {
+            hazelcastInstance.shutdown();
+        }
+    }
+
+    @Override
+    protected EmbeddingStore<TextSegment> embeddingStore() {
+        return embeddingStore;
+    }
+
+    @Override
+    protected EmbeddingModel embeddingModel() {
+        return embeddingModel;
+    }
+
+    @Override
+    protected void clearStore() {
+        embeddingStore.removeAll();
+    }
+
+    // -------------------------------------------------------------------------
+    // Builder / factory behaviour not covered by the shared suite
+    // -------------------------------------------------------------------------
+
+    @Test
+    void builder_throws_when_hazelcast_instance_missing() {
+        assertThatThrownBy(() -> HazelcastEmbeddingStore.builder()
+                        .collectionName("missing-instance")
+                        .dimension(DIMENSION)
+                        .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("hazelcastInstance");
+    }
+
+    @Test
+    void builder_throws_when_dimension_not_set() {
+        assertThatThrownBy(() -> HazelcastEmbeddingStore.builder()
+                        .hazelcastInstance(hazelcastInstance)
+                        .collectionName("missing-dimension")
+                        .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("dimension");
+    }
+
+    @Test
+    void removeAll_filter_throws_unsupported() {
+        assertThatThrownBy(() -> embeddingStore.removeAll((Filter) null))
+                .isInstanceOf(UnsupportedFeatureException.class);
+    }
+
+    @Test
+    void should_accept_pre_configured_collection() {
+        VectorCollectionConfig config = new VectorCollectionConfig("pre-configured-it")
+                .addVectorIndexConfig(
+                        new VectorIndexConfig().setDimension(DIMENSION).setMetric(Metric.COSINE));
+        VectorCollection<String, TextSegmentDocument> col = VectorCollection.getCollection(hazelcastInstance, config);
+
+        HazelcastEmbeddingStore store = HazelcastEmbeddingStore.create(col);
+        String id = store.add(embeddingModel.embed("pre-configured").content(), TextSegment.from("pre-configured"));
+        assertThat(id).isNotBlank();
+
+        col.destroy();
+    }
+}

--- a/embedding-stores/langchain4j-community-hazelcast-enterprise/src/test/java/dev/langchain4j/community/store/embedding/hazelcast/HazelcastEmbeddingStoreRemovalIT.java
+++ b/embedding-stores/langchain4j-community-hazelcast-enterprise/src/test/java/dev/langchain4j/community/store/embedding/hazelcast/HazelcastEmbeddingStoreRemovalIT.java
@@ -1,0 +1,84 @@
+package dev.langchain4j.community.store.embedding.hazelcast;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.JoinConfig;
+import com.hazelcast.config.vector.Metric;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.embedding.onnx.allminilml6v2q.AllMiniLmL6V2QuantizedEmbeddingModel;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import dev.langchain4j.store.embedding.EmbeddingStoreWithRemovalIT;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+/**
+ * Runs the standard {@link EmbeddingStoreWithRemovalIT} contract suite against
+ * {@link HazelcastEmbeddingStore}.
+ * <p>
+ * Hazelcast {@link com.hazelcast.vector.VectorCollection} has no server-side predicate delete, so
+ * {@link #supportsRemoveAllByFilter()} is disabled; {@code removeAll()} (clear all) is supported.
+ * <p>
+ * Requires a Hazelcast Enterprise license key in the {@code HZ_LICENSEKEY} environment variable;
+ * the class is skipped (e.g. in CI) when it is not set.
+ */
+@EnabledIfEnvironmentVariable(named = "HZ_LICENSEKEY", matches = ".+")
+class HazelcastEmbeddingStoreRemovalIT extends EmbeddingStoreWithRemovalIT {
+
+    /** Dimension of {@link AllMiniLmL6V2QuantizedEmbeddingModel}. */
+    private static final int DIMENSION = 384;
+
+    static HazelcastInstance hazelcastInstance;
+
+    static EmbeddingModel embeddingModel = new AllMiniLmL6V2QuantizedEmbeddingModel();
+
+    static HazelcastEmbeddingStore embeddingStore;
+
+    @BeforeAll
+    static void startHazelcast() {
+        Config config = new Config();
+        config.setClusterName("langchain4j-embedding-removal-it");
+        config.setLicenseKey(System.getenv("HZ_LICENSEKEY"));
+        JoinConfig join = config.getNetworkConfig().getJoin();
+        join.getMulticastConfig().setEnabled(false);
+        join.getTcpIpConfig().setEnabled(false);
+        hazelcastInstance = Hazelcast.newHazelcastInstance(config);
+
+        embeddingStore = HazelcastEmbeddingStore.builder()
+                .hazelcastInstance(hazelcastInstance)
+                .collectionName("embedding-store-removal-it")
+                .dimension(DIMENSION)
+                .metric(Metric.COSINE)
+                .build();
+    }
+
+    @AfterAll
+    static void stopHazelcast() {
+        if (hazelcastInstance != null) {
+            hazelcastInstance.shutdown();
+        }
+    }
+
+    @BeforeEach
+    void clearEmbeddings() {
+        embeddingStore.removeAll();
+    }
+
+    @Override
+    protected EmbeddingStore<TextSegment> embeddingStore() {
+        return embeddingStore;
+    }
+
+    @Override
+    protected EmbeddingModel embeddingModel() {
+        return embeddingModel;
+    }
+
+    @Override
+    protected boolean supportsRemoveAllByFilter() {
+        return false; // Hazelcast VectorCollection has no server-side predicate delete
+    }
+}

--- a/embedding-stores/langchain4j-community-hazelcast-enterprise/src/test/java/dev/langchain4j/community/store/memory/chat/hazelcast/HazelcastCPMapChatMemoryStoreIT.java
+++ b/embedding-stores/langchain4j-community-hazelcast-enterprise/src/test/java/dev/langchain4j/community/store/memory/chat/hazelcast/HazelcastCPMapChatMemoryStoreIT.java
@@ -1,0 +1,206 @@
+package dev.langchain4j.community.store.memory.chat.hazelcast;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.JoinConfig;
+import com.hazelcast.config.NetworkConfig;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ChatMessageType;
+import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.data.message.UserMessage;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+/**
+ * Integration tests for {@link HazelcastCPMapChatMemoryStore}.
+ * <p>
+ * A {@link com.hazelcast.cp.CPMap} requires the CP Subsystem, which needs a quorum of at least
+ * {@code MIN_GROUP_SIZE} (= 3) members. This test therefore starts a three-member embedded cluster
+ * in-process.
+ * <p>
+ * Requires a Hazelcast Enterprise license key in the {@code HZ_LICENSEKEY} environment variable;
+ * the class is skipped (e.g. in CI) when it is not set.
+ */
+@EnabledIfEnvironmentVariable(named = "HZ_LICENSEKEY", matches = ".+")
+class HazelcastCPMapChatMemoryStoreIT {
+
+    private static final int CP_MEMBER_COUNT = 3;
+    private static final int BASE_PORT = 5710;
+
+    static final List<HazelcastInstance> members = new ArrayList<>();
+
+    static HazelcastInstance hazelcastInstance;
+
+    private final String userId = "someUserId";
+
+    private HazelcastCPMapChatMemoryStore memoryStore;
+
+    @BeforeAll
+    static void startCluster() throws InterruptedException {
+        String licenseKey = System.getenv("HZ_LICENSEKEY");
+
+        List<String> memberAddresses =
+                List.of("127.0.0.1:" + BASE_PORT, "127.0.0.1:" + (BASE_PORT + 1), "127.0.0.1:" + (BASE_PORT + 2));
+
+        for (int i = 0; i < CP_MEMBER_COUNT; i++) {
+            Config config = new Config();
+            config.setClusterName("langchain4j-cpmap-it");
+            config.setLicenseKey(licenseKey);
+            config.getCPSubsystemConfig().setCPMemberCount(CP_MEMBER_COUNT);
+
+            NetworkConfig network = config.getNetworkConfig();
+            network.setPort(BASE_PORT).setPortAutoIncrement(true);
+            JoinConfig join = network.getJoin();
+            join.getMulticastConfig().setEnabled(false);
+            join.getTcpIpConfig().setEnabled(true).setMembers(memberAddresses);
+
+            members.add(Hazelcast.newHazelcastInstance(config));
+        }
+
+        hazelcastInstance = members.get(0);
+        // Block until the CP Subsystem has formed before any test runs.
+        hazelcastInstance
+                .getCPSubsystem()
+                .getCPSubsystemManagementService()
+                .awaitUntilDiscoveryCompleted(60, TimeUnit.SECONDS);
+    }
+
+    @AfterAll
+    static void stopCluster() {
+        members.forEach(HazelcastInstance::shutdown);
+        members.clear();
+    }
+
+    @BeforeEach
+    void setUp() {
+        memoryStore = HazelcastCPMapChatMemoryStore.builder()
+                .hazelcastInstance(hazelcastInstance)
+                .name("chatMemory")
+                .build();
+        memoryStore.deleteMessages(userId);
+        assertThat(memoryStore.getMessages(userId)).isEmpty();
+    }
+
+    // -------------------------------------------------------------------------
+    // Core CRUD behaviour
+    // -------------------------------------------------------------------------
+
+    @Test
+    void should_set_and_get_messages() {
+        String sysMessage = "You are a large language model working with LangChain4j";
+
+        List<ChatMessage> chatMessages = new ArrayList<>();
+        chatMessages.add(new SystemMessage(sysMessage));
+        chatMessages.add(new UserMessage("Hello"));
+        memoryStore.updateMessages(userId, chatMessages);
+
+        List<ChatMessage> messages = memoryStore.getMessages(userId);
+        assertThat(messages).hasSize(2);
+        assertThat(messages.get(0).type()).isEqualTo(ChatMessageType.SYSTEM);
+        assertThat(messages.get(1).type()).isEqualTo(ChatMessageType.USER);
+        assertThat(((SystemMessage) messages.get(0)).text()).isEqualTo(sysMessage);
+    }
+
+    @Test
+    void should_overwrite_messages_on_update() {
+        memoryStore.updateMessages(userId, List.of(new SystemMessage("First system prompt")));
+        memoryStore.updateMessages(
+                userId,
+                List.of(new SystemMessage("Updated system prompt"), new UserMessage("Hello"), new AiMessage("Hi!")));
+
+        List<ChatMessage> messages = memoryStore.getMessages(userId);
+        assertThat(messages).hasSize(3);
+        assertThat(((SystemMessage) messages.get(0)).text()).isEqualTo("Updated system prompt");
+    }
+
+    @Test
+    void should_delete_messages() {
+        memoryStore.updateMessages(userId, List.of(new SystemMessage("You are a helpful assistant")));
+        assertThat(memoryStore.getMessages(userId)).hasSize(1);
+
+        memoryStore.deleteMessages(userId);
+
+        assertThat(memoryStore.getMessages(userId)).isEmpty();
+    }
+
+    @Test
+    void should_isolate_different_memory_ids() {
+        memoryStore.updateMessages("alice", List.of(new UserMessage("Alice's message")));
+        memoryStore.updateMessages("bob", List.of(new UserMessage("Bob's message")));
+
+        assertThat(memoryStore.getMessages("alice")).containsExactly(new UserMessage("Alice's message"));
+        assertThat(memoryStore.getMessages("bob")).containsExactly(new UserMessage("Bob's message"));
+
+        // CPMap has no clear(); delete the non-default keys so they don't leak into other tests
+        memoryStore.deleteMessages("alice");
+        memoryStore.deleteMessages("bob");
+    }
+
+    @Test
+    void should_return_empty_list_for_unknown_memory_id() {
+        assertThat(memoryStore.getMessages("unknown-cpmap-id")).isEmpty();
+    }
+
+    @Test
+    void should_delete_non_existent_memory_id_without_error() {
+        memoryStore.deleteMessages("does-not-exist"); // must not throw
+    }
+
+    @Test
+    void should_support_non_string_memory_id() {
+        Integer memoryId = 42;
+        memoryStore.updateMessages(memoryId, List.of(new UserMessage("hi")));
+
+        assertThat(memoryStore.getMessages(memoryId)).containsExactly(new UserMessage("hi"));
+        assertThat(memoryStore.getMessages("42")).containsExactly(new UserMessage("hi"));
+
+        // CPMap has no clear(); delete the key this test wrote so it doesn't leak into other tests
+        memoryStore.deleteMessages(memoryId);
+    }
+
+    // -------------------------------------------------------------------------
+    // Null / empty validation
+    // -------------------------------------------------------------------------
+
+    @Test
+    void getMessages_memoryId_null() {
+        assertThatThrownBy(() -> memoryStore.getMessages(null))
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("memoryId cannot be null");
+    }
+
+    @Test
+    void updateMessages_messages_null() {
+        assertThatThrownBy(() -> memoryStore.updateMessages(userId, null))
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("messages cannot be null or empty");
+    }
+
+    @Test
+    void updateMessages_messages_empty() {
+        assertThatThrownBy(() -> memoryStore.updateMessages(userId, new ArrayList<>()))
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("messages cannot be null or empty");
+    }
+
+    @Test
+    void deleteMessages_memoryId_null() {
+        assertThatThrownBy(() -> memoryStore.deleteMessages(null))
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("memoryId cannot be null");
+    }
+
+    // Builder/factory validation that needs no cluster lives in HazelcastCPMapChatMemoryStoreTest
+    // so it runs without a license.
+}

--- a/embedding-stores/langchain4j-community-hazelcast-enterprise/src/test/java/dev/langchain4j/community/store/memory/chat/hazelcast/HazelcastCPMapChatMemoryStoreTest.java
+++ b/embedding-stores/langchain4j-community-hazelcast-enterprise/src/test/java/dev/langchain4j/community/store/memory/chat/hazelcast/HazelcastCPMapChatMemoryStoreTest.java
@@ -1,0 +1,27 @@
+package dev.langchain4j.community.store.memory.chat.hazelcast;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link HazelcastCPMapChatMemoryStore} that need neither a running cluster nor a
+ * Hazelcast Enterprise license, so they always run (unlike {@link HazelcastCPMapChatMemoryStoreIT},
+ * which is skipped without a license).
+ */
+class HazelcastCPMapChatMemoryStoreTest {
+
+    @Test
+    void builder_throws_when_hazelcast_instance_not_supplied() {
+        assertThatThrownBy(() -> HazelcastCPMapChatMemoryStore.builder().build())
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("hazelcastInstance is required");
+    }
+
+    @Test
+    void create_throws_when_null_cpmap_supplied() {
+        assertThatThrownBy(() -> HazelcastCPMapChatMemoryStore.create(null))
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("chatMemory");
+    }
+}

--- a/langchain4j-community-bom/pom.xml
+++ b/langchain4j-community-bom/pom.xml
@@ -93,6 +93,12 @@
 
             <dependency>
                 <groupId>dev.langchain4j</groupId>
+                <artifactId>langchain4j-community-hazelcast-enterprise</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>dev.langchain4j</groupId>
                 <artifactId>langchain4j-community-memfile</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/langchain4j-community-bom/pom.xml
+++ b/langchain4j-community-bom/pom.xml
@@ -160,6 +160,12 @@
             <!-- memory stores -->
             <dependency>
                 <groupId>dev.langchain4j</groupId>
+                <artifactId>langchain4j-community-hazelcast</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>dev.langchain4j</groupId>
                 <artifactId>langchain4j-community-mongodb</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
         <!-- Integration of embedding store -->
         <module>embedding-stores/langchain4j-community-clickhouse</module>
         <module>embedding-stores/langchain4j-community-duckdb</module>
+        <module>embedding-stores/langchain4j-community-hazelcast-enterprise</module>
         <module>embedding-stores/langchain4j-community-memfile</module>
         <module>embedding-stores/langchain4j-community-redis</module>
         <module>embedding-stores/langchain4j-community-vearch</module>
@@ -132,6 +133,20 @@
             <id>central-portal-snapshots</id>
             <name>Central Portal Snapshots</name>
             <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+        </repository>
+        <!-- Hazelcast Enterprise repository (com.hazelcast:hazelcast-enterprise is not on Maven
+             Central). Declared at the root so the license-maven-plugin compliance check, which
+             ignores module-level <repositories>, can resolve the artifact's POM. -->
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>hazelcast-release</id>
+            <name>Hazelcast Release Repository</name>
+            <url>https://repository.hazelcast.com/release/</url>
         </repository>
     </repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
         <module>embedding-stores/langchain4j-community-valkey</module>
 
         <!-- Integration of chat memory stores -->
+        <module>chat-memory-stores/langchain4j-community-hazelcast</module>
         <module>chat-memory-stores/langchain4j-community-mongodb</module>
         <module>chat-memory-stores/langchain4j-community-sql</module>
 


### PR DESCRIPTION
## Summary

Adds Hazelcast integration to the community repo, split into two modules so that the open-source path stays free of any Enterprise/licensing requirement.

### `langchain4j-community-hazelcast` (open source)

- **`HazelcastChatMemoryStore`** — a `ChatMemoryStore` backed by a Hazelcast `IMap<String,String>` storing JSON-serialised chat messages. Uses `IMap.set`/`delete` (no wasted old-value round-trips) and keys memory ids via `String.valueOf`, so any memory-id type with a stable `toString()` is supported.
- The Hazelcast dependency is `provided` (open-source Community Edition, `com.hazelcast:hazelcast`, by default), so the same store works against an embedded member or a thin client, on either Hazelcast edition, without a clashing duplicate jar.
- Integration tests run against an embedded member and require **no license**.

### `langchain4j-community-hazelcast-enterprise` (Hazelcast Enterprise)

A separate module for the features that require Hazelcast Enterprise:

- **`HazelcastEmbeddingStore`** — an `EmbeddingStore` backed by a `VectorCollection`, with `TextSegmentDocument` as the serialisable value type. Uses async ops (`setAsync`/`putAllAsync`/`deleteAsync`, `clearAsync` for `removeAll()`). Relevance score is taken directly from Hazelcast's already-normalised COSINE score. `removeAll(Filter)` is unsupported (no server-side predicate delete in the `VectorCollection` API).
- **`HazelcastCPMapChatMemoryStore`** — a `ChatMemoryStore` backed by a `CPMap` (CP Subsystem / Raft): a linearizable, strongly-consistent alternative to the AP `IMap` store. Fails fast if the CP Subsystem is not enabled.
- Re-exports `langchain4j-community-hazelcast`, so Enterprise consumers also get the IMap-based store from this single dependency.

#### Enterprise constraints (documented in the module Javadoc)

- `com.hazelcast:hazelcast-enterprise` is **not on Maven Central**. Building/running this module requires adding the Hazelcast release repository (`https://repository.hazelcast.com/release/`) to `~/.m2/settings.xml` or the project `pom.xml`, plus a **valid Hazelcast Enterprise license key**.
- Integration tests are gated with `@EnabledIfEnvironmentVariable(named = "HZ_LICENSEKEY", matches = ".+")`, so CI skips them when no license key is present; a license-free unit test still runs.
- The Hazelcast release repository is also declared in the root reactor `pom.xml` so the `license-maven-plugin` compliance check can resolve the `hazelcast-enterprise` POM (the plugin ignores module-level `<repositories>`). The Enterprise POM declares Apache-2.0, which is already in the accepted licenses.

## Wiring

Both modules are registered in the root reactor and the community BOM.