### PR TITLE
S3 Vectors: add Spring Boot starters

### DIFF
--- a/langchain4j-community-bom/pom.xml
+++ b/langchain4j-community-bom/pom.xml
@@ -406,6 +406,18 @@
                 <version>${project.version}</version>
             </dependency>
 
+            <dependency>
+                <groupId>dev.langchain4j</groupId>
+                <artifactId>langchain4j-community-s3-vectors-spring-boot-starter</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>dev.langchain4j</groupId>
+                <artifactId>langchain4j-community-s3-vectors-spring-boot4-starter</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
             <!-- Code Execution Engines -->
             <dependency>
                 <groupId>dev.langchain4j</groupId>

--- a/spring-boot-starters/langchain4j-community-s3-vectors-spring-boot-starter/pom.xml
+++ b/spring-boot-starters/langchain4j-community-s3-vectors-spring-boot-starter/pom.xml
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>dev.langchain4j</groupId>
+        <artifactId>langchain4j-community-spring-boot-starters</artifactId>
+        <version>1.18.0-beta28-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>langchain4j-community-s3-vectors-spring-boot-starter</artifactId>
+    <packaging>jar</packaging>
+    <name>LangChain4j :: Community :: Spring Boot starter :: Amazon S3 Vectors</name>
+
+    <licenses>
+        <license>
+            <name>Apache-2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+            <comments>A business-friendly OSS license</comments>
+        </license>
+    </licenses>
+
+    <properties>
+        <!--
+            The s3vectors artifact was introduced in AWS SDK 2.41.0; align with the version used by
+            the langchain4j-community-s3-vectors module.
+        -->
+        <aws.sdk.version>2.43.1</aws.sdk.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>bom</artifactId>
+                <version>${aws.sdk.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- Converge versions pulled transitively via s3vectors -> apache-client -> httpclient. -->
+            <dependency>
+                <groupId>commons-codec</groupId>
+                <artifactId>commons-codec</artifactId>
+                <version>1.20.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpcore</artifactId>
+                <version>4.4.16</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-community-s3-vectors</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3vectors</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-classic</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- test dependencies -->
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-embeddings-all-minilm-l6-v2-q</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-spring-boot-tests</artifactId>
+            <version>${project.version}</version>
+            <classifier>tests</classifier>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.honton.chas</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <configuration>
+                    <acceptableLicenses combine.children="append">
+                        <!-- due to logback-classic -->
+                        <license>
+                            <name>Eclipse Public License</name>
+                            <url>http://www.eclipse.org/legal/epl-v10.html</url>
+                        </license>
+                        <license>
+                            <name>GNU Lesser General Public License</name>
+                            <url>http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html</url>
+                        </license>
+                    </acceptableLicenses>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/spring-boot-starters/langchain4j-community-s3-vectors-spring-boot-starter/revapi.json
+++ b/spring-boot-starters/langchain4j-community-s3-vectors-spring-boot-starter/revapi.json
@@ -1,0 +1,14 @@
+[
+  {
+    "extension": "revapi.differences",
+    "configuration": {
+      "ignore": true,
+      "differences": [
+        {
+          "code": "java.class.externalClassExposedInAPI",
+          "justification": "AutoConfiguration module uses langchain4j core, community, and Spring types as public API - these are external dependency types, not this module's own API surface"
+        }
+      ]
+    }
+  }
+]

--- a/spring-boot-starters/langchain4j-community-s3-vectors-spring-boot-starter/src/main/java/dev/langchain4j/community/store/embedding/s3/spring/S3VectorsEmbeddingStoreAutoConfiguration.java
+++ b/spring-boot-starters/langchain4j-community-s3-vectors-spring-boot-starter/src/main/java/dev/langchain4j/community/store/embedding/s3/spring/S3VectorsEmbeddingStoreAutoConfiguration.java
@@ -1,0 +1,53 @@
+package dev.langchain4j.community.store.embedding.s3.spring;
+
+import static dev.langchain4j.community.store.embedding.s3.spring.S3VectorsEmbeddingStoreProperties.CONFIG_PREFIX;
+
+import dev.langchain4j.community.store.embedding.s3.S3VectorsEmbeddingStore;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import software.amazon.awssdk.services.s3vectors.S3VectorsClient;
+
+@AutoConfiguration
+@ConditionalOnClass(S3VectorsEmbeddingStore.class)
+@EnableConfigurationProperties(S3VectorsEmbeddingStoreProperties.class)
+@ConditionalOnProperty(prefix = CONFIG_PREFIX, name = "enabled", havingValue = "true", matchIfMissing = true)
+public class S3VectorsEmbeddingStoreAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    public S3VectorsEmbeddingStore s3VectorsEmbeddingStore(
+            S3VectorsEmbeddingStoreProperties properties, ObjectProvider<S3VectorsClient> s3VectorsClientProvider) {
+
+        S3VectorsEmbeddingStore.Builder builder = S3VectorsEmbeddingStore.builder()
+                .vectorBucketName(properties.getVectorBucketName())
+                .indexName(properties.getIndexName());
+
+        // No credential properties: without a user-provided client the store falls back to the AWS
+        // SDK default credentials provider chain.
+        S3VectorsClient s3VectorsClient = s3VectorsClientProvider.getIfAvailable();
+        if (s3VectorsClient != null) {
+            builder.s3VectorsClient(s3VectorsClient);
+        }
+        if (properties.getRegion() != null) {
+            builder.region(properties.getRegion());
+        }
+        if (properties.getDistanceMetric() != null) {
+            builder.distanceMetric(properties.getDistanceMetric());
+        }
+        if (properties.getCreateIndexIfNotExists() != null) {
+            builder.createIndexIfNotExists(properties.getCreateIndexIfNotExists());
+        }
+        if (properties.getTextMetadataKey() != null) {
+            builder.textMetadataKey(properties.getTextMetadataKey());
+        }
+        if (properties.getTimeout() != null) {
+            builder.timeout(properties.getTimeout());
+        }
+        return builder.build();
+    }
+}

