### PR TITLE
fix: skip DEL when removeAll(Filter) matches no documents

### DIFF
--- a/embedding-stores/langchain4j-community-redis/pom.xml
+++ b/embedding-stores/langchain4j-community-redis/pom.xml
@@ -109,6 +109,12 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/embedding-stores/langchain4j-community-redis/src/main/java/dev/langchain4j/community/store/embedding/redis/RedisEmbeddingStore.java
+++ b/embedding-stores/langchain4j-community-redis/src/main/java/dev/langchain4j/community/store/embedding/redis/RedisEmbeddingStore.java
@@ -169,6 +169,9 @@ public class RedisEmbeddingStore implements EmbeddingStore<TextSegment> {
         SearchResult results = client.ftSearch(schema.getIndexName(), filterMapper.mapToFilter(filter));
         String[] keys = results.getDocuments().stream().map(Document::getId).toArray(String[]::new);
 
+        if (keys.length == 0) {
+            return;
+        }
         client.del(keys);
     }
 

--- a/embedding-stores/langchain4j-community-redis/src/test/java/dev/langchain4j/community/store/embedding/redis/RedisEmbeddingStoreRemovalIT.java
+++ b/embedding-stores/langchain4j-community-redis/src/test/java/dev/langchain4j/community/store/embedding/redis/RedisEmbeddingStoreRemovalIT.java
@@ -6,6 +6,7 @@ import static dev.langchain4j.community.store.embedding.redis.RedisSchema.JSON_P
 import static dev.langchain4j.internal.Utils.randomUUID;
 
 import com.redis.testcontainers.RedisContainer;
+import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.model.embedding.onnx.allminilml6v2q.AllMiniLmL6V2QuantizedEmbeddingModel;
@@ -14,10 +15,15 @@ import dev.langchain4j.store.embedding.EmbeddingStoreWithRemovalIT;
 import java.util.Map;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import redis.clients.jedis.DefaultJedisClientConfig;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.UnifiedJedis;
 import redis.clients.jedis.search.schemafields.TagField;
