### PR TITLE
feat(cohere): Implement TokenCountEstimator for Cohere integration

### DIFF
--- a/models/langchain4j-community-cohere/src/main/java/dev/langchain4j/community/model/CohereTokenCountEstimator.java
+++ b/models/langchain4j-community-cohere/src/main/java/dev/langchain4j/community/model/CohereTokenCountEstimator.java
@@ -1,0 +1,230 @@
+package dev.langchain4j.community.model;
+
+import static dev.langchain4j.internal.RetryUtils.withRetryMappingExceptions;
+import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.Utils.isNotNullOrEmpty;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+
+import dev.langchain4j.community.model.client.CohereClient;
+import dev.langchain4j.community.model.client.tokenize.CohereTokenizeRequest;
+import dev.langchain4j.community.model.client.tokenize.CohereTokenizeResponse;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.Content;
+import dev.langchain4j.data.message.ContentType;
+import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.data.message.TextContent;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.TokenCountEstimator;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.StreamSupport;
+import org.slf4j.Logger;
+
+/**
+ * Estimates how many tokens a given text or set of chat messages may consume
+ * for a given Cohere model.
+ * <p>
+ * This implementation is based on the <b>/tokenize</b> endpoint of the public API.
+ *
+ * @see <a href="https://docs.cohere.com/reference/tokenize">Tokenization endpoint specification</a>
+ */
+public class CohereTokenCountEstimator implements TokenCountEstimator {
+
+    private final String modelName;
+    private final CohereClient client;
+    private final int maxRetries;
+
+    private CohereTokenCountEstimator(CohereTokenCountEstimatorBuilder builder) {
+        this.modelName = ensureNotBlank(builder.modelName, "model name");
+
+        this.client = CohereClient.builder()
+                .baseUrl(getOrDefault(builder.baseUrl, "https://api.cohere.com/v1"))
+                .authToken(builder.apiKey)
+                .timeout(builder.timeout)
+                .logger(builder.logger)
+                .logRequests(builder.logRequests)
+                .logResponses(builder.logResponses)
+                .build();
+
+        this.maxRetries = getOrDefault(builder.maxRetries, 3);
+    }
+
+    @Override
+    public int estimateTokenCountInText(String text) {
+        if (text == null) {
+            throw new IllegalArgumentException("text cannot be null");
+        }
+
+        if (text.isEmpty()) {
+            return 0;
+        }
+
+        CohereTokenizeRequest request = CohereTokenizeRequest.from(text, modelName);
+        CohereTokenizeResponse response = withRetryMappingExceptions(() -> client.tokenize(request), maxRetries);
+
+        return response.getTokens().size();
+    }
+
+    @Override
+    public int estimateTokenCountInMessage(ChatMessage message) {
+        if (message == null) {
+            throw new IllegalArgumentException("message cannot be null");
+        }
+
+        return switch (message.type()) {
+            case SYSTEM -> {
+                String text = ((SystemMessage) message).text();
+                yield estimateTokenCountInText(text);
+            }
+
+            case USER -> {
+                UserMessage userMessage = (UserMessage) message;
+                List<String> parts = new ArrayList<>();
+
+                for (Content content : userMessage.contents()) {
+                    if (Objects.requireNonNull(content.type()) == ContentType.TEXT) {
+                        String text = ((TextContent) content).text();
+                        parts.add(text);
+                    } else {
+                        throw new IllegalArgumentException("Content type not supported: " + content.type());
+                    }
+                }
+
+                String text = String.join("\n", parts);
+                yield estimateTokenCountInText(text);
+            }
+
+            case AI -> {
+                AiMessage aiMessage = (AiMessage) message;
+                List<String> parts = new ArrayList<>();
+
+                if (isNotNullOrEmpty(aiMessage.text())) {
+                    parts.add(aiMessage.text());
+                }
+
+                if (isNotNullOrEmpty(aiMessage.thinking())) {
+                    parts.add(aiMessage.thinking());
+                }
+
+                if (aiMessage.hasToolExecutionRequests()) {
+                    aiMessage.toolExecutionRequests().forEach(toolExecutionRequest -> {
+                        parts.add(toolExecutionRequest.id());
+                        parts.add(toolExecutionRequest.name());
+                        parts.add(toolExecutionRequest.arguments());
+                    });
+                }
+
+                String text = String.join("\n", parts);
+                yield estimateTokenCountInText(text);
+            }
+
+            case TOOL_EXECUTION_RESULT -> {
+                String text = ((ToolExecutionResultMessage) message).text();
+                yield estimateTokenCountInText(text);
+            }
+
+            default -> throw new IllegalArgumentException("Unsupported message type: " + message.type());
+        };
+    }
+
+    @Override
+    public int estimateTokenCountInMessages(Iterable<ChatMessage> messages) {
+        if (messages == null) {
+            throw new IllegalArgumentException("messages cannot be null");
+        }
+
+        return StreamSupport.stream(messages.spliterator(), false)
+                .mapToInt(this::estimateTokenCountInMessage)
+                .sum();
+    }
+
+    public static CohereTokenCountEstimatorBuilder builder() {
+        return new CohereTokenCountEstimatorBuilder();
+    }
+
+    public static class CohereTokenCountEstimatorBuilder {
+
+        private String modelName;
+        private String baseUrl;
+        private String apiKey;
+        private Duration timeout;
+        private Logger logger;
+        private Boolean logRequests;
+        private Boolean logResponses;
+        private Integer maxRetries;
+
+        /**
+         *  Models might differ in their tokenizer, so this can affect the
+         *  token count even for the same text.
+         */
+        public CohereTokenCountEstimatorBuilder modelName(String modelName) {
+            this.modelName = modelName;
+            return this;
+        }
+
+        /**
+         * The base URL of the Cohere API.
+         */
+        public CohereTokenCountEstimatorBuilder baseUrl(String baseUrl) {
+            this.baseUrl = baseUrl;
+            return this;
+        }
+
+        /**
+         * The Cohere API key.
+         */
+        public CohereTokenCountEstimatorBuilder apiKey(String apiKey) {
+            this.apiKey = apiKey;
+            return this;
+        }
+
+        /**
+         * The timeout value for the request to the {@code /tokenize} endpoint.
+         */
+        public CohereTokenCountEstimatorBuilder timeout(Duration timeout) {
+            this.timeout = timeout;
+            return this;
+        }
+
+        /**
+         * Override default client logger, used for HTTP request/response logging.
+         */
+        public CohereTokenCountEstimatorBuilder logger(Logger logger) {
+            this.logger = logger;
+            return this;
+        }
+
+        /**
+         * Whether to log HTTP requests.
+         */
+        public CohereTokenCountEstimatorBuilder logRequests(Boolean logRequests) {
+            this.logRequests = logRequests;
+            return this;
+        }
+
+        /**
+         * Whether to log HTTP responses.
+         */
+        public CohereTokenCountEstimatorBuilder logResponses(Boolean logResponses) {
+            this.logResponses = logResponses;
+            return this;
+        }
+
+        /**
+         * The number of maximum sequential retries allowed if the request
+         * fails.
+         */
+        public CohereTokenCountEstimatorBuilder maxRetries(Integer maxRetries) {
+            this.maxRetries = maxRetries;
+            return this;
+        }
+
+        public CohereTokenCountEstimator build() {
+            return new CohereTokenCountEstimator(this);
+        }
+    }
+}