--- a/spring-boot-starters/langchain4j-community-s3-vectors-spring-boot-starter/src/main/java/dev/langchain4j/community/store/embedding/s3/spring/S3VectorsEmbeddingStoreProperties.java
+++ b/spring-boot-starters/langchain4j-community-s3-vectors-spring-boot-starter/src/main/java/dev/langchain4j/community/store/embedding/s3/spring/S3VectorsEmbeddingStoreProperties.java
@@ -1,0 +1,75 @@
+package dev.langchain4j.community.store.embedding.s3.spring;
+
+import java.time.Duration;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import software.amazon.awssdk.services.s3vectors.model.DistanceMetric;
+
+@ConfigurationProperties(prefix = S3VectorsEmbeddingStoreProperties.CONFIG_PREFIX)
+public class S3VectorsEmbeddingStoreProperties {
+
+    static final String CONFIG_PREFIX = "langchain4j.community.s3-vectors";
+
+    private String vectorBucketName;
+    private String indexName;
+    private String region;
+    private DistanceMetric distanceMetric;
+    private Boolean createIndexIfNotExists;
+    private String textMetadataKey;
+    private Duration timeout;
+
+    public String getVectorBucketName() {
+        return vectorBucketName;
+    }
+
+    public void setVectorBucketName(String vectorBucketName) {
+        this.vectorBucketName = vectorBucketName;
+    }
+
+    public String getIndexName() {
+        return indexName;
+    }
+
+    public void setIndexName(String indexName) {
+        this.indexName = indexName;
+    }
+
+    public String getRegion() {
+        return region;
+    }
+
+    public void setRegion(String region) {
+        this.region = region;
+    }
+
+    public DistanceMetric getDistanceMetric() {
+        return distanceMetric;
+    }
+
+    public void setDistanceMetric(DistanceMetric distanceMetric) {
+        this.distanceMetric = distanceMetric;
+    }
+
+    public Boolean getCreateIndexIfNotExists() {
+        return createIndexIfNotExists;
+    }
+
+    public void setCreateIndexIfNotExists(Boolean createIndexIfNotExists) {
+        this.createIndexIfNotExists = createIndexIfNotExists;
+    }
+
+    public String getTextMetadataKey() {
+        return textMetadataKey;
+    }
+
+    public void setTextMetadataKey(String textMetadataKey) {
+        this.textMetadataKey = textMetadataKey;
+    }
+
+    public Duration getTimeout() {
+        return timeout;
+    }
+
+    public void setTimeout(Duration timeout) {
+        this.timeout = timeout;
+    }
+}

