### PR TITLE
[FEATURE] Support to SQLServer's half-precision float support in vector data type

### DIFF
--- a/embedding-stores/langchain4j-community-sqlserver/README.md
+++ b/embedding-stores/langchain4j-community-sqlserver/README.md
@@ -147,9 +147,9 @@ EmbeddingStore<TextSegment> embeddingStore = SQLServerEmbeddingStore.dataSourceB
 ```
 
 The `halfPrecision` parameter accepts the following options:
-- `HalfPrecisionConfiguration.AUTO` (Default): Uses `float32` by default, but automatically switches to `float16` if the configured dimension is greater than 1998.
+- `HalfPrecisionConfiguration.OFF` (Default): Uses `float32` vectors. Note that the table creation will fail if the dimension is greater than 1998.
 - `HalfPrecisionConfiguration.ON`: Forces the use of `float16` vectors.
-- `HalfPrecisionConfiguration.OFF`: Forces the use of `float32` vectors. Note that the table creation will fail if the dimension is greater than 1998.
+- `HalfPrecisionConfiguration.AUTO`: Uses `float32` by default, but automatically switches to `float16` if the configured dimension is greater than 1998.
 
 ### Embeddings table schema
 

--- a/embedding-stores/langchain4j-community-sqlserver/README.md
+++ b/embedding-stores/langchain4j-community-sqlserver/README.md
@@ -85,6 +85,30 @@ EmbeddingStore<TextSegment> embeddingStore = SQLServerEmbeddingStore.dataSourceB
    .build();
 ```
 
+### Half-Precision (float16) Support
+
+For scenarios requiring large embedding vectors, such as OpenAI's `text-embedding-3-large` (which can have up to 3072 dimensions), you can configure the store to use half-precision (float16) vectors.
+
+**Note:** This feature is currently only available when connecting to **Azure SQL databases**.
+
+Standard `float32` vectors in SQL Server are limited to 1998 dimensions. Enabling `halfPrecision` allows you to exceed this limit.
+
+```java
+EmbeddingStore<TextSegment> embeddingStore = SQLServerEmbeddingStore.dataSourceBuilder()
+   .dataSource(myDataSource)
+   .embeddingTable(EmbeddingTable.builder()
+           .name("my_large_embedding_table")
+           .dimension(3072) // Example: text-embedding-3-large
+           .halfPrecision(HalfPrecisionConfiguration.ON)
+           .build())
+   .build();
+```
+
+The `halfPrecision` parameter accepts the following options:
+- `HalfPrecisionConfiguration.AUTO` (Default): Uses `float32` by default, but automatically switches to `float16` if the configured dimension is greater than 1998.
+- `HalfPrecisionConfiguration.ON`: Forces the use of `float16` vectors.
+- `HalfPrecisionConfiguration.OFF`: Forces the use of `float32` vectors. Note that the table creation will fail if the dimension is greater than 1998.
+
 If the columns of your existing table do not match the predefined column names
 or you would like to use different column names, you can customize the table configuration:
 
@@ -129,7 +153,7 @@ By default, the embedding table will have the following columns:
 | Name | Type              | Description |
 | ---- |-------------------| ----------- |
 | id | NVARCHAR(36)      | Primary key. Used to store UUID strings which are generated when the embedding store |
-| embedding | VECTOR(dimension) | Stores the embedding using SQL Server 2025 native vector type |
+| embedding | VECTOR(dimension) | Stores the embedding using SQL Server 2025 native vector type. Can be `float32` or `float16` (see Half-Precision support). |
 | text | NVARCHAR(MAX)     | Stores the text segment |
 | metadata | JSON              | Stores the metadata using SQL Server 2025 native JSON data type |
 

--- a/embedding-stores/langchain4j-community-sqlserver/README.md
+++ b/embedding-stores/langchain4j-community-sqlserver/README.md
@@ -85,30 +85,6 @@ EmbeddingStore<TextSegment> embeddingStore = SQLServerEmbeddingStore.dataSourceB
    .build();
 ```
 
-### Half-Precision (float16) Support
-
-For scenarios requiring large embedding vectors, such as OpenAI's `text-embedding-3-large` (which can have up to 3072 dimensions), you can configure the store to use half-precision (float16) vectors.
-
-**Note:** This feature is currently only available when connecting to **Azure SQL databases**.
-
-Standard `float32` vectors in SQL Server are limited to 1998 dimensions. Enabling `halfPrecision` allows you to exceed this limit.
-
-```java
-EmbeddingStore<TextSegment> embeddingStore = SQLServerEmbeddingStore.dataSourceBuilder()
-   .dataSource(myDataSource)
-   .embeddingTable(EmbeddingTable.builder()
-           .name("my_large_embedding_table")
-           .dimension(3072) // Example: text-embedding-3-large
-           .halfPrecision(HalfPrecisionConfiguration.ON)
-           .build())
-   .build();
-```
-
-The `halfPrecision` parameter accepts the following options:
-- `HalfPrecisionConfiguration.AUTO` (Default): Uses `float32` by default, but automatically switches to `float16` if the configured dimension is greater than 1998.
-- `HalfPrecisionConfiguration.ON`: Forces the use of `float16` vectors.
-- `HalfPrecisionConfiguration.OFF`: Forces the use of `float32` vectors. Note that the table creation will fail if the dimension is greater than 1998.
-
 If the columns of your existing table do not match the predefined column names
 or you would like to use different column names, you can customize the table configuration:
 
@@ -145,6 +121,35 @@ SQLServerEmbeddingStore.connectionBuilder()
             .build())
     .build();
 ```
