### PR TITLE
TwelveLabs: add Marengo embedding model integration

### DIFF
--- a/langchain4j-community-bom/pom.xml
+++ b/langchain4j-community-bom/pom.xml
@@ -44,6 +44,12 @@
 
             <dependency>
                 <groupId>dev.langchain4j</groupId>
+                <artifactId>langchain4j-community-twelvelabs</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>dev.langchain4j</groupId>
                 <artifactId>langchain4j-community-dashscope</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/models/langchain4j-community-twelvelabs/pom.xml
+++ b/models/langchain4j-community-twelvelabs/pom.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>dev.langchain4j</groupId>
+        <artifactId>langchain4j-community</artifactId>
+        <version>1.17.0-beta27-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>langchain4j-community-twelvelabs</artifactId>
+    <name>Langchain4j :: Community :: Integration :: TwelveLabs</name>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-core</artifactId>
+            <version>${langchain4j.core.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-http-client</artifactId>
+            <version>${langchain4j.http-client-jdk.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-http-client-jdk</artifactId>
+            <version>${langchain4j.http-client-jdk.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <!-- Test -->
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-core</artifactId>
+            <version>${langchain4j.core.version}</version>
+            <classifier>tests</classifier>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.tinylog</groupId>
+            <artifactId>tinylog-impl</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.tinylog</groupId>
+            <artifactId>slf4j-tinylog</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/models/langchain4j-community-twelvelabs/revapi.json
+++ b/models/langchain4j-community-twelvelabs/revapi.json
@@ -1,0 +1,14 @@
+[
+  {
+    "extension": "revapi.differences",
+    "configuration": {
+      "ignore": true,
+      "differences": [
+        {
+          "code": "java.class.externalClassExposedInAPI",
+          "justification": "New module using langchain4j core types as public API - these are external dependency types, not this module's own API surface"
+        }
+      ]
+    }
+  }
+]

--- a/models/langchain4j-community-twelvelabs/src/main/java/dev/langchain4j/community/model/twelvelabs/EmbeddingResponse.java
+++ b/models/langchain4j-community-twelvelabs/src/main/java/dev/langchain4j/community/model/twelvelabs/EmbeddingResponse.java
@@ -1,0 +1,59 @@
+package dev.langchain4j.community.model.twelvelabs;
+
+import java.util.List;
+
+/**
+ * Response from the TwelveLabs
+ * <a href="https://docs.twelvelabs.io/v1.3/api-reference/text-image-embeddings/create-text-embeddings">Create text embeddings</a>
+ * endpoint.
+ *
+ * <p>The relevant payload looks like:
+ * <pre>{@code
+ * {
+ *   "model_name": "marengo3.0",
+ *   "text_embedding": {
+ *     "segments": [
+ *       { "float": [ ... ] }
+ *     ]
+ *   }
+ * }
+ * }</pre>
+ */
+class EmbeddingResponse {
+
+    private String modelName;
+    private TextEmbedding textEmbedding;
+
+    public String getModelName() {
+        return modelName;
+    }
+
+    public TextEmbedding getTextEmbedding() {
+        return textEmbedding;
+    }
+
+    static class TextEmbedding {
+
+        private List<Segment> segments;
+
+        public List<Segment> getSegments() {
+            return segments;
+        }
+    }
+
+    static class Segment {
+
+        private List<Float> floatValue;
+
+        // The TwelveLabs API names this JSON field "float", which is a Java reserved word.
+        @com.fasterxml.jackson.annotation.JsonProperty("float")
+        public List<Float> getFloat() {
+            return floatValue;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("float")
+        public void setFloat(List<Float> floatValue) {
+            this.floatValue = floatValue;
+        }
+    }
+}

--- a/models/langchain4j-community-twelvelabs/src/main/java/dev/langchain4j/community/model/twelvelabs/TwelveLabsClient.java
+++ b/models/langchain4j-community-twelvelabs/src/main/java/dev/langchain4j/community/model/twelvelabs/TwelveLabsClient.java
@@ -1,0 +1,167 @@
+package dev.langchain4j.community.model.twelvelabs;
+
+import static dev.langchain4j.community.model.twelvelabs.TwelveLabsJsonUtils.fromJson;
+import static dev.langchain4j.http.client.HttpMethod.POST;
+import static dev.langchain4j.internal.Utils.ensureTrailingForwardSlash;
+import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.Utils.isNullOrEmpty;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+import static java.time.Duration.ofSeconds;
+
+import dev.langchain4j.http.client.HttpClient;
+import dev.langchain4j.http.client.HttpClientBuilder;
+import dev.langchain4j.http.client.HttpClientBuilderLoader;
+import dev.langchain4j.http.client.HttpRequest;
+import dev.langchain4j.http.client.SuccessfulHttpResponse;
+import dev.langchain4j.http.client.log.LoggingHttpClient;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+import org.slf4j.Logger;
+
+class TwelveLabsClient {
+
+    public static final String DEFAULT_BASE_URL = "https://api.twelvelabs.io/v1.3/";
+
+    private final HttpClient httpClient;
+    private final String baseUrl;
+    private final Map<String, String> defaultHeaders;
+    private final Supplier<Map<String, String>> customHeadersSupplier;
+
+    TwelveLabsClient(Builder builder) {
+        HttpClientBuilder httpClientBuilder =
+                getOrDefault(builder.httpClientBuilder, HttpClientBuilderLoader::loadHttpClientBuilder);
+
+        HttpClient httpClient = httpClientBuilder
+                .connectTimeout(
+                        getOrDefault(getOrDefault(builder.timeout, httpClientBuilder.connectTimeout()), ofSeconds(15)))
+                .readTimeout(
+                        getOrDefault(getOrDefault(builder.timeout, httpClientBuilder.readTimeout()), ofSeconds(60)))
+                .build();
+
+        if (builder.logRequests != null && builder.logRequests
+                || builder.logResponses != null && builder.logResponses) {
+            this.httpClient =
+                    new LoggingHttpClient(httpClient, builder.logRequests, builder.logResponses, builder.logger);
+        } else {
+            this.httpClient = httpClient;
+        }
+
+        this.baseUrl = ensureTrailingForwardSlash(ensureNotBlank(builder.baseUrl, "baseUrl"));
+
+        Map<String, String> defaultHeaders = new HashMap<>();
+        if (builder.apiKey != null) {
+            defaultHeaders.put("x-api-key", builder.apiKey);
+        }
+        this.defaultHeaders = defaultHeaders;
+        this.customHeadersSupplier = getOrDefault(builder.customHeadersSupplier, () -> Map::of);
+    }
+
+    private Map<String, String> buildRequestHeaders() {
+        Map<String, String> dynamicHeaders = customHeadersSupplier.get();
+        if (isNullOrEmpty(dynamicHeaders)) {
+            return defaultHeaders;
+        }
+
+        Map<String, String> headers = new HashMap<>(defaultHeaders);
+        headers.putAll(dynamicHeaders);
+        return headers;
+    }
+
+    /**
+     * Creates a text embedding for a single piece of text.
+     *
+     * <p>The TwelveLabs embed endpoint accepts {@code multipart/form-data} and embeds one text per request.</p>
+     */
+    EmbeddingResponse embedText(String modelName, String text) {
+
+        HttpRequest httpRequest = HttpRequest.builder()
+                .method(POST)
+                .url(baseUrl + "embed")
+                // The JDK HttpClient does not set the multipart Content-Type (with boundary) itself, so we set it
+                // explicitly using the boundary the client encodes the body with, otherwise TwelveLabs rejects the
+                // request with content_type_invalid. Same approach as the Cohere integration.
+                .addHeader("Content-Type", "multipart/form-data; boundary=----LangChain4j")
+                .addFormDataField("model_name", modelName)
+                .addFormDataField("text", text)
+                .addHeader("Accept", "application/json")
+                .addHeaders(buildRequestHeaders())
+                .build();
+
+        SuccessfulHttpResponse successfulHttpResponse = httpClient.execute(httpRequest);
+
+        return fromJson(successfulHttpResponse.body(), EmbeddingResponse.class);
+    }
+
+    static Builder builder() {
+        return new Builder();
+    }
+
+    static class Builder {
+
+        private HttpClientBuilder httpClientBuilder;
+        private String baseUrl;
+        private Duration timeout;
+        private String apiKey;
+        private Boolean logRequests;
+        private Boolean logResponses;
+        private Logger logger;
+        private Supplier<Map<String, String>> customHeadersSupplier;
+
+        Builder httpClientBuilder(HttpClientBuilder httpClientBuilder) {
+            this.httpClientBuilder = httpClientBuilder;
+            return this;
+        }
+
+        Builder baseUrl(String baseUrl) {
+            this.baseUrl = baseUrl;
+            return this;
+        }
+
+        Builder timeout(Duration timeout) {
+            this.timeout = timeout;
+            return this;
+        }
+
+        Builder apiKey(String apiKey) {
+            this.apiKey = apiKey;
+            return this;
+        }
+
+        Builder logRequests(Boolean logRequests) {
+            this.logRequests = logRequests;
+            return this;
+        }
+
+        Builder logResponses(Boolean logResponses) {
+            this.logResponses = logResponses;
+            return this;
+        }
+
+        /**
+         * @param logger an alternate {@link Logger} to be used instead of the default one provided by Langchain4J for logging requests and responses.
+         * @return {@code this}.
+         */
+        Builder logger(Logger logger) {
+            this.logger = logger;
+            return this;
+        }
+
+        /**
+         * A supplier for custom headers to be added to each HTTP request.
+         * The supplier is called before each request, allowing dynamic header values.
+         *
+         * @param customHeadersSupplier a supplier that provides a map of headers
+         * @return builder
+         */
+        Builder customHeaders(Supplier<Map<String, String>> customHeadersSupplier) {
+            this.customHeadersSupplier = customHeadersSupplier;
+            return this;
+        }
+
+        TwelveLabsClient build() {
+            return new TwelveLabsClient(this);
+        }
+    }
+}

--- a/models/langchain4j-community-twelvelabs/src/main/java/dev/langchain4j/community/model/twelvelabs/TwelveLabsEmbeddingModel.java
+++ b/models/langchain4j-community-twelvelabs/src/main/java/dev/langchain4j/community/model/twelvelabs/TwelveLabsEmbeddingModel.java
@@ -1,0 +1,238 @@
+package dev.langchain4j.community.model.twelvelabs;
+
+import static dev.langchain4j.community.model.twelvelabs.TwelveLabsClient.DEFAULT_BASE_URL;
+import static dev.langchain4j.internal.RetryUtils.withRetryMappingExceptions;
+import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+import static java.time.Duration.ofSeconds;
+
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.http.client.HttpClientBuilder;
+import dev.langchain4j.model.embedding.DimensionAwareEmbeddingModel;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.output.Response;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+import org.slf4j.Logger;
+
+/**
+ * An implementation of an {@link EmbeddingModel} that uses the
+ * <a href="https://docs.twelvelabs.io/v1.3/api-reference/text-image-embeddings/create-text-embeddings">TwelveLabs
+ * text embedding API</a> (Marengo).
+ *
+ * <p>Marengo is a multimodal model: it produces embeddings for text, image, audio and video that live in the same
+ * vector space, so text embeddings created here can be used to search a video corpus indexed with the same model.
+ * This class exposes the text embedding capability through the standard LangChain4j {@link EmbeddingModel} contract.</p>
+ *
+ * <p>The TwelveLabs embed endpoint embeds a single piece of text per request; {@link #embedAll(List)} therefore
+ * issues one request per {@link TextSegment}.</p>
+ */
+public class TwelveLabsEmbeddingModel extends DimensionAwareEmbeddingModel {
+
+    private final TwelveLabsClient client;
+    private final Integer maxRetries;
+    private final String modelName;
+
+    public TwelveLabsEmbeddingModel(Builder builder) {
+        this.maxRetries = getOrDefault(builder.maxRetries, 2);
+        this.modelName = ensureNotBlank(builder.modelName, "modelName");
+
+        this.client = TwelveLabsClient.builder()
+                .httpClientBuilder(builder.httpClientBuilder)
+                .baseUrl(getOrDefault(builder.baseUrl, DEFAULT_BASE_URL))
+                .apiKey(ensureNotBlank(builder.apiKey, "apiKey"))
+                .timeout(getOrDefault(builder.timeout, ofSeconds(60)))
+                .logRequests(getOrDefault(builder.logRequests, false))
+                .logResponses(getOrDefault(builder.logResponses, false))
+                .logger(builder.logger)
+                .customHeaders(builder.customHeadersSupplier)
+                .build();
+    }
+
+    @Override
+    public Response<List<Embedding>> embedAll(List<TextSegment> textSegments) {
+        List<Embedding> embeddings = new ArrayList<>();
+
+        for (TextSegment textSegment : textSegments) {
+            EmbeddingResponse response =
+                    withRetryMappingExceptions(() -> client.embedText(modelName, textSegment.text()), maxRetries);
+            embeddings.add(Embedding.from(extractVector(response)));
+        }
+
+        return Response.from(embeddings);
+    }
+
+    @Override
+    public String modelName() {
+        return this.modelName;
+    }
+
+    @Override
+    protected Integer knownDimension() {
+        return TwelveLabsEmbeddingModelName.knownDimension(modelName);
+    }
+
+    private static List<Float> extractVector(EmbeddingResponse response) {
+        if (response == null
+                || response.getTextEmbedding() == null
+                || response.getTextEmbedding().getSegments() == null
+                || response.getTextEmbedding().getSegments().isEmpty()) {
+            throw new IllegalStateException("TwelveLabs returned no text embedding");
+        }
+        return response.getTextEmbedding().getSegments().get(0).getFloat();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private HttpClientBuilder httpClientBuilder;
+        private Supplier<Map<String, String>> customHeadersSupplier;
+        private String baseUrl;
+        private Duration timeout;
+        private Integer maxRetries;
+        private String apiKey;
+        private String modelName;
+        private Boolean logRequests;
+        private Boolean logResponses;
+        private Logger logger;
+
+        /**
+         * Sets a custom HTTP client builder, allowing fine-grained control over the HTTP client
+         * configuration such as timeouts and proxy settings.
+         *
+         * @param httpClientBuilder the HTTP client builder
+         * @return {@code this}
+         */
+        public Builder httpClientBuilder(HttpClientBuilder httpClientBuilder) {
+            this.httpClientBuilder = httpClientBuilder;
+            return this;
+        }
+
+        /**
+         * Sets custom HTTP headers.
+         */
+        public Builder customHeaders(Map<String, String> customHeaders) {
+            this.customHeadersSupplier = () -> customHeaders;
+            return this;
+        }
+
+        /**
+         * Sets a supplier for custom HTTP headers.
+         * The supplier is called before each request, allowing dynamic header values.
+         */
+        public Builder customHeaders(Supplier<Map<String, String>> customHeadersSupplier) {
+            this.customHeadersSupplier = customHeadersSupplier;
+            return this;
+        }
+
+        /**
+         * Sets the base URL of the TwelveLabs API.
+         * Defaults to {@code "https://api.twelvelabs.io/v1.3/"}.
+         *
+         * @param baseUrl the base URL
+         * @return {@code this}
+         */
+        public Builder baseUrl(String baseUrl) {
+            this.baseUrl = baseUrl;
+            return this;
+        }
+
+        /**
+         * Sets the HTTP request timeout. Defaults to 60 seconds.
+         *
+         * @param timeout the request timeout
+         * @return {@code this}
+         */
+        public Builder timeout(Duration timeout) {
+            this.timeout = timeout;
+            return this;
+        }
+
+        /**
+         * Sets the maximum number of retries on transient errors. Defaults to {@code 2}.
+         *
+         * @param maxRetries the maximum number of retries
+         * @return {@code this}
+         */
+        public Builder maxRetries(Integer maxRetries) {
+            this.maxRetries = maxRetries;
+            return this;
+        }
+
+        /**
+         * Sets the TwelveLabs API key used to authenticate requests.
+         * See the <a href="https://playground.twelvelabs.io/dashboard/api-key">TwelveLabs dashboard</a> to obtain a key.
+         *
+         * @param apiKey the TwelveLabs API key
+         * @return {@code this}
+         */
+        public Builder apiKey(String apiKey) {
+            this.apiKey = apiKey;
+            return this;
+        }
+
+        /**
+         * Name of the model.
+         *
+         * @param modelName Name of the model.
+         * @see TwelveLabsEmbeddingModelName
+         */
+        public Builder modelName(TwelveLabsEmbeddingModelName modelName) {
+            this.modelName = modelName.toString();
+            return this;
+        }
+
+        /**
+         * Name of the model.
+         *
+         * @param modelName Name of the model.
+         * @see TwelveLabsEmbeddingModelName
+         */
+        public Builder modelName(String modelName) {
+            this.modelName = modelName;
+            return this;
+        }
+
+        /**
+         * Enables debug logging of request bodies sent to the TwelveLabs API.
+         *
+         * @param logRequests {@code true} to enable request logging
+         * @return {@code this}
+         */
+        public Builder logRequests(Boolean logRequests) {
+            this.logRequests = logRequests;
+            return this;
+        }
+
+        /**
+         * Enables debug logging of response bodies received from the TwelveLabs API.
+         *
+         * @param logResponses {@code true} to enable response logging
+         * @return {@code this}
+         */
+        public Builder logResponses(Boolean logResponses) {
+            this.logResponses = logResponses;
+            return this;
+        }
+
+        /**
+         * @param logger an alternate {@link Logger} to be used instead of the default one provided by Langchain4J for logging requests and responses.
+         * @return {@code this}.
+         */
+        public Builder logger(Logger logger) {
+            this.logger = logger;
+            return this;
+        }
+
+        public TwelveLabsEmbeddingModel build() {
+            return new TwelveLabsEmbeddingModel(this);
+        }
+    }
+}

--- a/models/langchain4j-community-twelvelabs/src/main/java/dev/langchain4j/community/model/twelvelabs/TwelveLabsEmbeddingModelName.java
+++ b/models/langchain4j-community-twelvelabs/src/main/java/dev/langchain4j/community/model/twelvelabs/TwelveLabsEmbeddingModelName.java
@@ -1,0 +1,43 @@
+package dev.langchain4j.community.model.twelvelabs;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Known TwelveLabs Marengo embedding models and their output dimensions.
+ *
+ * @see <a href="https://docs.twelvelabs.io/v1.3/docs/concepts/models/marengo">Marengo models</a>
+ */
+public enum TwelveLabsEmbeddingModelName {
+    MARENGO_3("marengo3.0", 512);
+
+    private final String stringValue;
+    private final Integer dimension;
+
+    TwelveLabsEmbeddingModelName(String stringValue, Integer dimension) {
+        this.stringValue = stringValue;
+        this.dimension = dimension;
+    }
+
+    @Override
+    public String toString() {
+        return stringValue;
+    }
+
+    public Integer dimension() {
+        return dimension;
+    }
+
+    private static final Map<String, Integer> KNOWN_DIMENSION =
+            new HashMap<>(TwelveLabsEmbeddingModelName.values().length);
+
+    static {
+        for (TwelveLabsEmbeddingModelName embeddingModelName : TwelveLabsEmbeddingModelName.values()) {
+            KNOWN_DIMENSION.put(embeddingModelName.toString(), embeddingModelName.dimension());
+        }
+    }
+
+    public static Integer knownDimension(String modelName) {
+        return KNOWN_DIMENSION.get(modelName);
+    }
+}

--- a/models/langchain4j-community-twelvelabs/src/main/java/dev/langchain4j/community/model/twelvelabs/TwelveLabsJsonUtils.java
+++ b/models/langchain4j-community-twelvelabs/src/main/java/dev/langchain4j/community/model/twelvelabs/TwelveLabsJsonUtils.java
@@ -1,0 +1,27 @@
+package dev.langchain4j.community.model.twelvelabs;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+
+class TwelveLabsJsonUtils {
+
+    private TwelveLabsJsonUtils() throws InstantiationException {
+        throw new InstantiationException("Can't instantiate this utility class.");
+    }
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
+            .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
+            .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+    static <T> T fromJson(String jsonStr, Class<T> clazz) {
+        try {
+            return OBJECT_MAPPER.readValue(jsonStr, clazz);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/models/langchain4j-community-twelvelabs/src/test/java/dev/langchain4j/community/model/twelvelabs/TwelveLabsEmbeddingModelIT.java
+++ b/models/langchain4j-community-twelvelabs/src/test/java/dev/langchain4j/community/model/twelvelabs/TwelveLabsEmbeddingModelIT.java
@@ -1,0 +1,65 @@
+package dev.langchain4j.community.model.twelvelabs;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.output.Response;
+import dev.langchain4j.store.embedding.CosineSimilarity;
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+@EnabledIfEnvironmentVariable(named = "TWELVELABS_API_KEY", matches = ".+")
+class TwelveLabsEmbeddingModelIT {
+
+    private static EmbeddingModel model() {
+        return TwelveLabsEmbeddingModel.builder()
+                .apiKey(System.getenv("TWELVELABS_API_KEY"))
+                .modelName(TwelveLabsEmbeddingModelName.MARENGO_3)
+                .timeout(Duration.ofSeconds(60))
+                .logRequests(true)
+                .logResponses(false) // embeddings are huge in logs
+                .build();
+    }
+
+    @Test
+    void should_embed_single_text() {
+
+        // given
+        EmbeddingModel model = model();
+
+        // when
+        Response<Embedding> response = model.embed("Hello World");
+
+        // then
+        assertThat(response.content().dimension()).isEqualTo(model.dimension());
+    }
+
+    @Test
+    void should_embed_multiple_segments() {
+
+        // given
+        EmbeddingModel model = model();
+
+        TextSegment segment1 = TextSegment.from("a cat playing piano");
+        TextSegment segment2 = TextSegment.from("a kitten at a keyboard");
+
+        // when
+        Response<List<Embedding>> response = model.embedAll(asList(segment1, segment2));
+
+        // then
+        assertThat(response.content()).hasSize(2);
+
+        Embedding embedding1 = response.content().get(0);
+        assertThat(embedding1.dimension()).isEqualTo(model.dimension());
+
+        Embedding embedding2 = response.content().get(1);
+        assertThat(embedding2.dimension()).isEqualTo(model.dimension());
+
+        assertThat(CosineSimilarity.between(embedding1, embedding2)).isGreaterThan(0.5);
+    }
+}

--- a/models/langchain4j-community-twelvelabs/src/test/java/dev/langchain4j/community/model/twelvelabs/TwelveLabsEmbeddingModelTest.java
+++ b/models/langchain4j-community-twelvelabs/src/test/java/dev/langchain4j/community/model/twelvelabs/TwelveLabsEmbeddingModelTest.java
@@ -1,0 +1,33 @@
+package dev.langchain4j.community.model.twelvelabs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class TwelveLabsEmbeddingModelTest {
+
+    @Test
+    void should_require_api_key() {
+        assertThatThrownBy(() -> TwelveLabsEmbeddingModel.builder()
+                        .modelName(TwelveLabsEmbeddingModelName.MARENGO_3)
+                        .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("apiKey");
+    }
+
+    @Test
+    void should_require_model_name() {
+        assertThatThrownBy(
+                        () -> TwelveLabsEmbeddingModel.builder().apiKey("test").build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("modelName");
+    }
+
+    @Test
+    void should_expose_known_dimension_without_calling_api() {
+        assertThat(TwelveLabsEmbeddingModelName.knownDimension("marengo3.0")).isEqualTo(512);
+        assertThat(TwelveLabsEmbeddingModelName.MARENGO_3.dimension()).isEqualTo(512);
+        assertThat(TwelveLabsEmbeddingModelName.knownDimension("unknown-model")).isNull();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@
         <module>models/langchain4j-community-xinference</module>
         <module>models/langchain4j-community-zhipu-ai</module>
         <module>models/langchain4j-community-cohere</module>
+        <module>models/langchain4j-community-twelvelabs</module>
         <module>models/langchain4j-community-model-router</module>
         <module>models/langchain4j-community-model-registry</module>
 


### PR DESCRIPTION
Hi! I am Mohit, I work at TwelveLabs (@mohit-twelvelabs).

## Issue
N/A — new integration contribution. This was originally opened against the core repo in langchain4j/langchain4j#5566; moved here per @glaforge's feedback that it belongs in the community repo.

## Change
This adds **`langchain4j-community-twelvelabs`**, a new opt-in integration module exposing the [TwelveLabs](https://twelvelabs.io) **Marengo** model as a LangChain4j `EmbeddingModel`.

- `TwelveLabsEmbeddingModel` implements the standard `EmbeddingModel` contract (extends `DimensionAwareEmbeddingModel`), calling the TwelveLabs `POST /v1.3/embed` REST endpoint via `langchain4j-http-client` (no new third-party dependencies — same approach as the existing Cohere integration in this repo).
- Marengo is multimodal — text, image, audio and video embeddings share the same 512-dim vector space — so text embeddings produced here can search a video corpus indexed with the same model. This integration surfaces the **text** embedding capability through the standard contract.
- Builder follows the shape of existing HTTP-based providers: `apiKey`, `modelName`, `baseUrl`, `timeout`, `maxRetries`, `logRequests`/`logResponses`, custom headers, custom `HttpClientBuilder`.
- The `/v1.3/embed` endpoint requires `multipart/form-data`. The JDK `HttpClient` does not set the multipart `Content-Type` (with boundary) header itself, so the client sets it explicitly — exactly as the Cohere integration already does (`CohereClient`). There is also a small, independent fix for this in the JDK http-client living in core langchain4j (carved out of #5566 as a standalone core PR); once that lands and is released, the explicit header here becomes redundant, but it keeps this module self-contained against the current release.
- Wired into the root `pom.xml` and `langchain4j-community-bom/pom.xml`.

This is **opt-in and non-breaking** — a brand-new module; no existing behaviour or defaults change.

### How it was tested
- `TwelveLabsEmbeddingModelTest` — no-network unit tests (builder validation, known-dimension lookup).
- `TwelveLabsEmbeddingModelIT` — integration tests gated on `TWELVELABS_API_KEY` (skipped when unset); run green against the live Marengo endpoint, returning 512-dim vectors with cosine similarity between related texts > 0.5.
- `./mvnw -pl models/langchain4j-community-twelvelabs verify` is green (unit + integration tests; spotless check passes on changed files).

You can grab a free API key at https://twelvelabs.io — there's a generous free tier.

## General checklist
- [X] There are no breaking changes
- [X] I have added unit and integration tests for my change
- [ ] I have manually run all the unit tests in _all_ modules, and they are all green
- [X] I have manually run all integration tests in the module I have added/changed, and they are all green
- [ ] I have added/updated the documentation
- [ ] I have added an example in the examples repo
- [ ] I have added/updated Spring Boot starter(s)

## Checklist for adding new maven module
- [X] I have added my new module in the root `pom.xml` and `langchain4j-community-bom/pom.xml`