--- a/spring-boot-starters/langchain4j-community-s3-vectors-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/spring-boot-starters/langchain4j-community-s3-vectors-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+dev.langchain4j.community.store.embedding.s3.spring.S3VectorsEmbeddingStoreAutoConfiguration

--- a/spring-boot-starters/langchain4j-community-s3-vectors-spring-boot-starter/src/test/java/dev/langchain4j/community/store/embedding/s3/spring/S3VectorsEmbeddingStoreAutoConfigurationIT.java
+++ b/spring-boot-starters/langchain4j-community-s3-vectors-spring-boot-starter/src/test/java/dev/langchain4j/community/store/embedding/s3/spring/S3VectorsEmbeddingStoreAutoConfigurationIT.java
@@ -1,0 +1,160 @@
+package dev.langchain4j.community.store.embedding.s3.spring;
+
+import static dev.langchain4j.internal.Utils.randomUUID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import dev.langchain4j.community.store.embedding.s3.S3VectorsEmbeddingStore;
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.embedding.onnx.allminilml6v2q.AllMiniLmL6V2QuantizedEmbeddingModel;
+import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import dev.langchain4j.store.embedding.spring.EmbeddingStoreAutoConfigurationIT;
+import java.time.Duration;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.context.ApplicationContext;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3vectors.S3VectorsClient;
+import software.amazon.awssdk.services.s3vectors.model.CreateVectorBucketRequest;
+import software.amazon.awssdk.services.s3vectors.model.DeleteIndexRequest;
+import software.amazon.awssdk.services.s3vectors.model.DeleteVectorBucketRequest;
+
+@EnabledIfEnvironmentVariable(named = "AWS_SECRET_ACCESS_KEY", matches = ".+")
+class S3VectorsEmbeddingStoreAutoConfigurationIT extends EmbeddingStoreAutoConfigurationIT {
+
+    private static final String TEST_BUCKET_PREFIX = "langchain4j-starter-test-";
+    private static final String TEST_INDEX_PREFIX = "test-index-";
+
+    private static S3VectorsClient s3VectorsClient;
+    private static String bucketName;
+    private static String region;
+    private static boolean bucketCreatedByTest = false;
+
+    private String indexName;
+
+    @BeforeAll
+    static void beforeAll() {
+        region = System.getenv("AWS_REGION");
+        if (region == null || region.isBlank()) {
+            region = "us-east-1";
+        }
+        s3VectorsClient = S3VectorsClient.builder().region(Region.of(region)).build();
+
+        bucketName = System.getenv("S3_VECTORS_BUCKET_NAME");
+        if (bucketName == null || bucketName.isBlank()) {
+            bucketName = TEST_BUCKET_PREFIX + randomUUID().substring(0, 8);
+            s3VectorsClient.createVectorBucket(CreateVectorBucketRequest.builder()
+                    .vectorBucketName(bucketName)
+                    .build());
+            bucketCreatedByTest = true;
+        }
+    }
+
+    @AfterAll
+    static void afterAll() {
+        if (s3VectorsClient == null) {
+            return;
+        }
+        if (bucketCreatedByTest) {
+            try {
+                s3VectorsClient.deleteVectorBucket(DeleteVectorBucketRequest.builder()
+                        .vectorBucketName(bucketName)
+                        .build());
+            } catch (Exception e) {
+                // best-effort cleanup
+            }
+        }
+        s3VectorsClient.close();
+    }
+
+    @BeforeEach
+    void setIndexName() {
+        indexName = TEST_INDEX_PREFIX + randomUUID().substring(0, 8);
+    }
+
+    @AfterEach
+    void deleteIndex() {
+        try {
+            s3VectorsClient.deleteIndex(DeleteIndexRequest.builder()
+                    .vectorBucketName(bucketName)
+                    .indexName(indexName)
+                    .build());
+        } catch (Exception e) {
+            // index may not have been created by the test
+        }
+    }
+
+    @Test
+    void should_respect_embedding_model_bean() {
+        contextRunner
+                .withConfiguration(AutoConfigurations.of(TestEmbeddingModelAutoConfiguration.class))
+                .withPropertyValues(properties())
+                .run(context -> {
+                    EmbeddingModel embeddingModel = context.getBean(EmbeddingModel.class);
+                    assertThat(embeddingModel)
+                            .isNotNull()
+                            .isExactlyInstanceOf(AllMiniLmL6V2QuantizedEmbeddingModel.class);
+                    S3VectorsEmbeddingStore embeddingStore = context.getBean(S3VectorsEmbeddingStore.class);
+                    assertThat(embeddingStore).isNotNull();
+                });
+    }
+
+    @Override
+    protected Class<?> autoConfigurationClass() {
+        return S3VectorsEmbeddingStoreAutoConfiguration.class;
+    }
+
+    @Override
+    protected Class<? extends EmbeddingStore<TextSegment>> embeddingStoreClass() {
+        return S3VectorsEmbeddingStore.class;
+    }
+
+    @Override
+    protected String[] properties() {
+        return new String[] {
+            "langchain4j.community.s3-vectors.vector-bucket-name=" + bucketName,
+            "langchain4j.community.s3-vectors.index-name=" + indexName,
+            "langchain4j.community.s3-vectors.region=" + region,
+            "langchain4j.community.s3-vectors.create-index-if-not-exists=true"
+        };
+    }
+
+    @Override
+    protected String dimensionPropertyKey() {
+        // S3 Vectors derives the dimension from the first stored vector; no such property exists,
+        // so this key binds to nothing and is ignored.
+        return "langchain4j.community.s3-vectors.dimension";
+    }
+
+    @Override
+    protected boolean assertEmbedding() {
+        // S3 Vectors does not return the stored vector on query.
+        return false;
+    }
+
+    @Override
+    protected void awaitUntilPersisted(ApplicationContext context) {
+        // S3 Vectors can lag between PutVectors and QueryVectors, and the base test searches only once.
+        Embedding probe =
+                new AllMiniLmL6V2QuantizedEmbeddingModel().embed("hello").content();
+        S3VectorsEmbeddingStore embeddingStore = context.getBean(S3VectorsEmbeddingStore.class);
+        await().atMost(Duration.ofSeconds(60))
+                .pollInterval(Duration.ofSeconds(1))
+                .ignoreExceptions()
+                .untilAsserted(() -> assertThat(embeddingStore
+                                .search(EmbeddingSearchRequest.builder()
+                                        .queryEmbedding(probe)
+                                        .maxResults(10)
+                                        .build())
+                                .matches())
+                        .isNotEmpty());
+    }
+}

