### PR TITLE
fix(zhipu): preserve request defaults subtype

### DIFF
--- a/models/langchain4j-community-zhipu-ai/src/main/java/dev/langchain4j/community/model/zhipu/ZhipuAiChatRequestParameters.java
+++ b/models/langchain4j-community-zhipu-ai/src/main/java/dev/langchain4j/community/model/zhipu/ZhipuAiChatRequestParameters.java
@@ -41,6 +41,14 @@ public class ZhipuAiChatRequestParameters extends DefaultChatRequestParameters {
                 .build();
     }
 
+    @Override
+    public ZhipuAiChatRequestParameters defaultedBy(ChatRequestParameters that) {
+        return ZhipuAiChatRequestParameters.builder()
+                .overrideWith(that)
+                .overrideWith(this)
+                .build();
+    }
+
     public static Builder builder() {
         return new Builder();
     }

--- a/models/langchain4j-community-zhipu-ai/src/test/java/dev/langchain4j/community/model/zhipu/ZhipuAiChatRequestParametersTest.java
+++ b/models/langchain4j-community-zhipu-ai/src/test/java/dev/langchain4j/community/model/zhipu/ZhipuAiChatRequestParametersTest.java
@@ -92,7 +92,8 @@ class ZhipuAiChatRequestParametersTest {
                 .modelName("receiver-model")
                 .doSample(true)
                 .toolStream(true)
-                .thinking(Thinking.builder().type("enabled").clearThinking(false).build())
+                .thinking(
+                        Thinking.builder().type("enabled").clearThinking(false).build())
                 .build();
         ChatRequestParameters defaults = DefaultChatRequestParameters.builder()
                 .modelName("default-model")
@@ -128,7 +129,8 @@ class ZhipuAiChatRequestParametersTest {
                 .maxOutputTokens(512)
                 .doSample(true)
                 .toolStream(true)
-                .thinking(Thinking.builder().type("enabled").clearThinking(false).build())
+                .thinking(
+                        Thinking.builder().type("enabled").clearThinking(false).build())
                 .build();
 
         // when

--- a/models/langchain4j-community-zhipu-ai/src/test/java/dev/langchain4j/community/model/zhipu/ZhipuAiChatRequestParametersTest.java
+++ b/models/langchain4j-community-zhipu-ai/src/test/java/dev/langchain4j/community/model/zhipu/ZhipuAiChatRequestParametersTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.langchain4j.community.model.zhipu.chat.Thinking;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.request.DefaultChatRequestParameters;
 import dev.langchain4j.model.chat.request.ResponseFormat;
 import dev.langchain4j.model.chat.request.ToolChoice;
 import org.junit.jupiter.api.Test;
@@ -82,5 +83,65 @@ class ZhipuAiChatRequestParametersTest {
         assertThat(zhipuResult.thinking().getType()).isEqualTo("enabled");
         assertThat(zhipuResult.thinking().isClearThinking()).isFalse();
         assertThat(zhipuResult.temperature()).isEqualTo(0.5);
+    }
+
+    @Test
+    void should_retain_zhipu_specific_fields_when_defaulted_by_generic_parameters() {
+        // given
+        ZhipuAiChatRequestParameters parameters = ZhipuAiChatRequestParameters.builder()
+                .modelName("receiver-model")
+                .doSample(true)
+                .toolStream(true)
+                .thinking(Thinking.builder().type("enabled").clearThinking(false).build())
+                .build();
+        ChatRequestParameters defaults = DefaultChatRequestParameters.builder()
+                .modelName("default-model")
+                .temperature(0.4)
+                .maxOutputTokens(512)
+                .build();
+
+        // when
+        ChatRequestParameters result = parameters.defaultedBy(defaults);
+
+        // then
+        assertThat(result).isInstanceOf(ZhipuAiChatRequestParameters.class);
+        ZhipuAiChatRequestParameters zhipuResult = (ZhipuAiChatRequestParameters) result;
+        assertThat(zhipuResult.modelName()).isEqualTo("receiver-model");
+        assertThat(zhipuResult.temperature()).isEqualTo(0.4);
+        assertThat(zhipuResult.maxOutputTokens()).isEqualTo(512);
+        assertThat(zhipuResult.doSample()).isTrue();
+        assertThat(zhipuResult.toolStream()).isTrue();
+        assertThat(zhipuResult.thinking()).isEqualTo(parameters.thinking());
+    }
+
+    @Test
+    void should_default_missing_zhipu_fields_from_zhipu_parameters() {
+        // given
+        ZhipuAiChatRequestParameters parameters = ZhipuAiChatRequestParameters.builder()
+                .modelName("receiver-model")
+                .temperature(0.7)
+                .doSample(false)
+                .build();
+        ZhipuAiChatRequestParameters defaults = ZhipuAiChatRequestParameters.builder()
+                .modelName("default-model")
+                .temperature(0.4)
+                .maxOutputTokens(512)
+                .doSample(true)
+                .toolStream(true)
+                .thinking(Thinking.builder().type("enabled").clearThinking(false).build())
+                .build();
+
+        // when
+        ChatRequestParameters result = parameters.defaultedBy(defaults);
+
+        // then
+        assertThat(result).isInstanceOf(ZhipuAiChatRequestParameters.class);
+        ZhipuAiChatRequestParameters zhipuResult = (ZhipuAiChatRequestParameters) result;
+        assertThat(zhipuResult.modelName()).isEqualTo("receiver-model");
+        assertThat(zhipuResult.temperature()).isEqualTo(0.7);
+        assertThat(zhipuResult.maxOutputTokens()).isEqualTo(512);
+        assertThat(zhipuResult.doSample()).isFalse();
+        assertThat(zhipuResult.toolStream()).isTrue();
+        assertThat(zhipuResult.thinking()).isEqualTo(defaults.thinking());
     }
 }


### PR DESCRIPTION
## Issue

N/A — independently identified a regression in Zhipu-specific request-parameter defaulting.

## Change

- Add a covariant `defaultedBy(...)` merge for `ZhipuAiChatRequestParameters`.
- Preserve Zhipu-only values while retaining receiver precedence for explicitly set values.
- Add offline regression tests for generic and typed request defaults.

## General checklist

- [X] There are no breaking changes
- [ ] I have added unit and integration tests for my change (offline unit regression tests added; an integration test is not applicable to this pure parameter-merging behavior)
- [ ] I have manually run all the unit tests in _all_ modules, and they are all green (the full suite was attempted; three unrelated Neo4j Testcontainers tests require a local Docker daemon)
- [ ] I have manually run all integration tests in the module I have added/changed, and they are all green (not run; no API-key-backed tests were run)
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs) (awaiting review, as requested by the template)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (not applicable)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (not applicable)

## Checklist for adding new maven module

- [ ] I have added my new module in the root `pom.xml` and `langchain4j-community-bom/pom.xml` (not applicable)

## Checklist for adding new embedding store integration

- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT` (not applicable)
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT` (not applicable)

## Checklist for changing existing embedding store integration

- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j (not applicable)