+
+### Half-Precision (float16) Support
+
+For scenarios requiring large embedding vectors, such as OpenAI's `text-embedding-3-large` (which can have up to 3072 dimensions), 
+you can configure the store to use half-precision (float16) vectors. 
+See the [Microsoft documentation](https://learn.microsoft.com/en-us/sql/t-sql/data-types/vector-data-type-half-precision-float?view=sql-server-ver17) for more details.
+
+**Note:** This feature is currently only available when connecting to **Azure SQL databases**.
+
+Standard `float32` vectors in SQL Server are limited to 1998 dimensions. Enabling `halfPrecision` allows you to exceed this limit.
+
+**Important:** To use `halfPrecision` support, you must configure the JDBC driver property `vectorTypeSupport` to `v2`. 
+See the [Microsoft JDBC driver documentation](https://learn.microsoft.com/en-us/sql/connect/jdbc/use-vector-data-type?view=sql-server-ver17#use-vector-float16-data-type) for more details.
+
+```java
+EmbeddingStore<TextSegment> embeddingStore = SQLServerEmbeddingStore.dataSourceBuilder()
+   .dataSource(myDataSource)
+   .embeddingTable(EmbeddingTable.builder()
+           .name("my_large_embedding_table")
+           .dimension(3072) // Example: text-embedding-3-large
+           .halfPrecision(HalfPrecisionConfiguration.ON)
+           .build())
+   .build();
+```
+
+The `halfPrecision` parameter accepts the following options:
+- `HalfPrecisionConfiguration.AUTO` (Default): Uses `float32` by default, but automatically switches to `float16` if the configured dimension is greater than 1998.
+- `HalfPrecisionConfiguration.ON`: Forces the use of `float16` vectors.
+- `HalfPrecisionConfiguration.OFF`: Forces the use of `float32` vectors. Note that the table creation will fail if the dimension is greater than 1998.
 
 ### Embeddings table schema
 

--- a/embedding-stores/langchain4j-community-sqlserver/pom.xml
+++ b/embedding-stores/langchain4j-community-sqlserver/pom.xml
@@ -14,7 +14,7 @@
     <description>SQL Server Database Embedding Store</description>
 
     <properties>
-        <mssql.jdbc.version>13.2.1.jre11</mssql.jdbc.version>
+        <mssql.jdbc.version>13.4.0.jre11</mssql.jdbc.version>
     </properties>
 
     <dependencies>

--- a/embedding-stores/langchain4j-community-sqlserver/src/main/java/dev/langchain4j/store/embedding/sqlserver/EmbeddingTable.java
+++ b/embedding-stores/langchain4j-community-sqlserver/src/main/java/dev/langchain4j/store/embedding/sqlserver/EmbeddingTable.java
@@ -80,7 +80,7 @@ public class EmbeddingTable {
         ensureNotNull(dimension, "dimension");
 
         this.halfPrecision =
-                (builder.halfPrecision == null || HalfPrecisionConfiguration.AUTO.equals(builder.halfPrecision)
+                (builder.halfPrecision == null || HalfPrecisionConfiguration.AUTO == builder.halfPrecision
                         ? dimension > 1998
                         : builder.halfPrecision == HalfPrecisionConfiguration.ON);
     }

--- a/embedding-stores/langchain4j-community-sqlserver/src/main/java/dev/langchain4j/store/embedding/sqlserver/EmbeddingTable.java
+++ b/embedding-stores/langchain4j-community-sqlserver/src/main/java/dev/langchain4j/store/embedding/sqlserver/EmbeddingTable.java
@@ -58,6 +58,7 @@ public class EmbeddingTable {
     private final String metadataColumn;
     private final CreateOption createOption;
     private final Integer dimension;
+    private final boolean halfPrecision;
 
     private EmbeddingTable(Builder builder) {
         SQLServerEmbeddingStoreUtil.checkSQLInjection(builder.catalogName);
@@ -77,6 +78,9 @@ public class EmbeddingTable {
         this.createOption = builder.createOption;
         this.dimension = builder.dimension;
         ensureNotNull(dimension, "dimension");
+
+        this.halfPrecision = (builder.halfPrecision == null || HalfPrecisionConfiguration.AUTO.equals(builder.halfPrecision) ? dimension > 1998 :
+                builder.halfPrecision == HalfPrecisionConfiguration.ON);
     }
 
     /**
@@ -140,6 +144,17 @@ public class EmbeddingTable {
      */
     public Integer dimension() {
         return dimension;
+    }
+
+    /**
+     * Returns whether to use half-precision (float16) for embedding vectors.
+     * When disabled, the embedding store will only be able to store embeddings up to 1998 dimensions.
+     *
+     * @return True if half-precision is enabled, false otherwise.
+     * @see <a href="https://learn.microsoft.com/en-us/sql/t-sql/data-types/vector-data-type-half-precision-float?view=sql-server-ver17">Microsoft Documentation</a> for more information.
+     */
+    public boolean isHalfPrecision() {
+        return halfPrecision;
     }
 
     /**
@@ -218,15 +233,16 @@ public class EmbeddingTable {
 
     private String getCreateTableStatement(boolean ifNotExists) {
 
+        String vectorType = halfPrecision ? "float16" : "float32";
         String createSql = String.format(
                 """
                     CREATE TABLE %s (
                         %s NVARCHAR(36) PRIMARY KEY,
-                        %s VECTOR(%d),
+                        %s VECTOR(%d, %s),
                         %s NVARCHAR(MAX),
                         %s JSON)
                 """,
-                getQualifiedTableName(), idColumn, embeddingColumn, dimension, textColumn, metadataColumn);
+                getQualifiedTableName(), idColumn, embeddingColumn, dimension, vectorType, textColumn, metadataColumn);
         if (ifNotExists) {
             return String.format(
                     """
@@ -258,6 +274,7 @@ public class EmbeddingTable {
         private String metadataColumn = DEFAULT_METADATA_COLUMN;
         private CreateOption createOption = CreateOption.CREATE_NONE;
         private Integer dimension;
+        private HalfPrecisionConfiguration halfPrecision = HalfPrecisionConfiguration.AUTO;
 
         private Builder() {}
 
@@ -361,6 +378,24 @@ public class EmbeddingTable {
         }
 
         /**
+         * Sets the half-precision configuration for embedding vectors.
+         * If {@link HalfPrecisionConfiguration#ON}, the half-precision (float16) type is used for storing the embeddings.
+         * If {@link HalfPrecisionConfiguration#OFF}, the vectors are stored in full precision (float32). Note that the embedding process would fail with embedding models with more than 1998 dimensions.
+         * If {@link HalfPrecisionConfiguration#AUTO} or {@code null}, the default (float32) type is used unless the configured
+         * dimension is greater than 1998.
+         *
+         * @param halfPrecision The half-precision configuration.
+         * @return This builder.
+         *
+         * @see <a href="https://learn.microsoft.com/en-us/sql/t-sql/data-types/vector-data-type-half-precision-float?view=sql-server-ver17">Microsoft Documentation</a>
+         * for more information regarding the half-precision vector support.
+         */
+        public Builder halfPrecision(HalfPrecisionConfiguration halfPrecision) {
+            this.halfPrecision = halfPrecision;
+            return this;
+        }
+
+        /**
          * Builds the EmbeddingTable instance.
          *
          * @return The configured EmbeddingTable.
@@ -383,7 +418,9 @@ public class EmbeddingTable {
                     + textColumn + '\'' + ", metadataColumn='"
                     + metadataColumn + '\'' + ", createOption="
                     + createOption + ", dimension="
-                    + dimension + '}';
+                    + dimension + ", halfPrecision"
+                    + halfPrecision
+                    +'}';
         }
     }
 }

--- a/embedding-stores/langchain4j-community-sqlserver/src/main/java/dev/langchain4j/store/embedding/sqlserver/EmbeddingTable.java
+++ b/embedding-stores/langchain4j-community-sqlserver/src/main/java/dev/langchain4j/store/embedding/sqlserver/EmbeddingTable.java
@@ -15,6 +15,15 @@ import javax.sql.DataSource;
 public class EmbeddingTable {
 
     /**
+     * SQL Server can only store vectors with 1998 dimensions due to its page size limit of 8KB
+     * When the embedding model exceeds this value, the Embedding Store would fail if it tries to store float32 vectors.
+     * With {@code HalfPrecisionConfiguration.AUTO}, the embedding store will automatically switch to using half-precision (float16) vectors.
+     *
+     * @see <a href="https://learn.microsoft.com/en-us/sql/t-sql/data-types/vector-data-type?view=sql-server-ver17&tabs=csharp#dimensions">SQL Server Vector documentation</a>
+     */
+    public static final int SQLSERVER_VECTOR_PRECISION_LIMIT = 1998;
+
+    /**
      * The default catalog for the embedding table.
      */
     public static final String DEFAULT_CATALOG_NAME = null;
@@ -79,10 +88,9 @@ public class EmbeddingTable {
         this.dimension = builder.dimension;
         ensureNotNull(dimension, "dimension");
 
-        this.halfPrecision =
-                (builder.halfPrecision == null || HalfPrecisionConfiguration.AUTO == builder.halfPrecision
-                        ? dimension > 1998
-                        : builder.halfPrecision == HalfPrecisionConfiguration.ON);
+        this.halfPrecision = (builder.halfPrecision == null || HalfPrecisionConfiguration.AUTO == builder.halfPrecision
+                ? dimension > SQLSERVER_VECTOR_PRECISION_LIMIT
+                : builder.halfPrecision == HalfPrecisionConfiguration.ON);
     }
 
     /**
@@ -428,7 +436,7 @@ public class EmbeddingTable {
                     + textColumn + '\'' + ", metadataColumn='"
                     + metadataColumn + '\'' + ", createOption="
                     + createOption + ", dimension="
-                    + dimension + ", halfPrecision"
+                    + dimension + ", halfPrecision="
                     + halfPrecision
                     + '}';
         }

--- a/embedding-stores/langchain4j-community-sqlserver/src/main/java/dev/langchain4j/store/embedding/sqlserver/EmbeddingTable.java
+++ b/embedding-stores/langchain4j-community-sqlserver/src/main/java/dev/langchain4j/store/embedding/sqlserver/EmbeddingTable.java
@@ -378,19 +378,27 @@ public class EmbeddingTable {
         }
 
         /**
-         * Sets the half-precision configuration for embedding vectors.
+         * Sets the half-precision configuration for embedding vectors. This feature is only available for <strong>Azure SQL databases</strong> with preview features enabled.
          * <ul>
          * <li>If {@link HalfPrecisionConfiguration#ON}, the half-precision (float16) type is used for storing the embeddings.</li>
          * <li>If {@link HalfPrecisionConfiguration#OFF}, the vectors are stored in full precision (float32). Note that the embedding process would fail with embedding models with more than 1998 dimensions.</li>
          * <li>If {@link HalfPrecisionConfiguration#AUTO} or {@code null}, the default (float32) type is used unless the configured dimension is greater than 1998.</li>
          * </ul>
-         * This feature is only available for <strong>Azure SQL databases</strong>.
+         * <p>
+         * When enabling the half-precision support, you must configure the JDBC connection property {@code vectorTypeSupport=v2}.
+         * See the <a href="https://learn.microsoft.com/en-us/sql/connect/jdbc/use-vector-data-type?view=sql-server-ver17#use-vector-float16-data-type">Microsoft JDBC driver documentation</a>
+         * for more details.
+         * </p>
+         * <p>
+         * For more information, see {@link SQLServerEmbeddingStore}.
+         * </p>
          *
          * @param halfPrecision The half-precision configuration.
          * @return This builder.
          *
          * @see <a href="https://learn.microsoft.com/en-us/sql/t-sql/data-types/vector-data-type-half-precision-float?view=sql-server-ver17">Microsoft Documentation</a>
          * for more information regarding the half-precision vector support.
+         * @see SQLServerEmbeddingStore
          */
         public Builder halfPrecision(HalfPrecisionConfiguration halfPrecision) {
             this.halfPrecision = halfPrecision;

--- a/embedding-stores/langchain4j-community-sqlserver/src/main/java/dev/langchain4j/store/embedding/sqlserver/EmbeddingTable.java
+++ b/embedding-stores/langchain4j-community-sqlserver/src/main/java/dev/langchain4j/store/embedding/sqlserver/EmbeddingTable.java
@@ -7,12 +7,16 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Types;
 import javax.sql.DataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Represents a database table that stores embeddings, text segments, and metadata.
  * This class handles the creation and management of the table schema for SQL Server.
  */
 public class EmbeddingTable {
+
+    private static final Logger logger = LoggerFactory.getLogger(EmbeddingTable.class);
 
     /**
      * SQL Server can only store vectors with 1998 dimensions due to its page size limit of 8KB
@@ -88,9 +92,18 @@ public class EmbeddingTable {
         this.dimension = builder.dimension;
         ensureNotNull(dimension, "dimension");
 
-        this.halfPrecision = (builder.halfPrecision == null || HalfPrecisionConfiguration.AUTO == builder.halfPrecision
-                ? dimension > SQLSERVER_VECTOR_PRECISION_LIMIT
-                : builder.halfPrecision == HalfPrecisionConfiguration.ON);
+        if (HalfPrecisionConfiguration.AUTO == builder.halfPrecision) {
+            this.halfPrecision = dimension > SQLSERVER_VECTOR_PRECISION_LIMIT;
+            if (this.halfPrecision) {
+                logger.warn(
+                        "Dimension {} exceeds the float32 limit of {}. Automatically switching to half-precision (float16). "
+                                + "This requires an Azure SQL database with preview features enabled and the JDBC property vectorTypeSupport=v2.",
+                        dimension,
+                        SQLSERVER_VECTOR_PRECISION_LIMIT);
+            }
+        } else {
+            this.halfPrecision = builder.halfPrecision == HalfPrecisionConfiguration.ON;
+        }
     }
 
     /**
@@ -282,7 +295,7 @@ public class EmbeddingTable {
         private String metadataColumn = DEFAULT_METADATA_COLUMN;
         private CreateOption createOption = CreateOption.CREATE_NONE;
         private Integer dimension;
-        private HalfPrecisionConfiguration halfPrecision = HalfPrecisionConfiguration.AUTO;
+        private HalfPrecisionConfiguration halfPrecision = HalfPrecisionConfiguration.OFF;
 
         private Builder() {}
 
@@ -390,7 +403,8 @@ public class EmbeddingTable {
          * <ul>
          * <li>If {@link HalfPrecisionConfiguration#ON}, the half-precision (float16) type is used for storing the embeddings.</li>
          * <li>If {@link HalfPrecisionConfiguration#OFF}, the vectors are stored in full precision (float32). Note that the embedding process would fail with embedding models with more than 1998 dimensions.</li>
-         * <li>If {@link HalfPrecisionConfiguration#AUTO} or {@code null}, the default (float32) type is used unless the configured dimension is greater than 1998.</li>
+         * <li>If {@link HalfPrecisionConfiguration#AUTO}, the default (float32) type is used unless the configured dimension is greater than 1998, in which case half-precision (float16) is used automatically.</li>
+         * <li>If {@code null}, treated as {@link HalfPrecisionConfiguration#OFF}.</li>
          * </ul>
          * <p>
          * When enabling the half-precision support, you must configure the JDBC connection property {@code vectorTypeSupport=v2}.

--- a/embedding-stores/langchain4j-community-sqlserver/src/main/java/dev/langchain4j/store/embedding/sqlserver/EmbeddingTable.java
+++ b/embedding-stores/langchain4j-community-sqlserver/src/main/java/dev/langchain4j/store/embedding/sqlserver/EmbeddingTable.java
@@ -379,10 +379,12 @@ public class EmbeddingTable {
 
         /**
          * Sets the half-precision configuration for embedding vectors.
-         * If {@link HalfPrecisionConfiguration#ON}, the half-precision (float16) type is used for storing the embeddings.
-         * If {@link HalfPrecisionConfiguration#OFF}, the vectors are stored in full precision (float32). Note that the embedding process would fail with embedding models with more than 1998 dimensions.
-         * If {@link HalfPrecisionConfiguration#AUTO} or {@code null}, the default (float32) type is used unless the configured
-         * dimension is greater than 1998.
+         * <ul>
+         * <li>If {@link HalfPrecisionConfiguration#ON}, the half-precision (float16) type is used for storing the embeddings.</li>
+         * <li>If {@link HalfPrecisionConfiguration#OFF}, the vectors are stored in full precision (float32). Note that the embedding process would fail with embedding models with more than 1998 dimensions.</li>
+         * <li>If {@link HalfPrecisionConfiguration#AUTO} or {@code null}, the default (float32) type is used unless the configured dimension is greater than 1998.</li>
+         * </ul>
+         * This feature is only available for <strong>Azure SQL databases</strong>.
          *
          * @param halfPrecision The half-precision configuration.
          * @return This builder.

--- a/embedding-stores/langchain4j-community-sqlserver/src/main/java/dev/langchain4j/store/embedding/sqlserver/EmbeddingTable.java
+++ b/embedding-stores/langchain4j-community-sqlserver/src/main/java/dev/langchain4j/store/embedding/sqlserver/EmbeddingTable.java
@@ -79,8 +79,10 @@ public class EmbeddingTable {
         this.dimension = builder.dimension;
         ensureNotNull(dimension, "dimension");
 
-        this.halfPrecision = (builder.halfPrecision == null || HalfPrecisionConfiguration.AUTO.equals(builder.halfPrecision) ? dimension > 1998 :
-                builder.halfPrecision == HalfPrecisionConfiguration.ON);
+        this.halfPrecision =
+                (builder.halfPrecision == null || HalfPrecisionConfiguration.AUTO.equals(builder.halfPrecision)
+                        ? dimension > 1998
+                        : builder.halfPrecision == HalfPrecisionConfiguration.ON);
     }
 
     /**
@@ -244,14 +246,12 @@ public class EmbeddingTable {
                 """,
                 getQualifiedTableName(), idColumn, embeddingColumn, dimension, vectorType, textColumn, metadataColumn);
         if (ifNotExists) {
-            return String.format(
-                    """
+            return String.format("""
                         IF OBJECT_ID(N'%s', N'U') IS NULL
                             BEGIN
                                 %s
                             END;
-                    """,
-                    getQualifiedTableName(), createSql);
+                    """, getQualifiedTableName(), createSql);
         } else {
             return createSql;
         }
@@ -420,7 +420,7 @@ public class EmbeddingTable {
                     + createOption + ", dimension="
                     + dimension + ", halfPrecision"
                     + halfPrecision
-                    +'}';
+                    + '}';
         }
     }
 }

--- a/embedding-stores/langchain4j-community-sqlserver/src/main/java/dev/langchain4j/store/embedding/sqlserver/HalfPrecisionConfiguration.java
+++ b/embedding-stores/langchain4j-community-sqlserver/src/main/java/dev/langchain4j/store/embedding/sqlserver/HalfPrecisionConfiguration.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026. DENODO Technologies.
+ * http://www.denodo.com
+ * All rights reserved.
+ *
+ * This software is the confidential and proprietary information of DENODO
+ * Technologies ("Confidential Information"). You shall not disclose such
+ * Confidential Information and shall use it only in accordance with the terms
+ * of the license agreement you entered into with DENODO.
+ */
+package dev.langchain4j.store.embedding.sqlserver;
+
+/**
+ * Represents the configuration options for using half-precision (16-bit) floating-point numbers.
+ * This enumeration defines the following modes:
+ *
+ * <ul>
+ *   <li>{@code AUTO}: Automatic determination of whether to use half-precision based on the dimensions.</li>
+ *   <li>{@code ON}: Explicitly enables the use of half-precision.</li>
+ *   <li>{@code OFF}: Explicitly disables the use of half-precision. This mode can make the embedding store fail when the embedding dimension is too large for full precision.</li>
+ * </ul>
+ *
+ */
+public enum HalfPrecisionConfiguration {
+
+    AUTO,
+    ON,
+    OFF;
+
+}

--- a/embedding-stores/langchain4j-community-sqlserver/src/main/java/dev/langchain4j/store/embedding/sqlserver/HalfPrecisionConfiguration.java
+++ b/embedding-stores/langchain4j-community-sqlserver/src/main/java/dev/langchain4j/store/embedding/sqlserver/HalfPrecisionConfiguration.java
@@ -1,13 +1,3 @@
-/*
- * Copyright (c) 2026. DENODO Technologies.
- * http://www.denodo.com
- * All rights reserved.
- *
- * This software is the confidential and proprietary information of DENODO
- * Technologies ("Confidential Information"). You shall not disclose such
- * Confidential Information and shall use it only in accordance with the terms
- * of the license agreement you entered into with DENODO.
- */
 package dev.langchain4j.store.embedding.sqlserver;
 
 /**
@@ -22,7 +12,16 @@ package dev.langchain4j.store.embedding.sqlserver;
  *
  */
 public enum HalfPrecisionConfiguration {
+    /**
+     * Automatic determination of whether to use half-precision based on the dimensions.
+     */
     AUTO,
+    /**
+     * Explicitly enables the use of half-precision.
+     */
     ON,
+    /**
+     * Explicitly disables the use of half-precision. This mode can make the embedding store fail when the embedding dimension is too large for full precision.
+     */
     OFF;
 }

--- a/embedding-stores/langchain4j-community-sqlserver/src/main/java/dev/langchain4j/store/embedding/sqlserver/HalfPrecisionConfiguration.java
+++ b/embedding-stores/langchain4j-community-sqlserver/src/main/java/dev/langchain4j/store/embedding/sqlserver/HalfPrecisionConfiguration.java
@@ -22,9 +22,7 @@ package dev.langchain4j.store.embedding.sqlserver;
  *
  */
 public enum HalfPrecisionConfiguration {
-
     AUTO,
     ON,
     OFF;
-
 }

--- a/embedding-stores/langchain4j-community-sqlserver/src/main/java/dev/langchain4j/store/embedding/sqlserver/SQLServerEmbeddingStore.java
+++ b/embedding-stores/langchain4j-community-sqlserver/src/main/java/dev/langchain4j/store/embedding/sqlserver/SQLServerEmbeddingStore.java
@@ -27,7 +27,18 @@ import org.slf4j.LoggerFactory;
  * SQL Server implementation of {@link EmbeddingStore}.
  * <p>
  * This implementation uses SQL Server database to store embeddings along with their associated text segments and metadata.
- * It leverages SQL Server 2025+'s native VECTOR data type and VECTOR_DISTANCE function for efficient similarity calculations.
+ * It leverages SQL Server 2025+'s native {@code VECTOR} data type and {@code VECTOR_DISTANCE} function for efficient similarity calculations.
+ * </p>
+ * <p>
+ * Standard SQL Server vectors can only handle 1998 dimensions when using the {@code float32} precision.
+ * For larger dimensions, <string>Azure SQL</string> Database supports half-precision ({@code float16}) vectors.
+ * However, this is a preview feature and requires enabling it in the database.
+ * For more details, see the <a href="https://learn.microsoft.com/en-us/sql/t-sql/data-types/vector-data-type-half-precision-float?view=sql-server-ver17">Microsoft documentation</a>.
+ * </p>
+ * <p>
+ * When using half-precision support, you must configure the JDBC connection property {@code vectorTypeSupport=v2}.
+ * See the <a href="https://learn.microsoft.com/en-us/sql/connect/jdbc/use-vector-data-type?view=sql-server-ver17#use-vector-float16-data-type">Microsoft JDBC driver documentation</a>
+ * for more details.
  * </p>
  */
 public class SQLServerEmbeddingStore implements EmbeddingStore<TextSegment> {
@@ -68,7 +79,7 @@ public class SQLServerEmbeddingStore implements EmbeddingStore<TextSegment> {
     }
 
     /**
-     * Creates a builder for configuring a SQLServerEmbeddingStore with a java.sql.DataSource.
+     * Creates a builder for configuring a {@code SQLServerEmbeddingStore} using the connection details.
      *
      * @return A new builder instance.
      */

--- a/embedding-stores/langchain4j-community-sqlserver/src/main/java/dev/langchain4j/store/embedding/sqlserver/SQLServerEmbeddingStore.java
+++ b/embedding-stores/langchain4j-community-sqlserver/src/main/java/dev/langchain4j/store/embedding/sqlserver/SQLServerEmbeddingStore.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
  * </p>
  * <p>
  * Standard SQL Server vectors can only handle 1998 dimensions when using the {@code float32} precision.
- * For larger dimensions, <string>Azure SQL</string> Database supports half-precision ({@code float16}) vectors.
+ * For larger dimensions, <strong>Azure SQL</strong> Database supports half-precision ({@code float16}) vectors.
  * However, this is a preview feature and requires enabling it in the database.
  * For more details, see the <a href="https://learn.microsoft.com/en-us/sql/t-sql/data-types/vector-data-type-half-precision-float?view=sql-server-ver17">Microsoft documentation</a>.
  * </p>

--- a/embedding-stores/langchain4j-community-sqlserver/src/main/java/dev/langchain4j/store/embedding/sqlserver/SQLServerEmbeddingStore.java
+++ b/embedding-stores/langchain4j-community-sqlserver/src/main/java/dev/langchain4j/store/embedding/sqlserver/SQLServerEmbeddingStore.java
@@ -114,8 +114,7 @@ public class SQLServerEmbeddingStore implements EmbeddingStore<TextSegment> {
 
                 statement.setString(1, id);
                 Float[] boxedVector = SQLServerEmbeddingStoreUtil.boxEmbeddings(embedding.vector());
-                Vector vector =
-                        new microsoft.sql.Vector(boxedVector.length, Vector.VectorDimensionType.FLOAT32, boxedVector);
+                Vector vector = SQLServerEmbeddingStoreUtil.getVector(boxedVector, embeddingTable.isHalfPrecision());
                 statement.setObject(2, vector, microsoft.sql.Types.VECTOR);
 
                 statement.addBatch();
@@ -179,8 +178,7 @@ public class SQLServerEmbeddingStore implements EmbeddingStore<TextSegment> {
                         SQLServerEmbeddingStoreUtil.ensureIndexNotNull(textSegments, i, "textSegments");
 
                 Float[] boxedVector = SQLServerEmbeddingStoreUtil.boxEmbeddings(embedding.vector());
-                Vector vector =
-                        new microsoft.sql.Vector(boxedVector.length, Vector.VectorDimensionType.FLOAT32, boxedVector);
+                Vector vector = SQLServerEmbeddingStoreUtil.getVector(boxedVector, embeddingTable.isHalfPrecision());
                 statement.setObject(2, vector, microsoft.sql.Types.VECTOR);
 
                 statement.setObject(3, textSegment.text());
@@ -235,8 +233,7 @@ public class SQLServerEmbeddingStore implements EmbeddingStore<TextSegment> {
 
             // Set the query embedding vector as the first parameter
             Float[] boxedVector = SQLServerEmbeddingStoreUtil.boxEmbeddings(referenceEmbedding.vector());
-            Vector vector =
-                    new microsoft.sql.Vector(boxedVector.length, Vector.VectorDimensionType.FLOAT32, boxedVector);
+            Vector vector = SQLServerEmbeddingStoreUtil.getVector(boxedVector, embeddingTable.isHalfPrecision());
             statement.setObject(1, vector, microsoft.sql.Types.VECTOR);
 
             // Set filter parameters starting from index 2
@@ -356,8 +353,7 @@ public class SQLServerEmbeddingStore implements EmbeddingStore<TextSegment> {
                 PreparedStatement statement = connection.prepareStatement(sql)) {
 
             Float[] boxedVector = SQLServerEmbeddingStoreUtil.boxEmbeddings(embedding.vector());
-            Vector vector =
-                    new microsoft.sql.Vector(boxedVector.length, Vector.VectorDimensionType.FLOAT32, boxedVector);
+            Vector vector = SQLServerEmbeddingStoreUtil.getVector(boxedVector, embeddingTable.isHalfPrecision());
             statement.setString(1, id);
             statement.setObject(2, vector, microsoft.sql.Types.VECTOR);
             statement.setString(3, textSegment != null ? textSegment.text() : null);

--- a/embedding-stores/langchain4j-community-sqlserver/src/main/java/dev/langchain4j/store/embedding/sqlserver/SQLServerEmbeddingStoreUtil.java
+++ b/embedding-stores/langchain4j-community-sqlserver/src/main/java/dev/langchain4j/store/embedding/sqlserver/SQLServerEmbeddingStoreUtil.java
@@ -140,6 +140,15 @@ class SQLServerEmbeddingStoreUtil {
         }
     }
 
+    /**
+     * Creates a {@link Vector} instance from the given boxed float array, using either half-precision (float16)
+     * or full-precision (float32) based on the {@code halfPrecision} flag.
+     *
+     * @param boxedVector the embedding vector as an array of {@link Float} objects
+     * @param halfPrecision if {@code true}, the vector uses {@link Vector.VectorDimensionType#FLOAT16};
+     *                      otherwise, it uses {@link Vector.VectorDimensionType#FLOAT32}
+     * @return a new {@link Vector} instance with the specified precision
+     */
     public static Vector getVector(Float[] boxedVector, boolean halfPrecision) {
         return new Vector(
                 boxedVector.length,

--- a/embedding-stores/langchain4j-community-sqlserver/src/main/java/dev/langchain4j/store/embedding/sqlserver/SQLServerEmbeddingStoreUtil.java
+++ b/embedding-stores/langchain4j-community-sqlserver/src/main/java/dev/langchain4j/store/embedding/sqlserver/SQLServerEmbeddingStoreUtil.java
@@ -139,4 +139,10 @@ class SQLServerEmbeddingStoreUtil {
                     "SQL identifier contains potentially dangerous characters: " + identifier);
         }
     }
+
+    public static Vector getVector(Float[] boxedVector, boolean halfPrecision) {
+        return new Vector(boxedVector.length,
+                halfPrecision ? Vector.VectorDimensionType.FLOAT16 : Vector.VectorDimensionType.FLOAT32,
+                boxedVector);
+    }
 }

--- a/embedding-stores/langchain4j-community-sqlserver/src/main/java/dev/langchain4j/store/embedding/sqlserver/SQLServerEmbeddingStoreUtil.java
+++ b/embedding-stores/langchain4j-community-sqlserver/src/main/java/dev/langchain4j/store/embedding/sqlserver/SQLServerEmbeddingStoreUtil.java
@@ -141,7 +141,8 @@ class SQLServerEmbeddingStoreUtil {
     }
 
     public static Vector getVector(Float[] boxedVector, boolean halfPrecision) {
-        return new Vector(boxedVector.length,
+        return new Vector(
+                boxedVector.length,
                 halfPrecision ? Vector.VectorDimensionType.FLOAT16 : Vector.VectorDimensionType.FLOAT32,
                 boxedVector);
     }

--- a/embedding-stores/langchain4j-community-sqlserver/src/main/java/dev/langchain4j/store/embedding/sqlserver/exception/SQLServerLangChain4jException.java
+++ b/embedding-stores/langchain4j-community-sqlserver/src/main/java/dev/langchain4j/store/embedding/sqlserver/exception/SQLServerLangChain4jException.java
@@ -3,15 +3,28 @@ package dev.langchain4j.store.embedding.sqlserver.exception;
 import dev.langchain4j.exception.LangChain4jException;
 import java.io.Serial;
 
+/**
+ * Exception specific to SQL Server operations within LangChain4j.
+ */
 public class SQLServerLangChain4jException extends LangChain4jException {
 
     @Serial
     private static final long serialVersionUID = -8750324500800275924L;
 
+    /**
+     * Constructs a new instance of SQLServerLangChain4jException with the specified cause.
+     *
+     * @param cause The underlying cause of the exception. Can be null.
+     */
     public SQLServerLangChain4jException(final Throwable cause) {
         super(cause);
     }
 
+    /**
+     * Creates a new instance of SQLServerLangChain4jException with the specified message and cause.
+     * @param message Error message.
+     * @param cause The underlying cause of the exception. Can be null.
+     */
     public SQLServerLangChain4jException(final String message, final Throwable cause) {
         super(message, cause);
     }

--- a/embedding-stores/langchain4j-community-sqlserver/src/test/java/dev/langchain4j/store/embedding/sqlserver/SQLServerHalfPrecisionEmbeddingStoreIT.java
+++ b/embedding-stores/langchain4j-community-sqlserver/src/test/java/dev/langchain4j/store/embedding/sqlserver/SQLServerHalfPrecisionEmbeddingStoreIT.java
@@ -2,6 +2,7 @@ package dev.langchain4j.store.embedding.sqlserver;
 
 import static dev.langchain4j.store.embedding.TestUtils.awaitUntilAsserted;
 import static dev.langchain4j.store.embedding.sqlserver.util.SQLServerTestsUtil.DEFAULT_CONTAINER;
+import static dev.langchain4j.store.embedding.sqlserver.util.SQLServerTestsUtil.getLocalSqlServerDataSource;
 import static dev.langchain4j.store.embedding.sqlserver.util.SQLServerTestsUtil.getSqlServerDataSource;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.data.Percentage.withPercentage;
@@ -33,7 +34,7 @@ class SQLServerHalfPrecisionEmbeddingStoreIT extends EmbeddingStoreWithFiltering
     static String tableName = "test_" + nextInt(1000, 2000);
     static EmbeddingModel embeddingModel = new AllMiniLmL6V2QuantizedEmbeddingModel();
     static EmbeddingStore<TextSegment> embeddingStore = SQLServerEmbeddingStore.dataSourceBuilder()
-            .dataSource(getSqlServerDataSource())
+            .dataSource(getLocalSqlServerDataSource())
             .embeddingTable(EmbeddingTable.builder()
                     .name(tableName)
                     .createOption(CreateOption.CREATE_OR_REPLACE)

--- a/embedding-stores/langchain4j-community-sqlserver/src/test/java/dev/langchain4j/store/embedding/sqlserver/SQLServerHalfPrecisionEmbeddingStoreIT.java
+++ b/embedding-stores/langchain4j-community-sqlserver/src/test/java/dev/langchain4j/store/embedding/sqlserver/SQLServerHalfPrecisionEmbeddingStoreIT.java
@@ -1,9 +1,7 @@
 package dev.langchain4j.store.embedding.sqlserver;
 
 import static dev.langchain4j.store.embedding.TestUtils.awaitUntilAsserted;
-import static dev.langchain4j.store.embedding.sqlserver.util.SQLServerTestsUtil.DEFAULT_CONTAINER;
 import static dev.langchain4j.store.embedding.sqlserver.util.SQLServerTestsUtil.getAzureSqlServerDataSource;
-import static dev.langchain4j.store.embedding.sqlserver.util.SQLServerTestsUtil.getSqlServerDataSource;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.data.Percentage.withPercentage;
 import static org.testcontainers.shaded.org.apache.commons.lang3.RandomUtils.nextInt;
@@ -22,13 +20,10 @@ import dev.langchain4j.store.embedding.sqlserver.util.SQLServerTestsUtil;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
-@Testcontainers
 class SQLServerHalfPrecisionEmbeddingStoreIT extends EmbeddingStoreWithFilteringIT {
 
     static String tableName = "test_" + nextInt(1000, 2000);
@@ -43,6 +38,13 @@ class SQLServerHalfPrecisionEmbeddingStoreIT extends EmbeddingStoreWithFiltering
                     .halfPrecision(HalfPrecisionConfiguration.ON)
                     .build())
             .build();
+
+    // Override needed because the expected embeddings have more precision than the obtained with the half-precision
+    // support
+    @Override
+    protected boolean assertEmbedding() {
+        return false;
+    }
 
     @Test
     void test_unicode_embeddings() {
@@ -134,10 +136,5 @@ class SQLServerHalfPrecisionEmbeddingStoreIT extends EmbeddingStoreWithFiltering
     @AfterEach
     void after() {
         clearStore();
-    }
-
-    @AfterAll
-    static void afterClass() {
-        DEFAULT_CONTAINER.stop();
     }
 }

--- a/embedding-stores/langchain4j-community-sqlserver/src/test/java/dev/langchain4j/store/embedding/sqlserver/SQLServerHalfPrecisionEmbeddingStoreIT.java
+++ b/embedding-stores/langchain4j-community-sqlserver/src/test/java/dev/langchain4j/store/embedding/sqlserver/SQLServerHalfPrecisionEmbeddingStoreIT.java
@@ -23,7 +23,9 @@ import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
+@EnabledIfEnvironmentVariable(named = "AZURE_SQL_SERVER_NAME", matches = ".+")
 class SQLServerHalfPrecisionEmbeddingStoreIT extends EmbeddingStoreWithFilteringIT {
 
     static String tableName = "test_" + nextInt(1000, 2000);

--- a/embedding-stores/langchain4j-community-sqlserver/src/test/java/dev/langchain4j/store/embedding/sqlserver/SQLServerHalfPrecisionEmbeddingStoreIT.java
+++ b/embedding-stores/langchain4j-community-sqlserver/src/test/java/dev/langchain4j/store/embedding/sqlserver/SQLServerHalfPrecisionEmbeddingStoreIT.java
@@ -1,0 +1,142 @@
+package dev.langchain4j.store.embedding.sqlserver;
+
+import static dev.langchain4j.store.embedding.TestUtils.awaitUntilAsserted;
+import static dev.langchain4j.store.embedding.sqlserver.util.SQLServerTestsUtil.DEFAULT_CONTAINER;
+import static dev.langchain4j.store.embedding.sqlserver.util.SQLServerTestsUtil.getSqlServerDataSource;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.Percentage.withPercentage;
+import static org.testcontainers.shaded.org.apache.commons.lang3.RandomUtils.nextInt;
+
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.embedding.onnx.allminilml6v2q.AllMiniLmL6V2QuantizedEmbeddingModel;
+import dev.langchain4j.store.embedding.EmbeddingMatch;
+import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
+import dev.langchain4j.store.embedding.EmbeddingSearchResult;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import dev.langchain4j.store.embedding.EmbeddingStoreWithFilteringIT;
+import dev.langchain4j.store.embedding.filter.MetadataFilterBuilder;
+import dev.langchain4j.store.embedding.sqlserver.util.SQLServerTestsUtil;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+class SQLServerHalfPrecisionEmbeddingStoreIT extends EmbeddingStoreWithFilteringIT {
+
+    static String tableName = "test_" + nextInt(1000, 2000);
+    static EmbeddingModel embeddingModel = new AllMiniLmL6V2QuantizedEmbeddingModel();
+    static EmbeddingStore<TextSegment> embeddingStore = SQLServerEmbeddingStore.dataSourceBuilder()
+            .dataSource(getSqlServerDataSource())
+            .embeddingTable(EmbeddingTable.builder()
+                    .name(tableName)
+                    .createOption(CreateOption.CREATE_OR_REPLACE)
+                    .dimension(embeddingModel.dimension())
+                    // Force half-precision for embeddings
+                    .halfPrecision(HalfPrecisionConfiguration.ON)
+                    .build())
+            .build();
+
+    @Test
+    void test_unicode_embeddings() {
+
+        TextSegment[] segments = SQLServerTestsUtil.japaneseSampling();
+        List<Embedding> embeddings = new ArrayList<>(segments.length);
+        for (TextSegment segment : segments) {
+            Embedding embedding = embeddingModel().embed(segment.text()).content();
+            embeddings.add(embedding);
+        }
+
+        List<String> ids = embeddingStore().addAll(embeddings, Arrays.asList(segments));
+        awaitUntilAsserted(() -> assertThat(getAllEmbeddings()).hasSameSizeAs(segments));
+
+        EmbeddingSearchRequest searchRequest = EmbeddingSearchRequest.builder()
+                .queryEmbedding(embeddings.get(0))
+                .maxResults(1)
+                .build();
+
+        // when
+        EmbeddingSearchResult<TextSegment> searchResult = embeddingStore().search(searchRequest);
+
+        // then
+        assertThat(searchResult.matches()).hasSize(1);
+        EmbeddingMatch<TextSegment> match = searchResult.matches().get(0);
+        assertThat(match.score()).isCloseTo(1, withPercentage(1));
+        assertThat(match.embeddingId()).isEqualTo(ids.get(0));
+        if (assertEmbedding()) {
+            assertThat(match.embedding()).isEqualTo(embeddings.get(0));
+        }
+
+        assertThat(match.embedded().text()).isEqualTo(segments[0].text());
+    }
+
+    @Test
+    void test_unicode_metadata() {
+        TextSegment[] segments = SQLServerTestsUtil.japaneseSampling();
+        List<Embedding> embeddings = new ArrayList<>(segments.length);
+        for (TextSegment segment : segments) {
+            Embedding embedding = embeddingModel().embed(segment.text()).content();
+            embeddings.add(embedding);
+        }
+
+        Embedding emb = embeddingModel().embed("Test embedding").content();
+
+        embeddingStore().addAll(embeddings, Arrays.asList(segments));
+        awaitUntilAsserted(() -> assertThat(getAllEmbeddings()).hasSameSizeAs(segments));
+
+        EmbeddingSearchRequest searchRequest = EmbeddingSearchRequest.builder()
+                .queryEmbedding(emb)
+                .filter(MetadataFilterBuilder.metadataKey("jap_name")
+                        .isEqualTo("天ぷら (てんぷら)")
+                        .and(MetadataFilterBuilder.metadataKey("jap_name").isNotEqualTo("ラーメン")))
+                .maxResults(2)
+                .build();
+
+        // when
+        EmbeddingSearchResult<TextSegment> searchResult = embeddingStore().search(searchRequest);
+
+        // then
+        assertThat(searchResult.matches()).hasSize(1);
+        EmbeddingMatch<TextSegment> match = searchResult.matches().get(0);
+
+        assertThat(match.embedded().metadata().getString("name")).isEqualTo("Tempura");
+    }
+
+    @Override
+    protected EmbeddingStore<TextSegment> embeddingStore() {
+        return embeddingStore;
+    }
+
+    @Override
+    protected EmbeddingModel embeddingModel() {
+        return embeddingModel;
+    }
+
+    @Override
+    protected void clearStore() {
+        if (embeddingStore != null) {
+            embeddingStore.removeAll();
+        }
+    }
+
+    @BeforeEach
+    void before() {
+        clearStore();
+    }
+
+    @AfterEach
+    void after() {
+        clearStore();
+    }
+
+    @AfterAll
+    static void afterClass() {
+        DEFAULT_CONTAINER.stop();
+    }
+}

--- a/embedding-stores/langchain4j-community-sqlserver/src/test/java/dev/langchain4j/store/embedding/sqlserver/SQLServerHalfPrecisionEmbeddingStoreIT.java
+++ b/embedding-stores/langchain4j-community-sqlserver/src/test/java/dev/langchain4j/store/embedding/sqlserver/SQLServerHalfPrecisionEmbeddingStoreIT.java
@@ -2,7 +2,7 @@ package dev.langchain4j.store.embedding.sqlserver;
 
 import static dev.langchain4j.store.embedding.TestUtils.awaitUntilAsserted;
 import static dev.langchain4j.store.embedding.sqlserver.util.SQLServerTestsUtil.DEFAULT_CONTAINER;
-import static dev.langchain4j.store.embedding.sqlserver.util.SQLServerTestsUtil.getLocalSqlServerDataSource;
+import static dev.langchain4j.store.embedding.sqlserver.util.SQLServerTestsUtil.getAzureSqlServerDataSource;
 import static dev.langchain4j.store.embedding.sqlserver.util.SQLServerTestsUtil.getSqlServerDataSource;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.data.Percentage.withPercentage;
@@ -34,7 +34,7 @@ class SQLServerHalfPrecisionEmbeddingStoreIT extends EmbeddingStoreWithFiltering
     static String tableName = "test_" + nextInt(1000, 2000);
     static EmbeddingModel embeddingModel = new AllMiniLmL6V2QuantizedEmbeddingModel();
     static EmbeddingStore<TextSegment> embeddingStore = SQLServerEmbeddingStore.dataSourceBuilder()
-            .dataSource(getLocalSqlServerDataSource())
+            .dataSource(getAzureSqlServerDataSource())
             .embeddingTable(EmbeddingTable.builder()
                     .name(tableName)
                     .createOption(CreateOption.CREATE_OR_REPLACE)

--- a/embedding-stores/langchain4j-community-sqlserver/src/test/java/dev/langchain4j/store/embedding/sqlserver/SQLServerHalfPrecisionEmbeddingStoreRemovalIT.java
+++ b/embedding-stores/langchain4j-community-sqlserver/src/test/java/dev/langchain4j/store/embedding/sqlserver/SQLServerHalfPrecisionEmbeddingStoreRemovalIT.java
@@ -12,7 +12,9 @@ import dev.langchain4j.store.embedding.EmbeddingStoreWithRemovalIT;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
+@EnabledIfEnvironmentVariable(named = "AZURE_SQL_SERVER_NAME", matches = ".+")
 class SQLServerHalfPrecisionEmbeddingStoreRemovalIT extends EmbeddingStoreWithRemovalIT {
 
     static String tableName = "test_remove_" + nextInt(1000, 2000);
@@ -23,6 +25,7 @@ class SQLServerHalfPrecisionEmbeddingStoreRemovalIT extends EmbeddingStoreWithRe
                     .name(tableName)
                     .createOption(CreateOption.CREATE_OR_REPLACE)
                     .dimension(embeddingModel.dimension())
+                    .halfPrecision(HalfPrecisionConfiguration.ON)
                     .build())
             .build();
 

--- a/embedding-stores/langchain4j-community-sqlserver/src/test/java/dev/langchain4j/store/embedding/sqlserver/SQLServerHalfPrecisionEmbeddingStoreRemovalIT.java
+++ b/embedding-stores/langchain4j-community-sqlserver/src/test/java/dev/langchain4j/store/embedding/sqlserver/SQLServerHalfPrecisionEmbeddingStoreRemovalIT.java
@@ -1,0 +1,57 @@
+package dev.langchain4j.store.embedding.sqlserver;
+
+import static dev.langchain4j.store.embedding.sqlserver.util.SQLServerTestsUtil.getAzureSqlServerDataSource;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testcontainers.shaded.org.apache.commons.lang3.RandomUtils.nextInt;
+
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.embedding.onnx.allminilml6v2q.AllMiniLmL6V2QuantizedEmbeddingModel;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import dev.langchain4j.store.embedding.EmbeddingStoreWithRemovalIT;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class SQLServerHalfPrecisionEmbeddingStoreRemovalIT extends EmbeddingStoreWithRemovalIT {
+
+    static String tableName = "test_remove_" + nextInt(1000, 2000);
+    static EmbeddingModel embeddingModel = new AllMiniLmL6V2QuantizedEmbeddingModel();
+    static EmbeddingStore<TextSegment> embeddingStore = SQLServerEmbeddingStore.dataSourceBuilder()
+            .dataSource(getAzureSqlServerDataSource())
+            .embeddingTable(EmbeddingTable.builder()
+                    .name(tableName)
+                    .createOption(CreateOption.CREATE_OR_REPLACE)
+                    .dimension(embeddingModel.dimension())
+                    .build())
+            .build();
+
+    @Test
+    void config() {
+        assertThat(embeddingStore).isNotNull();
+    }
+
+    @Override
+    protected EmbeddingStore<TextSegment> embeddingStore() {
+        return embeddingStore;
+    }
+
+    @Override
+    protected EmbeddingModel embeddingModel() {
+        return embeddingModel;
+    }
+
+    @AfterEach
+    void after() {
+        if (embeddingStore != null) {
+            embeddingStore.removeAll();
+        }
+    }
+
+    @BeforeEach
+    void before() {
+        if (embeddingStore != null) {
+            embeddingStore.removeAll();
+        }
+    }
+}

--- a/embedding-stores/langchain4j-community-sqlserver/src/test/java/dev/langchain4j/store/embedding/sqlserver/util/SQLServerTestsUtil.java
+++ b/embedding-stores/langchain4j-community-sqlserver/src/test/java/dev/langchain4j/store/embedding/sqlserver/util/SQLServerTestsUtil.java
@@ -3,6 +3,9 @@ package dev.langchain4j.store.embedding.sqlserver.util;
 import com.microsoft.sqlserver.jdbc.SQLServerDataSource;
 import dev.langchain4j.data.document.Metadata;
 import dev.langchain4j.data.segment.TextSegment;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.Map;
 import org.jspecify.annotations.NonNull;
 import org.testcontainers.containers.JdbcDatabaseContainer;
@@ -12,6 +15,7 @@ public class SQLServerTestsUtil {
 
     public static final MSSQLServerContainer DEFAULT_CONTAINER =
             (MSSQLServerContainer) new MSSQLServerContainer("mcr.microsoft.com/mssql/server:2025-latest")
+                    .withPassword("Str0ng_P@ssw0rd_2026!")
                     .withEnv("MSSQL_COLLATION", "SQL_Latin1_General_CP1_CS_AS");
 
     public static @NonNull SQLServerDataSource getSqlServerDataSource() {
@@ -33,6 +37,17 @@ public class SQLServerTestsUtil {
         dataSource.setPassword(password);
         dataSource.setEncrypt("false");
         dataSource.setTrustServerCertificate(true);
+
+        try (Connection connection = dataSource.getConnection();
+             Statement stmt = connection.createStatement()) {
+            // Enable preview features for SQL Server 2025
+            stmt.execute("CREATE DATABASE TestDB;");
+            stmt.execute("USE TestDB; ALTER DATABASE SCOPED CONFIGURATION SET PREVIEW_FEATURES = ON");
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+
+        dataSource.setDatabaseName("TestDB");
         return dataSource;
     }
 

--- a/embedding-stores/langchain4j-community-sqlserver/src/test/java/dev/langchain4j/store/embedding/sqlserver/util/SQLServerTestsUtil.java
+++ b/embedding-stores/langchain4j-community-sqlserver/src/test/java/dev/langchain4j/store/embedding/sqlserver/util/SQLServerTestsUtil.java
@@ -39,7 +39,7 @@ public class SQLServerTestsUtil {
         dataSource.setTrustServerCertificate(true);
 
         try (Connection connection = dataSource.getConnection();
-             Statement stmt = connection.createStatement()) {
+                Statement stmt = connection.createStatement()) {
             // Enable preview features for SQL Server 2025
             stmt.execute("CREATE DATABASE TestDB;");
             stmt.execute("USE TestDB; ALTER DATABASE SCOPED CONFIGURATION SET PREVIEW_FEATURES = ON");

--- a/embedding-stores/langchain4j-community-sqlserver/src/test/java/dev/langchain4j/store/embedding/sqlserver/util/SQLServerTestsUtil.java
+++ b/embedding-stores/langchain4j-community-sqlserver/src/test/java/dev/langchain4j/store/embedding/sqlserver/util/SQLServerTestsUtil.java
@@ -22,6 +22,19 @@ public class SQLServerTestsUtil {
         return getSqlServerDataSource(DEFAULT_CONTAINER);
     }
 
+    public static @NonNull SQLServerDataSource getLocalSqlServerDataSource() {
+        SQLServerDataSource dataSource = new SQLServerDataSource();
+        dataSource.setServerName("localhost");
+        dataSource.setPortNumber(1433);
+        dataSource.setUser("sa");
+        dataSource.setPassword("StrongPassword2026!");
+        dataSource.setEncrypt("false");
+        dataSource.setTrustServerCertificate(true);
+        dataSource.setDatabaseName("test_vector");
+        dataSource.setVectorTypeSupport("v2");
+        return dataSource;
+    }
+
     public static @NonNull SQLServerDataSource getSqlServerDataSource(JdbcDatabaseContainer sqlServerContainer) {
         sqlServerContainer.start();
 

--- a/embedding-stores/langchain4j-community-sqlserver/src/test/java/dev/langchain4j/store/embedding/sqlserver/util/SQLServerTestsUtil.java
+++ b/embedding-stores/langchain4j-community-sqlserver/src/test/java/dev/langchain4j/store/embedding/sqlserver/util/SQLServerTestsUtil.java
@@ -57,18 +57,26 @@ public class SQLServerTestsUtil {
         dataSource.setPassword(password);
         dataSource.setEncrypt("false");
         dataSource.setTrustServerCertificate(true);
+        return dataSource;
+    }
 
+    /**
+     * Enables preview features on the given SQL Server data source by creating a dedicated database
+     * and setting {@code PREVIEW_FEATURES = ON}. This is required for half-precision (float16) vector support.
+     *
+     * @param dataSource the data source to configure; must already be connected
+     * @param databaseName the name of the database to create and use
+     */
+    public static void enablePreviewFeatures(SQLServerDataSource dataSource, String databaseName) {
         try (Connection connection = dataSource.getConnection();
                 Statement stmt = connection.createStatement()) {
-            // Enable preview features for SQL Server 2025
-            stmt.execute("CREATE DATABASE TestDB;");
-            stmt.execute("USE TestDB; ALTER DATABASE SCOPED CONFIGURATION SET PREVIEW_FEATURES = ON");
+            stmt.execute(String.format("IF DB_ID(N'%s') IS NULL CREATE DATABASE [%s];", databaseName, databaseName));
+            stmt.execute(String.format(
+                    "USE [%s]; ALTER DATABASE SCOPED CONFIGURATION SET PREVIEW_FEATURES = ON", databaseName));
         } catch (SQLException e) {
             throw new RuntimeException(e);
         }
-
-        dataSource.setDatabaseName("TestDB");
-        return dataSource;
+        dataSource.setDatabaseName(databaseName);
     }
 
     /**

--- a/embedding-stores/langchain4j-community-sqlserver/src/test/java/dev/langchain4j/store/embedding/sqlserver/util/SQLServerTestsUtil.java
+++ b/embedding-stores/langchain4j-community-sqlserver/src/test/java/dev/langchain4j/store/embedding/sqlserver/util/SQLServerTestsUtil.java
@@ -22,15 +22,22 @@ public class SQLServerTestsUtil {
         return getSqlServerDataSource(DEFAULT_CONTAINER);
     }
 
-    public static @NonNull SQLServerDataSource getLocalSqlServerDataSource() {
+    public static @NonNull SQLServerDataSource getAzureSqlServerDataSource() {
         SQLServerDataSource dataSource = new SQLServerDataSource();
-        dataSource.setServerName("localhost");
-        dataSource.setPortNumber(1433);
-        dataSource.setUser("sa");
-        dataSource.setPassword("StrongPassword2026!");
-        dataSource.setEncrypt("false");
+        dataSource.setServerName(System.getenv("AZURE_SQL_SERVER_NAME"));
+        String portNumber = System.getenv("AZURE_SQL_PORT");
+        if (portNumber != null) {
+            dataSource.setPortNumber(Integer.parseInt(portNumber));
+        }
+        dataSource.setDatabaseName(System.getenv("AZURE_SQL_DATABASE_NAME"));
+
+        dataSource.setUser(System.getenv("AZURE_SQL_USER"));
+        dataSource.setPassword(System.getenv("AZURE_SQL_PASSWORD"));
+
+        dataSource.setEncrypt("true");
         dataSource.setTrustServerCertificate(true);
-        dataSource.setDatabaseName("test_vector");
+        dataSource.setHostNameInCertificate("*.database.windows.net");
+
         dataSource.setVectorTypeSupport("v2");
         return dataSource;
     }


### PR DESCRIPTION
## Issue
<!-- Please specify the ID of the issue this PR is addressing. For example: "Closes #1234" or "Fixes #1234" -->
Closes #660

## Change
This PR adds support to SQLServer's half-precision vectors.

Added PR for documentation: https://github.com/langchain4j/langchain4j/pull/5418

## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] There are no breaking changes
- [X] I have added unit and integration tests for my change
- [X] I have manually run all the unit tests in _all_ modules, and they are all green
- [X] I have manually run all integration tests in the module I have added/changed, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [X] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)


## Checklist for adding new maven module
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-community-bom/pom.xml`


## Checklist for adding new embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [X] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