--- a/spring-boot-starters/langchain4j-community-s3-vectors-spring-boot-starter/src/test/java/dev/langchain4j/community/store/embedding/s3/spring/TestEmbeddingModelAutoConfiguration.java
+++ b/spring-boot-starters/langchain4j-community-s3-vectors-spring-boot-starter/src/test/java/dev/langchain4j/community/store/embedding/s3/spring/TestEmbeddingModelAutoConfiguration.java
@@ -1,0 +1,15 @@
+package dev.langchain4j.community.store.embedding.s3.spring;
+
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.embedding.onnx.allminilml6v2q.AllMiniLmL6V2QuantizedEmbeddingModel;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TestEmbeddingModelAutoConfiguration {
+
+    @Bean
+    public EmbeddingModel embeddingModel() {
+        return new AllMiniLmL6V2QuantizedEmbeddingModel();
+    }
+}

--- a/spring-boot-starters/pom.xml
+++ b/spring-boot-starters/pom.xml
@@ -36,6 +36,7 @@
         <module>langchain4j-community-zhipu-ai-spring-boot-starter</module>
         <module>langchain4j-community-cohere-spring-boot-starter</module>
         <module>langchain4j-community-cockroachdb-spring-boot-starter</module>
+        <module>langchain4j-community-s3-vectors-spring-boot-starter</module>
     </modules>
 
     <properties>