--- a/models/langchain4j-community-cohere/src/main/java/dev/langchain4j/community/model/client/CohereClient.java
+++ b/models/langchain4j-community-cohere/src/main/java/dev/langchain4j/community/model/client/CohereClient.java
@@ -11,6 +11,8 @@ import dev.langchain4j.Internal;
 import dev.langchain4j.community.model.client.chat.CohereChatRequest;
 import dev.langchain4j.community.model.client.chat.response.CohereChatResponse;
 import dev.langchain4j.community.model.client.chat.streaming.CohereServerSentEventListener;
+import dev.langchain4j.community.model.client.tokenize.CohereTokenizeRequest;
+import dev.langchain4j.community.model.client.tokenize.CohereTokenizeResponse;
 import dev.langchain4j.community.model.client.transcription.CohereTranscriptionRequest;
 import dev.langchain4j.community.model.client.transcription.CohereTranscriptionResponse;
 import dev.langchain4j.http.client.HttpClient;
@@ -97,6 +99,21 @@ public class CohereClient {
         }
 
         return httpRequestBuilder.build();
+    }
+
+    public CohereTokenizeResponse tokenize(CohereTokenizeRequest request) {
+        SuccessfulHttpResponse rawResponse = this.httpClient.execute(toHttpRequest(request));
+        return fromJson(rawResponse.body(), CohereTokenizeResponse.class);
+    }
+
+    private HttpRequest toHttpRequest(CohereTokenizeRequest request) {
+        return HttpRequest.builder()
+                .url(baseUrl, "/tokenize")
+                .addHeader("Authorization", "bearer " + apiKey)
+                .addHeader("Content-Type", "application/json")
+                .method(POST)
+                .body(toJson(request))
+                .build();
     }
 
     public static Builder builder() {

--- a/models/langchain4j-community-cohere/src/main/java/dev/langchain4j/community/model/client/tokenize/CohereTokenizeRequest.java
+++ b/models/langchain4j-community-cohere/src/main/java/dev/langchain4j/community/model/client/tokenize/CohereTokenizeRequest.java
@@ -1,0 +1,53 @@
+package dev.langchain4j.community.model.client.tokenize;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+import static dev.langchain4j.internal.Utils.quoted;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotEmpty;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.util.Objects;
+
+@JsonInclude(NON_NULL)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class CohereTokenizeRequest {
+
+    private final String text;
+    private final String model;
+
+    private CohereTokenizeRequest(String text, String model) {
+        this.text = ensureNotEmpty(text, "text");
+        this.model = ensureNotBlank(model, "model");
+    }
+
+    public static CohereTokenizeRequest from(String text, String model) {
+        return new CohereTokenizeRequest(text, model);
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public String getModel() {
+        return model;
+    }
+
+    @Override
+    public String toString() {
+        return "CohereTokenizeRequest{ " + "text=" + quoted(text) + ", model=" + quoted(model) + " }";
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(text, model);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return o instanceof CohereTokenizeRequest that
+                && Objects.equals(text, that.text)
+                && Objects.equals(model, that.model);
+    }
+}

--- a/models/langchain4j-community-cohere/src/main/java/dev/langchain4j/community/model/client/tokenize/CohereTokenizeResponse.java
+++ b/models/langchain4j-community-cohere/src/main/java/dev/langchain4j/community/model/client/tokenize/CohereTokenizeResponse.java
@@ -1,0 +1,73 @@
+package dev.langchain4j.community.model.client.tokenize;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import java.util.List;
+import java.util.Objects;
+
+@JsonDeserialize(builder = CohereTokenizeResponse.Builder.class)
+public class CohereTokenizeResponse {
+
+    private final List<Integer> tokens;
+    private final List<String> tokenStrings;
+
+    private CohereTokenizeResponse(Builder builder) {
+        this.tokens = builder.tokens;
+        this.tokenStrings = builder.tokenStrings;
+    }
+
+    public List<Integer> getTokens() {
+        return tokens;
+    }
+
+    public List<String> getTokenStrings() {
+        return tokenStrings;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public String toString() {
+        return "CohereTokenizeResponse{ " + "tokens=" + tokens + ", tokenStrings=" + tokenStrings + " }";
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(tokens, tokenStrings);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return o instanceof CohereTokenizeResponse that
+                && Objects.equals(tokens, that.tokens)
+                && Objects.equals(tokenStrings, that.tokenStrings);
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Builder {
+
+        private List<Integer> tokens;
+        private List<String> tokenStrings;
+
+        public Builder tokens(List<Integer> tokens) {
+            this.tokens = tokens;
+            return this;
+        }
+
+        public Builder tokenStrings(List<String> tokenStrings) {
+            this.tokenStrings = tokenStrings;
+            return this;
+        }
+
+        public CohereTokenizeResponse build() {
+            return new CohereTokenizeResponse(this);
+        }
+    }
+}

--- a/models/langchain4j-community-cohere/src/test/java/dev/langchain4j/community/model/cohere/CohereTokenCountEstimatorIT.java
+++ b/models/langchain4j-community-cohere/src/test/java/dev/langchain4j/community/model/cohere/CohereTokenCountEstimatorIT.java
@@ -1,0 +1,182 @@
+package dev.langchain4j.community.model.cohere;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.community.model.CohereTokenCountEstimator;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.AudioContent;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.CustomMessage;
+import dev.langchain4j.data.message.ImageContent;
+import dev.langchain4j.data.message.PdfFileContent;
+import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.data.message.TextContent;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.data.message.VideoContent;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@EnabledIfEnvironmentVariable(named = "CO_API_KEY", matches = ".+")
+class CohereTokenCountEstimatorIT {
+
+    private static final CohereTokenCountEstimator TOKEN_ESTIMATOR = CohereTokenCountEstimator.builder()
+            .apiKey(System.getenv("CO_API_KEY"))
+            .modelName("command-r7b-12-2024")
+            .logRequests(true)
+            .logResponses(true)
+            .build();
+
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {"", "   "})
+    void should_not_allow_blank_or_null_names_during_instantiation(String invalidModelName) {
+
+        // given - when - then
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> CohereTokenCountEstimator.builder()
+                        .modelName(invalidModelName)
+                        .build());
+    }
+
+    @Test
+    void should_estimate_tokens_in_plain_text() {
+
+        // given - when
+        int tokens = TOKEN_ESTIMATOR.estimateTokenCountInText("Hello there!");
+
+        // then
+        assertThat(tokens).isEqualTo(3);
+    }
+
+    @Test
+    void should_throw_on_null_text_when_estimating_tokens_in_plain_text() {
+
+        // given - when - then
+        assertThrows(IllegalArgumentException.class, () -> TOKEN_ESTIMATOR.estimateTokenCountInText(null));
+    }
+
+    @Test
+    void should_estimate_zero_tokens_in_empty_plain_text() {
+
+        // given - when
+        int tokens = TOKEN_ESTIMATOR.estimateTokenCountInText("");
+
+        // then
+        assertThat(tokens).isZero();
+    }
+
+    @ParameterizedTest
+    @MethodSource("chatMessages")
+    void should_estimate_token_count_in_any_type_of_chat_message(ChatMessage chatMessage, Integer expectedTokens) {
+
+        // given - when
+        int tokens = TOKEN_ESTIMATOR.estimateTokenCountInMessage(chatMessage);
+
+        // then
+        assertThat(tokens).isEqualTo(expectedTokens);
+    }
+
+    @Test
+    void should_throw_when_estimating_tokens_in_message_if_null_message() {
+
+        // given - when - then
+        assertThrows(IllegalArgumentException.class, () -> TOKEN_ESTIMATOR.estimateTokenCountInMessage(null));
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidChatMessages")
+    void should_throw_when_estimating_tokens_in_message_with_unsupported_content(ChatMessage invalidChatMessage) {
+
+        // given - when - then
+        assertThrows(
+                IllegalArgumentException.class, () -> TOKEN_ESTIMATOR.estimateTokenCountInMessage(invalidChatMessage));
+    }
+
+    @Test
+    void should_estimate_tokens_in_chat_messages() {
+
+        // given
+        List<ChatMessage> messages = asList(
+                SystemMessage.from("You are a helpful assistant"),
+                UserMessage.from("Hello there!"),
+                AiMessage.from("Hi!"));
+
+        // when
+        int tokens = TOKEN_ESTIMATOR.estimateTokenCountInMessages(messages);
+
+        // then
+        assertThat(tokens).isEqualTo(10);
+    }
+
+    @Test
+    void should_estimate_zero_tokens_in_empty_chat_messages() {
+
+        // given - when
+        int tokens = TOKEN_ESTIMATOR.estimateTokenCountInMessages(emptyList());
+
+        // then
+        assertThat(tokens).isZero();
+    }
+
+    @Test
+    void should_throw_while_estimating_tokens_in_chat_messages_if_null_messages() {
+
+        // given - when - then
+        assertThrows(IllegalArgumentException.class, () -> TOKEN_ESTIMATOR.estimateTokenCountInMessages(null));
+    }
+
+    static Stream<Arguments> chatMessages() {
+        ToolExecutionRequest weatherToolRequest = ToolExecutionRequest.builder()
+                .id("call_1")
+                .name("getWeather")
+                .arguments("{\"city\":\"Valera\"}")
+                .build();
+
+        return Stream.of(
+                Arguments.of(SystemMessage.from("You are a helpful assistant"), 5),
+                Arguments.of(UserMessage.from("Hello there!"), 3),
+                Arguments.of(
+                        UserMessage.from(asList(
+                                TextContent.from("Hello there!"),
+                                TextContent.from("Hello there!"),
+                                TextContent.from("Hello there!"))),
+                        11),
+                Arguments.of(AiMessage.from("What's up?"), 4),
+                Arguments.of(
+                        AiMessage.builder().thinking("The user is greeting me").build(), 5),
+                Arguments.of(AiMessage.from(weatherToolRequest), 13),
+                Arguments.of(
+                        AiMessage.builder()
+                                .text("Let me check the weather.")
+                                .thinking("The user is greeting me")
+                                .toolExecutionRequests(List.of(weatherToolRequest))
+                                .build(),
+                        26),
+                Arguments.of(ToolExecutionResultMessage.from(weatherToolRequest, "22 degrees and sunny"), 5));
+    }
+
+    static Stream<Arguments> invalidChatMessages() {
+        return Stream.of(
+                Arguments.of(UserMessage.from(ImageContent.from("https://example.com/cat.png"))),
+                Arguments.of(UserMessage.from(AudioContent.from("https://example.com/sound.mp3"))),
+                Arguments.of(UserMessage.from(VideoContent.from("https://example.com/clip.mp4"))),
+                Arguments.of(UserMessage.from(PdfFileContent.from("https://example.com/doc.pdf"))),
+                Arguments.of(UserMessage.from(
+                        TextContent.from("Describe this"), ImageContent.from("https://example.com/cat.png"))),
+                Arguments.of(CustomMessage.from(Map.of("custom", "message"))));
+    }
+}


### PR DESCRIPTION
<!--
Thank you so much for your contribution!

Please fill in all the sections below.
Please open the PR as a draft initially. Once it is reviewed and approved, we will ask you to add documentation and examples.
Please note that PRs with breaking changes or without tests will be rejected.

Please note that PRs will be reviewed based on the priority of the issues they address.
We ask for your patience. We are doing our best to review your PR as quickly as possible.
Please refrain from pinging and asking when it will be reviewed. Thank you for understanding!
-->

## Issue
<!-- Please specify the ID of the issue this PR is addressing. For example: "Closes #1234" or "Fixes #1234" -->
Closes #747

## Change
<!-- Please describe the changes you made. -->
Added an implementation of `TokenCountEstimator` using [Cohere's tokenization API](https://docs.cohere.com/reference/tokenize) (`/tokenize` endpoint for V1):

- `CohereTokenCountEstimator` can be configured with multiple configurable parameters  (`modelName`, `maxRetries`, `timeout`, etc) via builder instantiation.
- It uses the `/tokenize` response object `token` field to get the token count for a given string (`token` corresponds to the tokenized version of the input string, so it's size can be used to calculate the number of tokens).
- Since the API endpoint expects raw text to tokenize (unlike Anthropic, which receives the actual message object), the final implementation ends up being similar to [WatsonXTokenCountEstimator](https://github.com/langchain4j/langchain4j/blob/main/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxTokenCountEstimator.java) where you try to extract all relevant text information for each supported type of `ChatMessage`.
- Only `TextContent` is supported for tokenization, other formats like `PdfFileContent` will cause the token estimator to throw an exception.
- For messages with many text possible blocks (like `AiMessage` with `text` and `thinking`), a single chunk of text is sent in the request to avoid calling the API too many times. 

*Full test suite run result for the Cohere integration module*

<img width="647" height="385" alt="image" src="https://github.com/user-attachments/assets/5e44cf65-91f4-4b59-b988-aa0f802ddef7" />


*new ITs run result*

<img width="646" height="381" alt="image" src="https://github.com/user-attachments/assets/b41d3610-5260-4ff7-a718-ba5e40ebf637" />

## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [X] There are no breaking changes
- [X] I have added unit and integration tests for my change
- [ ] I have manually run all the unit tests in _all_ modules, and they are all green
- [X] I have manually run all integration tests in the module I have added/changed, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