+
+import static dev.langchain4j.store.embedding.TestUtils.awaitUntilAsserted;
+import static dev.langchain4j.store.embedding.filter.MetadataFilterBuilder.metadataKey;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class RedisEmbeddingStoreRemovalIT extends EmbeddingStoreWithRemovalIT {
 
@@ -37,6 +43,21 @@ class RedisEmbeddingStoreRemovalIT extends EmbeddingStoreWithRemovalIT {
             .metadataConfig(
                     Map.of("type", TagField.of(JSON_PATH_PREFIX + "type").as("type")))
             .build();
+
+    @Test
+    void should_not_fail_when_remove_all_by_filter_matches_nothing() {
+
+        // given
+        Embedding embedding = embeddingModel().embed("test").content();
+        embeddingStore().add(embedding);
+
+        awaitUntilAsserted(() -> assertThat(getAllEmbeddings()).hasSize(1));
+
+        // when / then — filter matches zero documents; must not call DEL with zero keys
+        embeddingStore().removeAll(metadataKey("type").isEqualTo("nonexistent"));
+
+        awaitUntilAsserted(() -> assertThat(getAllEmbeddings()).hasSize(1));
+    }
 
     @BeforeAll
     static void beforeAll() {

--- a/embedding-stores/langchain4j-community-redis/src/test/java/dev/langchain4j/community/store/embedding/redis/RedisEmbeddingStoreRemovalIT.java
+++ b/embedding-stores/langchain4j-community-redis/src/test/java/dev/langchain4j/community/store/embedding/redis/RedisEmbeddingStoreRemovalIT.java
@@ -4,6 +4,9 @@ import static com.redis.testcontainers.RedisStackContainer.DEFAULT_IMAGE_NAME;
 import static com.redis.testcontainers.RedisStackContainer.DEFAULT_TAG;
 import static dev.langchain4j.community.store.embedding.redis.RedisSchema.JSON_PATH_PREFIX;
 import static dev.langchain4j.internal.Utils.randomUUID;
+import static dev.langchain4j.store.embedding.TestUtils.awaitUntilAsserted;
+import static dev.langchain4j.store.embedding.filter.MetadataFilterBuilder.metadataKey;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.redis.testcontainers.RedisContainer;
 import dev.langchain4j.data.embedding.Embedding;
@@ -20,10 +23,6 @@ import redis.clients.jedis.DefaultJedisClientConfig;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.UnifiedJedis;
 import redis.clients.jedis.search.schemafields.TagField;
-
-import static dev.langchain4j.store.embedding.TestUtils.awaitUntilAsserted;
-import static dev.langchain4j.store.embedding.filter.MetadataFilterBuilder.metadataKey;
-import static org.assertj.core.api.Assertions.assertThat;
 
 class RedisEmbeddingStoreRemovalIT extends EmbeddingStoreWithRemovalIT {
 

--- a/embedding-stores/langchain4j-community-redis/src/test/java/dev/langchain4j/community/store/embedding/redis/RedisEmbeddingStoreTest.java
+++ b/embedding-stores/langchain4j-community-redis/src/test/java/dev/langchain4j/community/store/embedding/redis/RedisEmbeddingStoreTest.java
@@ -3,7 +3,6 @@ package dev.langchain4j.community.store.embedding.redis;
 import static dev.langchain4j.community.store.embedding.redis.RedisSchema.JSON_PATH_PREFIX;
 import static dev.langchain4j.store.embedding.filter.MetadataFilterBuilder.metadataKey;
 import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -21,7 +20,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import redis.clients.jedis.UnifiedJedis;
 import redis.clients.jedis.search.Document;
-import redis.clients.jedis.search.Query;
 import redis.clients.jedis.search.SearchResult;
 import redis.clients.jedis.search.schemafields.TagField;
 
@@ -53,7 +51,7 @@ class RedisEmbeddingStoreTest {
     void should_not_call_del_when_remove_all_by_filter_matches_nothing() {
         SearchResult searchResult = mock(SearchResult.class);
         when(searchResult.getDocuments()).thenReturn(List.of());
-        when(client.ftSearch(eq(INDEX_NAME), any(Query.class))).thenReturn(searchResult);
+        when(client.ftSearch(eq(INDEX_NAME), anyString())).thenReturn(searchResult);
 
         assertThatCode(() -> store.removeAll(metadataKey("type").isEqualTo("nonexistent")))
                 .doesNotThrowAnyException();
@@ -68,7 +66,7 @@ class RedisEmbeddingStoreTest {
 
         SearchResult searchResult = mock(SearchResult.class);
         when(searchResult.getDocuments()).thenReturn(List.of(document));
-        when(client.ftSearch(eq(INDEX_NAME), any(Query.class))).thenReturn(searchResult);
+        when(client.ftSearch(eq(INDEX_NAME), anyString())).thenReturn(searchResult);
 
         store.removeAll(metadataKey("type").isEqualTo("a"));
 

--- a/embedding-stores/langchain4j-community-redis/src/test/java/dev/langchain4j/community/store/embedding/redis/RedisEmbeddingStoreTest.java
+++ b/embedding-stores/langchain4j-community-redis/src/test/java/dev/langchain4j/community/store/embedding/redis/RedisEmbeddingStoreTest.java
@@ -44,7 +44,8 @@ class RedisEmbeddingStoreTest {
                 .indexName(INDEX_NAME)
                 .prefix(PREFIX)
                 .dimension(384)
-                .metadataConfig(Map.of("type", TagField.of(JSON_PATH_PREFIX + "type").as("type")))
+                .metadataConfig(
+                        Map.of("type", TagField.of(JSON_PATH_PREFIX + "type").as("type")))
                 .build();
     }
 

--- a/embedding-stores/langchain4j-community-redis/src/test/java/dev/langchain4j/community/store/embedding/redis/RedisEmbeddingStoreTest.java
+++ b/embedding-stores/langchain4j-community-redis/src/test/java/dev/langchain4j/community/store/embedding/redis/RedisEmbeddingStoreTest.java
@@ -70,6 +70,6 @@ class RedisEmbeddingStoreTest {
 
         store.removeAll(metadataKey("type").isEqualTo("a"));
 
-        verify(client).del(PREFIX + "doc-1");
+        verify(client).del(new String[] {PREFIX + "doc-1"});
     }
 }

--- a/embedding-stores/langchain4j-community-redis/src/test/java/dev/langchain4j/community/store/embedding/redis/RedisEmbeddingStoreTest.java
+++ b/embedding-stores/langchain4j-community-redis/src/test/java/dev/langchain4j/community/store/embedding/redis/RedisEmbeddingStoreTest.java
@@ -1,0 +1,76 @@
+package dev.langchain4j.community.store.embedding.redis;
+
+import static dev.langchain4j.community.store.embedding.redis.RedisSchema.JSON_PATH_PREFIX;
+import static dev.langchain4j.store.embedding.filter.MetadataFilterBuilder.metadataKey;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import redis.clients.jedis.UnifiedJedis;
+import redis.clients.jedis.search.Document;
+import redis.clients.jedis.search.Query;
+import redis.clients.jedis.search.SearchResult;
+import redis.clients.jedis.search.schemafields.TagField;
+
+@ExtendWith(MockitoExtension.class)
+class RedisEmbeddingStoreTest {
+
+    private static final String INDEX_NAME = "test-index";
+    private static final String PREFIX = "embedding:";
+
+    @Mock
+    UnifiedJedis client;
+
+    RedisEmbeddingStore store;
+
+    @BeforeEach
+    void setUp() {
+        when(client.ftList()).thenReturn(Set.of(INDEX_NAME));
+        store = RedisEmbeddingStore.builder()
+                .unifiedJedis(client)
+                .indexName(INDEX_NAME)
+                .prefix(PREFIX)
+                .dimension(384)
+                .metadataConfig(Map.of("type", TagField.of(JSON_PATH_PREFIX + "type").as("type")))
+                .build();
+    }
+
+    @Test
+    void should_not_call_del_when_remove_all_by_filter_matches_nothing() {
+        SearchResult searchResult = mock(SearchResult.class);
+        when(searchResult.getDocuments()).thenReturn(List.of());
+        when(client.ftSearch(eq(INDEX_NAME), any(Query.class))).thenReturn(searchResult);
+
+        assertThatCode(() -> store.removeAll(metadataKey("type").isEqualTo("nonexistent")))
+                .doesNotThrowAnyException();
+
+        verify(client, never()).del(anyString());
+    }
+
+    @Test
+    void should_call_del_when_remove_all_by_filter_matches_documents() {
+        Document document = mock(Document.class);
+        when(document.getId()).thenReturn(PREFIX + "doc-1");
+
+        SearchResult searchResult = mock(SearchResult.class);
+        when(searchResult.getDocuments()).thenReturn(List.of(document));
+        when(client.ftSearch(eq(INDEX_NAME), any(Query.class))).thenReturn(searchResult);
+
+        store.removeAll(metadataKey("type").isEqualTo("a"));
+
+        verify(client).del(PREFIX + "doc-1");
+    }
+}


### PR DESCRIPTION
 ## Issue

Closes langchain4j/langchain4j#5642

## Change

`RedisEmbeddingStore.removeAll(Filter)` runs a RediSearch query, then calls `client.del(keys)` with matching document IDs. When the filter matches **zero** documents, Jedis sends `DEL` with no key arguments and Redis returns `ERR wrong number of arguments for 'del' command`.

This adds an early return when no keys are matched, consistent with `removeAll()` which already skips delete when the scanned key set is empty.

Added:
- Integration test `should_not_fail_when_remove_all_by_filter_matches_nothing` in `RedisEmbeddingStoreRemovalIT`
- Unit tests in `RedisEmbeddingStoreTest` (Mockito: no `del` on zero matches; `del` called when matches exist)

## General checklist

- [x] There are no breaking changes
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit tests in _all_ modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-community/tree/main/spring-boot-starters)

## Checklist for adding new maven module

N/A

## Checklist for adding new embedding store integration

N/A

## Checklist for changing existing embedding store integration

- [x] I have manually verified that the `RedisEmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j