--- a/spring-boot4-starters/langchain4j-community-s3-vectors-spring-boot4-starter/pom.xml
+++ b/spring-boot4-starters/langchain4j-community-s3-vectors-spring-boot4-starter/pom.xml
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>dev.langchain4j</groupId>
+        <artifactId>langchain4j-community-spring-boot4-starters</artifactId>
+        <version>1.18.0-beta28-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>langchain4j-community-s3-vectors-spring-boot4-starter</artifactId>
+    <name>LangChain4j :: Community :: Spring Boot 4 starter :: Amazon S3 Vectors</name>
+
+    <licenses>
+        <license>
+            <name>Apache-2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+            <comments>A business-friendly OSS license</comments>
+        </license>
+    </licenses>
+
+    <properties>
+        <!--
+            The s3vectors artifact was introduced in AWS SDK 2.41.0; align with the version used by
+            the langchain4j-community-s3-vectors module.
+        -->
+        <aws.sdk.version>2.43.1</aws.sdk.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>bom</artifactId>
+                <version>${aws.sdk.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- Converge versions pulled transitively via s3vectors -> apache-client -> httpclient. -->
+            <dependency>
+                <groupId>commons-codec</groupId>
+                <artifactId>commons-codec</artifactId>
+                <version>1.20.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpcore</artifactId>
+                <version>4.4.16</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-community-s3-vectors</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3vectors</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-classic</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- test dependencies -->
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-embeddings-all-minilm-l6-v2-q</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-spring-boot-tests</artifactId>
+            <version>${project.version}</version>
+            <classifier>tests</classifier>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.honton.chas</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <configuration>
+                    <acceptableLicenses combine.children="append">
+                        <!-- due to logback-classic -->
+                        <license>
+                            <name>Eclipse Public License</name>
+                            <url>http://www.eclipse.org/legal/epl-v10.html</url>
+                        </license>
+                        <license>
+                            <name>GNU Lesser General Public License</name>
+                            <url>http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html</url>
+                        </license>
+                    </acceptableLicenses>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/spring-boot4-starters/langchain4j-community-s3-vectors-spring-boot4-starter/revapi.json
+++ b/spring-boot4-starters/langchain4j-community-s3-vectors-spring-boot4-starter/revapi.json
@@ -1,0 +1,14 @@
+[
+  {
+    "extension": "revapi.differences",
+    "configuration": {
+      "ignore": true,
+      "differences": [
+        {
+          "code": "java.class.externalClassExposedInAPI",
+          "justification": "AutoConfiguration module uses langchain4j core, community, and Spring types as public API - these are external dependency types, not this module's own API surface"
+        }
+      ]
+    }
+  }
+]

--- a/spring-boot4-starters/langchain4j-community-s3-vectors-spring-boot4-starter/src/main/java/dev/langchain4j/community/store/embedding/s3/spring/S3VectorsEmbeddingStoreAutoConfiguration.java
+++ b/spring-boot4-starters/langchain4j-community-s3-vectors-spring-boot4-starter/src/main/java/dev/langchain4j/community/store/embedding/s3/spring/S3VectorsEmbeddingStoreAutoConfiguration.java
@@ -1,0 +1,53 @@
+package dev.langchain4j.community.store.embedding.s3.spring;
+
+import static dev.langchain4j.community.store.embedding.s3.spring.S3VectorsEmbeddingStoreProperties.CONFIG_PREFIX;
+
+import dev.langchain4j.community.store.embedding.s3.S3VectorsEmbeddingStore;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import software.amazon.awssdk.services.s3vectors.S3VectorsClient;
+
+@AutoConfiguration
+@ConditionalOnClass(S3VectorsEmbeddingStore.class)
+@EnableConfigurationProperties(S3VectorsEmbeddingStoreProperties.class)
+@ConditionalOnProperty(prefix = CONFIG_PREFIX, name = "enabled", havingValue = "true", matchIfMissing = true)
+public class S3VectorsEmbeddingStoreAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    public S3VectorsEmbeddingStore s3VectorsEmbeddingStore(
+            S3VectorsEmbeddingStoreProperties properties, ObjectProvider<S3VectorsClient> s3VectorsClientProvider) {
+
+        S3VectorsEmbeddingStore.Builder builder = S3VectorsEmbeddingStore.builder()
+                .vectorBucketName(properties.getVectorBucketName())
+                .indexName(properties.getIndexName());
+
+        // No credential properties: without a user-provided client the store falls back to the AWS
+        // SDK default credentials provider chain.
+        S3VectorsClient s3VectorsClient = s3VectorsClientProvider.getIfAvailable();
+        if (s3VectorsClient != null) {
+            builder.s3VectorsClient(s3VectorsClient);
+        }
+        if (properties.getRegion() != null) {
+            builder.region(properties.getRegion());
+        }
+        if (properties.getDistanceMetric() != null) {
+            builder.distanceMetric(properties.getDistanceMetric());
+        }
+        if (properties.getCreateIndexIfNotExists() != null) {
+            builder.createIndexIfNotExists(properties.getCreateIndexIfNotExists());
+        }
+        if (properties.getTextMetadataKey() != null) {
+            builder.textMetadataKey(properties.getTextMetadataKey());
+        }
+        if (properties.getTimeout() != null) {
+            builder.timeout(properties.getTimeout());
+        }
+        return builder.build();
+    }
+}

