### PR TITLE
DashScope: expose rerank response metadata and returnDocuments

### DIFF
--- a/models/langchain4j-community-dashscope/src/main/java/dev/langchain4j/community/model/dashscope/QwenScoringModel.java
+++ b/models/langchain4j-community-dashscope/src/main/java/dev/langchain4j/community/model/dashscope/QwenScoringModel.java
@@ -20,7 +20,9 @@ import dev.langchain4j.model.output.Response;
 import dev.langchain4j.model.output.TokenUsage;
 import dev.langchain4j.model.scoring.ScoringModel;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
 
 /**
@@ -32,24 +34,24 @@ public class QwenScoringModel implements ScoringModel {
     private final String apiKey;
     private final String modelName;
     private final Integer topN;
+    private final Boolean returnDocuments;
     private final String instruct;
     private final TextReRank textReRank;
     private Consumer<TextReRankParam.TextReRankParamBuilder<?, ?>> textReRankParamCustomizer = p -> {};
 
-    public QwenScoringModel(String baseUrl, String apiKey, String modelName, Integer topN) {
-        this(baseUrl, apiKey, modelName, topN, null);
-    }
-
-    public QwenScoringModel(String baseUrl, String apiKey, String modelName, Integer topN, String instruct) {
-        if (isNullOrBlank(apiKey)) {
+    public QwenScoringModel(QwenScoringModelBuilder builder) {
+        if (isNullOrBlank(builder.apiKey)) {
             throw new IllegalArgumentException(
                     "DashScope api key must be defined. Reference: https://www.alibabacloud.com/help/en/model-studio/get-api-key");
         }
-        this.apiKey = apiKey;
-        this.modelName = isNullOrBlank(modelName) ? GTE_RERANK_V2 : modelName;
-        this.topN = topN;
-        this.instruct = instruct;
-        this.textReRank = isNullOrBlank(baseUrl) ? new TextReRank() : new TextReRank(Protocol.HTTP.getValue(), baseUrl);
+        this.apiKey = builder.apiKey;
+        this.modelName = isNullOrBlank(builder.modelName) ? GTE_RERANK_V2 : builder.modelName;
+        this.topN = builder.topN;
+        this.returnDocuments = builder.returnDocuments;
+        this.instruct = builder.instruct;
+        this.textReRank = isNullOrBlank(builder.baseUrl)
+                ? new TextReRank()
+                : new TextReRank(Protocol.HTTP.getValue(), builder.baseUrl);
     }
 
     @Override
@@ -62,6 +64,9 @@ public class QwenScoringModel implements ScoringModel {
 
         if (topN != null) {
             builder.topN(topN);
+        }
+        if (returnDocuments != null) {
+            builder.returnDocuments(returnDocuments);
         }
         if (instruct != null) {
             builder.instruct(instruct);
@@ -78,7 +83,9 @@ public class QwenScoringModel implements ScoringModel {
             throw new RuntimeException(e);
         }
 
-        List<Double> scores = result.getOutput().getResults().stream()
+        List<TextReRankOutput.Result> rerankResults = result.getOutput().getResults();
+
+        List<Double> scores = rerankResults.stream()
                 .sorted(Comparator.comparing(TextReRankOutput.Result::getIndex))
                 .map(TextReRankOutput.Result::getRelevanceScore)
                 .collect(toList());
@@ -88,7 +95,34 @@ public class QwenScoringModel implements ScoringModel {
             tokenUsage = new TokenUsage(result.getUsage().getTotalTokens());
         }
 
-        return Response.from(scores, tokenUsage);
+        // Always expose the original request_id and output.results via metadata,
+        // regardless of whether returnDocuments was requested.
+        List<QwenScoringResponseMetadata.Result> metadataResults = rerankResults.stream()
+                .map(rerankResult -> new QwenScoringResponseMetadata.Result(
+                        toDocumentMap(rerankResult.getDocument()),
+                        rerankResult.getIndex(),
+                        rerankResult.getRelevanceScore()))
+                .collect(toList());
+        QwenScoringResponseMetadata scoringMetadata = QwenScoringResponseMetadata.builder()
+                .requestId(result.getRequestId())
+                .results(metadataResults)
+                .build();
+
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put(QwenScoringResponseMetadata.DASHSCOPE_RESPONSE, scoringMetadata);
+
+        return Response.from(scores, tokenUsage, null, metadata);
+    }
+
+    private static Map<String, String> toDocumentMap(TextReRankOutput.Document document) {
+        if (document == null) {
+            return null;
+        }
+        Map<String, String> map = new HashMap<>();
+        if (document.getText() != null) {
+            map.put("text", document.getText());
+        }
+        return map;
     }
 
     public void setTextReRankParamCustomizer(
@@ -109,6 +143,7 @@ public class QwenScoringModel implements ScoringModel {
         private String apiKey;
         private String modelName;
         private Integer topN;
+        private Boolean returnDocuments;
         private String instruct;
 
         public QwenScoringModelBuilder() {
@@ -146,13 +181,29 @@ public class QwenScoringModel implements ScoringModel {
             return this;
         }
 
+        /**
+         * Whether the original document text should be returned with each result. Defaults to {@code false} (not returned).
+         *
+         * <p>When enabled, the document text is available via
+         * {@link QwenScoringResponseMetadata.Result#document()} on the metadata exposed under
+         * {@link QwenScoringResponseMetadata#DASHSCOPE_RESPONSE} in
+         * {@link dev.langchain4j.model.output.Response#metadata()}.
+         * The metadata itself is always populated, regardless of this setting.
+         *
+         * @param returnDocuments whether to return the original document text
+         */
+        public QwenScoringModelBuilder returnDocuments(Boolean returnDocuments) {
+            this.returnDocuments = returnDocuments;
+            return this;
+        }
+
         public QwenScoringModelBuilder instruct(String instruct) {
             this.instruct = instruct;
             return this;
         }
 
         public QwenScoringModel build() {
-            return new QwenScoringModel(baseUrl, apiKey, modelName, topN, instruct);
+            return new QwenScoringModel(this);
         }
     }
 }

