### PR TITLE
fix: remove dimension constraint from QwenEmbeddingModel for future extensibility

### DIFF
--- a/models/langchain4j-community-dashscope/src/main/java/dev/langchain4j/community/model/dashscope/QwenEmbeddingModel.java
+++ b/models/langchain4j-community-dashscope/src/main/java/dev/langchain4j/community/model/dashscope/QwenEmbeddingModel.java
@@ -39,8 +39,6 @@ public class QwenEmbeddingModel extends DimensionAwareEmbeddingModel {
     public static final String TYPE_QUERY = "query";
     public static final String TYPE_DOCUMENT = "document";
     private static final int BATCH_SIZE = 10;
-    // https://www.alibabacloud.com/help/en/model-studio/text-embedding-synchronous-api#853dfeccb97cd
-    private static final List<Integer> SUPPORTED_DIMENSIONS = List.of(1024, 768, 512);
 
     private final String apiKey;
     private final String modelName;
@@ -170,9 +168,7 @@ public class QwenEmbeddingModel extends DimensionAwareEmbeddingModel {
         if (dimension == null) {
             return null;
         }
-        if (TEXT_EMBEDDING_V1.equals(modelName)
-                || TEXT_EMBEDDING_V2.equals(modelName)
-                || !SUPPORTED_DIMENSIONS.contains(dimension)) {
+        if (TEXT_EMBEDDING_V1.equals(modelName) || TEXT_EMBEDDING_V2.equals(modelName)) {
             throw new IllegalArgumentException("dimension '" + dimension + "' is not supported by " + modelName);
         }
         return dimension;

--- a/models/langchain4j-community-dashscope/src/main/java/dev/langchain4j/community/model/dashscope/QwenModelName.java
+++ b/models/langchain4j-community-dashscope/src/main/java/dev/langchain4j/community/model/dashscope/QwenModelName.java
@@ -111,6 +111,8 @@ public class QwenModelName {
 
     public static final String TEXT_EMBEDDING_V3 = "text-embedding-v3"; // Support 50+ languages
 
+    public static final String TEXT_EMBEDDING_V4 = "text-embedding-v4";
+
     // Use with QwenScoringModel
     public static final String GTE_RERANK_V2 =
             "gte-rerank-v2"; // gte-rerank-v2, large-scale text reranking (up to 30k documents)

--- a/models/langchain4j-community-dashscope/src/test/java/dev/langchain4j/community/model/dashscope/QwenEmbeddingModelDimensionTest.java
+++ b/models/langchain4j-community-dashscope/src/test/java/dev/langchain4j/community/model/dashscope/QwenEmbeddingModelDimensionTest.java
@@ -1,0 +1,82 @@
+package dev.langchain4j.community.model.dashscope;
+
+import static dev.langchain4j.community.model.dashscope.QwenModelName.TEXT_EMBEDDING_V1;
+import static dev.langchain4j.community.model.dashscope.QwenModelName.TEXT_EMBEDDING_V2;
+import static dev.langchain4j.community.model.dashscope.QwenModelName.TEXT_EMBEDDING_V3;
+import static dev.langchain4j.community.model.dashscope.QwenModelName.TEXT_EMBEDDING_V4;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Unit tests for QwenEmbeddingModel dimension validation.
+ * These tests verify that ensureDimension correctly handles different model-dimension combinations.
+ */
+class QwenEmbeddingModelDimensionTest {
+
+    private static final String API_KEY = "test-api-key";
+
+    private QwenEmbeddingModel buildModel(String modelName, Integer dimension) {
+        return QwenEmbeddingModel.builder()
+                .apiKey(API_KEY)
+                .modelName(modelName)
+                .dimension(dimension)
+                .build();
+    }
+
+    // --- V1 and V2: always reject custom dimension ---
+
+    @Test
+    void should_reject_dimension_for_v1() {
+        assertThatThrownBy(() -> buildModel(TEXT_EMBEDDING_V1, 512))
+                .isExactlyInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void should_reject_dimension_for_v2() {
+        assertThatThrownBy(() -> buildModel(TEXT_EMBEDDING_V2, 512))
+                .isExactlyInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void should_reject_2048_dimension_for_v1() {
+        assertThatThrownBy(() -> buildModel(TEXT_EMBEDDING_V1, 2048))
+                .isExactlyInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void should_reject_2048_dimension_for_v2() {
+        assertThatThrownBy(() -> buildModel(TEXT_EMBEDDING_V2, 2048))
+                .isExactlyInstanceOf(IllegalArgumentException.class);
+    }
+
+    // --- V3: accept all dimensions (API validates) ---
+
+    static Stream<Integer> supportedDimensionsV3() {
+        return Stream.of(64, 128, 256, 512, 768, 1024, 1536, 2048);
+    }
+
+    @ParameterizedTest
+    @MethodSource("supportedDimensionsV3")
+    void should_accept_dimension_for_v3(Integer dimension) {
+        QwenEmbeddingModel model = buildModel(TEXT_EMBEDDING_V3, dimension);
+        assertThat(model.dimension()).isEqualTo(dimension);
+    }
+
+    // --- V4: accept all dimensions (API validates) ---
+
+    static Stream<Integer> supportedDimensionsV4() {
+        return Stream.of(64, 128, 256, 512, 768, 1024, 1536, 2048);
+    }
+
+    @ParameterizedTest
+    @MethodSource("supportedDimensionsV4")
+    void should_accept_dimension_for_v4(Integer dimension) {
+        QwenEmbeddingModel model = buildModel(TEXT_EMBEDDING_V4, dimension);
+        assertThat(model.dimension()).isEqualTo(dimension);
+    }
+}

--- a/models/langchain4j-community-dashscope/src/test/java/dev/langchain4j/community/model/dashscope/QwenEmbeddingModelIT.java
+++ b/models/langchain4j-community-dashscope/src/test/java/dev/langchain4j/community/model/dashscope/QwenEmbeddingModelIT.java
@@ -5,6 +5,7 @@ import static dev.langchain4j.community.model.dashscope.QwenEmbeddingModel.TYPE_
 import static dev.langchain4j.community.model.dashscope.QwenModelName.TEXT_EMBEDDING_V1;
 import static dev.langchain4j.community.model.dashscope.QwenModelName.TEXT_EMBEDDING_V2;
 import static dev.langchain4j.community.model.dashscope.QwenModelName.TEXT_EMBEDDING_V3;
+import static dev.langchain4j.community.model.dashscope.QwenModelName.TEXT_EMBEDDING_V4;
 import static dev.langchain4j.community.model.dashscope.QwenTestHelper.apiKey;
 import static dev.langchain4j.data.segment.TextSegment.textSegment;
 import static java.util.Arrays.asList;
@@ -145,13 +146,21 @@ class QwenEmbeddingModelIT {
     void should_embed_one_text_by_customized_dimension() {
         assertThatThrownBy(() -> getModel(TEXT_EMBEDDING_V1, 512)).isExactlyInstanceOf(IllegalArgumentException.class);
         assertThatThrownBy(() -> getModel(TEXT_EMBEDDING_V2, 512)).isExactlyInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> getModel(TEXT_EMBEDDING_V3, 510)).isExactlyInstanceOf(IllegalArgumentException.class);
 
         QwenEmbeddingModel model = getModel(TEXT_EMBEDDING_V3, 512);
         assertThat(model.dimension()).isEqualTo(512);
 
         Embedding embedding = model.embed("hello").content();
         assertThat(embedding.dimension()).isEqualTo(512);
+    }
+
+    @Test
+    void should_embed_with_2048_dimension_for_v4() {
+        QwenEmbeddingModel model = getModel(TEXT_EMBEDDING_V4, 2048);
+        assertThat(model.dimension()).isEqualTo(2048);
+
+        Embedding embedding = model.embed("hello").content();
+        assertThat(embedding.dimension()).isEqualTo(2048);
     }
 
     @AfterEach

--- a/models/langchain4j-community-dashscope/src/test/java/dev/langchain4j/community/model/dashscope/QwenTestHelper.java
+++ b/models/langchain4j-community-dashscope/src/test/java/dev/langchain4j/community/model/dashscope/QwenTestHelper.java
@@ -65,7 +65,7 @@ class QwenTestHelper {
     }
 
     public static Stream<Arguments> embeddingModelNameProvider() {
-        return Stream.of(Arguments.of(QwenModelName.TEXT_EMBEDDING_V3));
+        return Stream.of(Arguments.of(QwenModelName.TEXT_EMBEDDING_V3), Arguments.of(QwenModelName.TEXT_EMBEDDING_V4));
     }
 
     public static Stream<Arguments> scoringModelNameProvider() {


### PR DESCRIPTION
## Issue
Closes #708

## Change

This PR removes the hardcoded `SUPPORTED_DIMENSIONS` constraint from `QwenEmbeddingModel` to improve future extensibility.

### Problem
The `ensureDimension` method had a hardcoded list of supported dimensions `[1024, 768, 512]`, which caused `text-embedding-v4` (which supports 8 dimensions including 2048) to reject valid dimension values.

### Solution
- **Removed `SUPPORTED_DIMENSIONS` hardcoded list**: No longer maintaining a static dimension whitelist
- **Simplified `ensureDimension()`**: Only rejects dimension for V1/V2 models (which don't support custom dimensions)
- **API validates dimensions**: Invalid dimensions will be rejected by the DashScope API itself

### Benefits
1. **Future-proof**: When DashScope adds new embedding models with different supported dimensions, langchain4j-community won't need code changes
2. **Maintainable**: No need to track dimension support across model versions
3. **User-friendly**: Users can try any dimension value and get clear API error messages if unsupported

### Files Changed
- `QwenEmbeddingModel.java`: Remove `SUPPORTED_DIMENSIONS`, simplify `ensureDimension()`
- `QwenModelName.java`: Add `TEXT_EMBEDDING_V4` constant
- `QwenEmbeddingModelDimensionTest.java`: New unit tests for dimension validation (20 tests)
- `QwenEmbeddingModelIT.java`: Update IT tests, add 2048 dimension test for V4
- `QwenTestHelper.java`: Add `TEXT_EMBEDDING_V4` to test providers

## General checklist
- [X] There are no breaking changes
- [X] I have added unit and integration tests for my change
- [X] I have manually run all the unit tests in _all_ modules, and they are all green
- [X] I have manually run all integration tests in the module I have added/changed, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)