--- a/spring-boot4-starters/langchain4j-community-s3-vectors-spring-boot4-starter/src/main/java/dev/langchain4j/community/store/embedding/s3/spring/S3VectorsEmbeddingStoreProperties.java
+++ b/spring-boot4-starters/langchain4j-community-s3-vectors-spring-boot4-starter/src/main/java/dev/langchain4j/community/store/embedding/s3/spring/S3VectorsEmbeddingStoreProperties.java
@@ -1,0 +1,75 @@
+package dev.langchain4j.community.store.embedding.s3.spring;
+
+import java.time.Duration;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import software.amazon.awssdk.services.s3vectors.model.DistanceMetric;
+
+@ConfigurationProperties(prefix = S3VectorsEmbeddingStoreProperties.CONFIG_PREFIX)
+public class S3VectorsEmbeddingStoreProperties {
+
+    static final String CONFIG_PREFIX = "langchain4j.community.s3-vectors";
+
+    private String vectorBucketName;
+    private String indexName;
+    private String region;
+    private DistanceMetric distanceMetric;
+    private Boolean createIndexIfNotExists;
+    private String textMetadataKey;
+    private Duration timeout;
+
+    public String getVectorBucketName() {
+        return vectorBucketName;
+    }
+
+    public void setVectorBucketName(String vectorBucketName) {
+        this.vectorBucketName = vectorBucketName;
+    }
+
+    public String getIndexName() {
+        return indexName;
+    }
+
+    public void setIndexName(String indexName) {
+        this.indexName = indexName;
+    }
+
+    public String getRegion() {
+        return region;
+    }
+
+    public void setRegion(String region) {
+        this.region = region;
+    }
+
+    public DistanceMetric getDistanceMetric() {
+        return distanceMetric;
+    }
+
+    public void setDistanceMetric(DistanceMetric distanceMetric) {
+        this.distanceMetric = distanceMetric;
+    }
+
+    public Boolean getCreateIndexIfNotExists() {
+        return createIndexIfNotExists;
+    }
+
+    public void setCreateIndexIfNotExists(Boolean createIndexIfNotExists) {
+        this.createIndexIfNotExists = createIndexIfNotExists;
+    }
+
+    public String getTextMetadataKey() {
+        return textMetadataKey;
+    }
+
+    public void setTextMetadataKey(String textMetadataKey) {
+        this.textMetadataKey = textMetadataKey;
+    }
+
+    public Duration getTimeout() {
+        return timeout;
+    }
+
+    public void setTimeout(Duration timeout) {
+        this.timeout = timeout;
+    }
+}

--- a/spring-boot4-starters/langchain4j-community-s3-vectors-spring-boot4-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/spring-boot4-starters/langchain4j-community-s3-vectors-spring-boot4-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+dev.langchain4j.community.store.embedding.s3.spring.S3VectorsEmbeddingStoreAutoConfiguration