--- a/models/langchain4j-community-dashscope/src/main/java/dev/langchain4j/community/model/dashscope/QwenScoringResponseMetadata.java
+++ b/models/langchain4j-community-dashscope/src/main/java/dev/langchain4j/community/model/dashscope/QwenScoringResponseMetadata.java
@@ -1,0 +1,119 @@
+package dev.langchain4j.community.model.dashscope;
+
+import static dev.langchain4j.internal.Utils.quoted;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * DashScope-specific response metadata for {@link QwenScoringModel}, exposed via
+ * {@link dev.langchain4j.model.output.Response#metadata()} under the
+ * {@link #DASHSCOPE_RESPONSE} key.
+ *
+ * <p>It is always populated (regardless of whether {@code returnDocuments} was requested),
+ * carrying the original {@code request_id} and the {@code output.results} returned by the
+ * <a href="https://www.alibabacloud.com/help/en/model-studio/text-rerank-api">DashScope Text Rerank API</a>.
+ * The {@link Result#document} map is only populated when {@code returnDocuments} was enabled.
+ */
+public class QwenScoringResponseMetadata {
+
+    /**
+     * Key under which a {@link QwenScoringResponseMetadata} instance is stored in
+     * {@link dev.langchain4j.model.output.Response#metadata()}.
+     */
+    public static final String DASHSCOPE_RESPONSE = "dashscope_response";
+
+    private final String requestId;
+    private final List<Result> results;
+
+    protected QwenScoringResponseMetadata(Builder builder) {
+        this.requestId = builder.requestId;
+        this.results = builder.results;
+    }
+
+    /**
+     * The {@code request_id} returned by the DashScope API.
+     *
+     * @return the request id.
+     */
+    public String requestId() {
+        return requestId;
+    }
+
+    /**
+     * The {@code output.results} returned by the DashScope API, in the original (relevance-descending)
+     * order. Each {@link Result#index} maps back to the position in the input documents.
+     *
+     * @return the results.
+     */
+    public List<Result> results() {
+        return results;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        QwenScoringResponseMetadata that = (QwenScoringResponseMetadata) o;
+        return Objects.equals(requestId, that.requestId) && Objects.equals(results, that.results);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(requestId, results);
+    }
+
+    @Override
+    public String toString() {
+        return "QwenScoringResponseMetadata{" + "requestId=" + quoted(requestId) + ", results=" + results + '}';
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private String requestId;
+        private List<Result> results;
+
+        /**
+         * The {@code request_id} returned by the DashScope API.
+         *
+         * @param requestId the request id
+         * @return {@code this}
+         */
+        public Builder requestId(String requestId) {
+            this.requestId = requestId;
+            return this;
+        }
+
+        /**
+         * The {@code output.results} returned by the DashScope API, in the original (relevance-descending)
+         * order.
+         *
+         * @param results the results
+         * @return {@code this}
+         */
+        public Builder results(List<Result> results) {
+            this.results = results;
+            return this;
+        }
+
+        public QwenScoringResponseMetadata build() {
+            return new QwenScoringResponseMetadata(this);
+        }
+    }
+
+    /**
+     * A single rerank result entry from the DashScope {@code output.results}.
+     *
+     * @param document       the original document as a map of its fields (e.g. {@code {"text": "..."}}),
+     *                       only populated when {@code returnDocuments} was enabled on the request;
+     *                       {@code null} otherwise
+     * @param index          the index of the document in the input {@code documents} array
+     * @param relevanceScore the relevance score of the document with respect to the query
+     */
+    public record Result(Map<String, String> document, Integer index, Double relevanceScore) {}
+}

--- a/models/langchain4j-community-dashscope/src/test/java/dev/langchain4j/community/model/dashscope/QwenScoringModelIT.java
+++ b/models/langchain4j-community-dashscope/src/test/java/dev/langchain4j/community/model/dashscope/QwenScoringModelIT.java
@@ -87,6 +87,73 @@ class QwenScoringModelIT {
         assertThat(response.finishReason()).isNull();
     }
 
+    @ParameterizedTest
+    @MethodSource("dev.langchain4j.community.model.dashscope.QwenTestHelper#scoringModelNameProvider")
+    void should_always_populate_metadata(String modelName) {
+        // given
+        ScoringModel model =
+                QwenScoringModel.builder().apiKey(apiKey()).modelName(modelName).build();
+
+        TextSegment catSegment = TextSegment.from("The Maine Coon is a large domesticated cat breed.");
+        TextSegment dogSegment = TextSegment.from(
+                "The sweet-faced, lovable Labrador Retriever is one of America's most popular dog breeds, year after year.");
+        List<TextSegment> segments = asList(catSegment, dogSegment);
+
+        String query = "tell me about dogs";
+
+        // when
+        Response<List<Double>> response = model.scoreAll(segments, query);
+
+        // then: metadata is always present, even though returnDocuments was not set
+        QwenScoringResponseMetadata metadata =
+                (QwenScoringResponseMetadata) response.metadata().get(QwenScoringResponseMetadata.DASHSCOPE_RESPONSE);
+
+        assertThat(metadata).isNotNull();
+        assertThat(metadata.requestId()).isNotBlank();
+        assertThat(metadata.results()).hasSize(2);
+        assertThat(metadata.results()).allSatisfy(result -> {
+            assertThat(result.index()).isNotNull();
+            assertThat(result.relevanceScore()).isNotNull();
+            // document text is not returned unless returnDocuments is enabled
+            assertThat(result.document()).isNull();
+        });
+    }
+
+    @ParameterizedTest
+    @MethodSource("dev.langchain4j.community.model.dashscope.QwenTestHelper#scoringModelNameProvider")
+    void should_return_documents_when_enabled(String modelName) {
+        // given
+        ScoringModel model = QwenScoringModel.builder()
+                .apiKey(apiKey())
+                .modelName(modelName)
+                .returnDocuments(true)
+                .build();
+
+        TextSegment catSegment = TextSegment.from("The Maine Coon is a large domesticated cat breed.");
+        TextSegment dogSegment = TextSegment.from(
+                "The sweet-faced, lovable Labrador Retriever is one of America's most popular dog breeds, year after year.");
+        List<TextSegment> segments = asList(catSegment, dogSegment);
+
+        String query = "tell me about dogs";
+
+        // when
+        Response<List<Double>> response = model.scoreAll(segments, query);
+
+        // then: document text is returned with each result
+        QwenScoringResponseMetadata metadata =
+                (QwenScoringResponseMetadata) response.metadata().get(QwenScoringResponseMetadata.DASHSCOPE_RESPONSE);
+
+        assertThat(metadata).isNotNull();
+        assertThat(metadata.results()).hasSize(2);
+        assertThat(metadata.results()).allSatisfy(result -> {
+            assertThat(result.document()).isNotNull();
+            assertThat(result.document()).containsKey("text");
+            assertThat(result.document().get("text")).isNotBlank();
+            assertThat(result.index()).isNotNull();
+            assertThat(result.relevanceScore()).isNotNull();
+        });
+    }
+
     @AfterEach
     void afterEach() throws InterruptedException {
         String ciDelaySeconds = System.getenv("CI_DELAY_SECONDS_DASHSCOPE");


### PR DESCRIPTION
<!--
Thank you so much for your contribution!

Please fill in all the sections below.
Please open the PR as a draft initially. Once it is reviewed and approved, we will ask you to add documentation and examples.
Please note that PRs with breaking changes or without tests will be rejected.

Please note that PRs will be reviewed based on the priority of the issues they address.
We ask for your patience. We are doing our best to review your PR as quickly as possible.
Please refrain from pinging and asking when it will be reviewed. Thank you for understanding!
-->

## Issue
<!-- Please specify the ID of the issue this PR is addressing. For example: "Closes #1234" or "Fixes #1234" -->
Closes #

## Change
<!-- Please describe the changes you made. -->
Add QwenScoringResponseMetadata (requestId + results), always populated and exposed via Response.metadata under the "dashscope_response" key, carrying the original request_id and output.results from the DashScope Text Rerank API. Each Result (record) holds document (Map<String,String>), index, and relevanceScore.

Re-add the returnDocuments parameter to QwenScoringModel/builder so the original document text can be surfaced through the metadata; the metadata itself is populated regardless of this setting.

Unify QwenScoringModel construction: collapse the telescoping constructors into a single QwenScoringModel(QwenScoringModelBuilder), making the builder the only construction path. Add a QwenScoringResponseMetadata.Builder, mirroring QwenChatResponseMetadata.

Add IT coverage for the always-populated metadata and for returnDocuments.

## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [X] There are no breaking changes
- [X] I have added unit and integration tests for my change
- [ ] I have manually run all the unit tests in _all_ modules, and they are all green
- [X] I have manually run all integration tests in the module I have added/changed, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)


## Checklist for adding new maven module
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-community-bom/pom.xml`


## Checklist for adding new embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