--- a/spring-boot4-starters/langchain4j-community-s3-vectors-spring-boot4-starter/src/test/java/dev/langchain4j/community/store/embedding/s3/spring/S3VectorsEmbeddingStoreAutoConfigurationIT.java
+++ b/spring-boot4-starters/langchain4j-community-s3-vectors-spring-boot4-starter/src/test/java/dev/langchain4j/community/store/embedding/s3/spring/S3VectorsEmbeddingStoreAutoConfigurationIT.java
@@ -1,0 +1,160 @@
+package dev.langchain4j.community.store.embedding.s3.spring;
+
+import static dev.langchain4j.internal.Utils.randomUUID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import dev.langchain4j.community.store.embedding.s3.S3VectorsEmbeddingStore;
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.embedding.onnx.allminilml6v2q.AllMiniLmL6V2QuantizedEmbeddingModel;
+import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import dev.langchain4j.store.embedding.spring.EmbeddingStoreAutoConfigurationIT;
+import java.time.Duration;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.context.ApplicationContext;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3vectors.S3VectorsClient;
+import software.amazon.awssdk.services.s3vectors.model.CreateVectorBucketRequest;
+import software.amazon.awssdk.services.s3vectors.model.DeleteIndexRequest;
+import software.amazon.awssdk.services.s3vectors.model.DeleteVectorBucketRequest;
+
+@EnabledIfEnvironmentVariable(named = "AWS_SECRET_ACCESS_KEY", matches = ".+")
+class S3VectorsEmbeddingStoreAutoConfigurationIT extends EmbeddingStoreAutoConfigurationIT {
+
+    private static final String TEST_BUCKET_PREFIX = "langchain4j-starter-test-";
+    private static final String TEST_INDEX_PREFIX = "test-index-";
+
+    private static S3VectorsClient s3VectorsClient;
+    private static String bucketName;
+    private static String region;
+    private static boolean bucketCreatedByTest = false;
+
+    private String indexName;
+
+    @BeforeAll
+    static void beforeAll() {
+        region = System.getenv("AWS_REGION");
+        if (region == null || region.isBlank()) {
+            region = "us-east-1";
+        }
+        s3VectorsClient = S3VectorsClient.builder().region(Region.of(region)).build();
+
+        bucketName = System.getenv("S3_VECTORS_BUCKET_NAME");
+        if (bucketName == null || bucketName.isBlank()) {
+            bucketName = TEST_BUCKET_PREFIX + randomUUID().substring(0, 8);
+            s3VectorsClient.createVectorBucket(CreateVectorBucketRequest.builder()
+                    .vectorBucketName(bucketName)
+                    .build());
+            bucketCreatedByTest = true;
+        }
+    }
+
+    @AfterAll
+    static void afterAll() {
+        if (s3VectorsClient == null) {
+            return;
+        }
+        if (bucketCreatedByTest) {
+            try {
+                s3VectorsClient.deleteVectorBucket(DeleteVectorBucketRequest.builder()
+                        .vectorBucketName(bucketName)
+                        .build());
+            } catch (Exception e) {
+                // best-effort cleanup
+            }
+        }
+        s3VectorsClient.close();
+    }
+
+    @BeforeEach
+    void setIndexName() {
+        indexName = TEST_INDEX_PREFIX + randomUUID().substring(0, 8);
+    }
+
+    @AfterEach
+    void deleteIndex() {
+        try {
+            s3VectorsClient.deleteIndex(DeleteIndexRequest.builder()
+                    .vectorBucketName(bucketName)
+                    .indexName(indexName)
+                    .build());
+        } catch (Exception e) {
+            // index may not have been created by the test
+        }
+    }
+
+    @Test
+    void should_respect_embedding_model_bean() {
+        contextRunner
+                .withConfiguration(AutoConfigurations.of(TestEmbeddingModelAutoConfiguration.class))
+                .withPropertyValues(properties())
+                .run(context -> {
+                    EmbeddingModel embeddingModel = context.getBean(EmbeddingModel.class);
+                    assertThat(embeddingModel)
+                            .isNotNull()
+                            .isExactlyInstanceOf(AllMiniLmL6V2QuantizedEmbeddingModel.class);
+                    S3VectorsEmbeddingStore embeddingStore = context.getBean(S3VectorsEmbeddingStore.class);
+                    assertThat(embeddingStore).isNotNull();
+                });
+    }
+
+    @Override
+    protected Class<?> autoConfigurationClass() {
+        return S3VectorsEmbeddingStoreAutoConfiguration.class;
+    }
+
+    @Override
+    protected Class<? extends EmbeddingStore<TextSegment>> embeddingStoreClass() {
+        return S3VectorsEmbeddingStore.class;
+    }
+
+    @Override
+    protected String[] properties() {
+        return new String[] {
+            "langchain4j.community.s3-vectors.vector-bucket-name=" + bucketName,
+            "langchain4j.community.s3-vectors.index-name=" + indexName,
+            "langchain4j.community.s3-vectors.region=" + region,
+            "langchain4j.community.s3-vectors.create-index-if-not-exists=true"
+        };
+    }
+
+    @Override
+    protected String dimensionPropertyKey() {
+        // S3 Vectors derives the dimension from the first stored vector; no such property exists,
+        // so this key binds to nothing and is ignored.
+        return "langchain4j.community.s3-vectors.dimension";
+    }
+
+    @Override
+    protected boolean assertEmbedding() {
+        // S3 Vectors does not return the stored vector on query.
+        return false;
+    }
+
+    @Override
+    protected void awaitUntilPersisted(ApplicationContext context) {
+        // S3 Vectors can lag between PutVectors and QueryVectors, and the base test searches only once.
+        Embedding probe =
+                new AllMiniLmL6V2QuantizedEmbeddingModel().embed("hello").content();
+        S3VectorsEmbeddingStore embeddingStore = context.getBean(S3VectorsEmbeddingStore.class);
+        await().atMost(Duration.ofSeconds(60))
+                .pollInterval(Duration.ofSeconds(1))
+                .ignoreExceptions()
+                .untilAsserted(() -> assertThat(embeddingStore
+                                .search(EmbeddingSearchRequest.builder()
+                                        .queryEmbedding(probe)
+                                        .maxResults(10)
+                                        .build())
+                                .matches())
+                        .isNotEmpty());
+    }
+}

--- a/spring-boot4-starters/langchain4j-community-s3-vectors-spring-boot4-starter/src/test/java/dev/langchain4j/community/store/embedding/s3/spring/TestEmbeddingModelAutoConfiguration.java
+++ b/spring-boot4-starters/langchain4j-community-s3-vectors-spring-boot4-starter/src/test/java/dev/langchain4j/community/store/embedding/s3/spring/TestEmbeddingModelAutoConfiguration.java
@@ -1,0 +1,15 @@
+package dev.langchain4j.community.store.embedding.s3.spring;
+
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.embedding.onnx.allminilml6v2q.AllMiniLmL6V2QuantizedEmbeddingModel;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TestEmbeddingModelAutoConfiguration {
+
+    @Bean
+    public EmbeddingModel embeddingModel() {
+        return new AllMiniLmL6V2QuantizedEmbeddingModel();
+    }
+}

--- a/spring-boot4-starters/pom.xml
+++ b/spring-boot4-starters/pom.xml
@@ -36,6 +36,7 @@
         <module>langchain4j-community-zhipu-ai-spring-boot4-starter</module>
         <module>langchain4j-community-cohere-spring-boot4-starter</module>
         <module>langchain4j-community-cockroachdb-spring-boot4-starter</module>
+        <module>langchain4j-community-s3-vectors-spring-boot4-starter</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
## Change

Follow-up to #536, which added the `langchain4j-community-s3-vectors` embedding store but left its Spring Boot starters out.

Added Spring Boot 3 and Spring Boot 4 starters for the S3 Vectors embedding store. Both auto-configure an `S3VectorsEmbeddingStore` bean from `langchain4j.community.s3-vectors.*` (bucket, index, region, distance metric, create-index-if-not-exists, text metadata key, timeout), guarded by `@ConditionalOnMissingBean`.

No credential properties. The store falls back to the AWS SDK default credentials provider chain, and a user-defined `S3VectorsClient` bean wins. Follows the twin Boot 3/Boot 4 starter layout from #662 (Valkey) and the BOM registration from #673 (CockroachDB).

**Testing:** The IT extends the shared `EmbeddingStoreAutoConfigurationIT` and is gated on `AWS_SECRET_ACCESS_KEY` (no S3 Vectors emulator/Testcontainer exists. Same as the module IT in #536, where the store's add/search behavior was verified against live S3). It compiles and the full reactor builds green; the starter IT is skipped in CI without AWS credentials.

## General checklist
- [X] There are no breaking changes
- [X] I have added unit and integration tests for my change
- [ ] I have manually run all the unit tests in _all_ modules, and they are all green
- [ ] I have manually run all integration tests in the module I have added/changed, and they are all green
- [ ] I have added/updated the documentation
- [ ] I have added an example in the examples repo (only for "big" features)
- [X] I have added/updated Spring Boot starter(s)

## Checklist for adding new maven module
- [X] I have added my new module in the root `pom.xml` and `langchain4j-community-bom/pom.xml`