### PR TITLE
fix: bound failover retry in ModelRouter to avoid unbounded recursion

### DIFF
--- a/models/langchain4j-community-model-router/src/main/java/dev/langchain4j/model/router/ModelRouter.java
+++ b/models/langchain4j-community-model-router/src/main/java/dev/langchain4j/model/router/ModelRouter.java
@@ -65,26 +65,43 @@ public class ModelRouter implements ChatModel, StreamingChatModel {
 
     @Override
     public ChatResponse doChat(ChatRequest chatRequest) {
+        // Bound the failover retry to the number of configured routes: each route is
+        // given a single attempt before the original failure propagates. Without this
+        // bound, a persistently-failing delegate would cause unbounded recursion and a
+        // StackOverflowError instead of surfacing the underlying failure.
+        return doChatInternal(chatRequest, this.routes.size());
+    }
+
+    private ChatResponse doChatInternal(ChatRequest chatRequest, int attemptsLeft) {
         ChatModelWrapper delegate = resolveDelegate(chatRequest);
         try {
-            ChatResponse response = delegate.chat(chatRequest);
-            return response;
+            return delegate.chat(chatRequest);
         } catch (NoMatchingModelFoundException e) {
             throw e;
         } catch (Exception e) {
-            return doChat(chatRequest);
+            if (attemptsLeft <= 1) {
+                throw e;
+            }
+            return doChatInternal(chatRequest, attemptsLeft - 1);
         }
     }
 
     @Override
     public void doChat(ChatRequest chatRequest, StreamingChatResponseHandler handler) {
+        doChatInternal(chatRequest, handler, this.routes.size());
+    }
+
+    private void doChatInternal(ChatRequest chatRequest, StreamingChatResponseHandler handler, int attemptsLeft) {
         ChatModelWrapper delegate = resolveDelegate(chatRequest);
         try {
             delegate.chat(chatRequest, handler);
         } catch (NoMatchingModelFoundException e) {
             throw e;
         } catch (Exception e) {
-            doChat(chatRequest, handler);
+            if (attemptsLeft <= 1) {
+                throw e;
+            }
+            doChatInternal(chatRequest, handler, attemptsLeft - 1);
         }
     }
 

--- a/models/langchain4j-community-model-router/src/test/java/dev/langchain4j/model/router/ModelRouterTest.java
+++ b/models/langchain4j-community-model-router/src/test/java/dev/langchain4j/model/router/ModelRouterTest.java
@@ -1,0 +1,180 @@
+package dev.langchain4j.model.router;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.ModelProvider;
+import dev.langchain4j.model.chat.Capability;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.listener.ChatModelListener;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.request.DefaultChatRequestParameters;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class ModelRouterTest {
+
+    private static final ChatRequest REQUEST =
+            ChatRequest.builder().messages(new UserMessage("ping")).build();
+
+    private static class NoOpChatModel implements ChatModel {
+
+        private final String id;
+
+        NoOpChatModel(String id) {
+            this.id = id;
+        }
+
+        @Override
+        public ChatResponse doChat(ChatRequest chatRequest) {
+            return ChatResponse.builder().aiMessage(new AiMessage(id)).build();
+        }
+
+        @Override
+        public ChatRequestParameters defaultRequestParameters() {
+            return DefaultChatRequestParameters.EMPTY;
+        }
+
+        @Override
+        public ModelProvider provider() {
+            return ModelProvider.OTHER;
+        }
+
+        @Override
+        public List<ChatModelListener> listeners() {
+            return List.of();
+        }
+
+        @Override
+        public Set<Capability> supportedCapabilities() {
+            return Set.of();
+        }
+    }
+
+    private static class AlwaysThrowingChatModel implements ChatModel {
+
+        @Override
+        public ChatResponse doChat(ChatRequest chatRequest) {
+            throw new IllegalStateException("permanent delegate failure");
+        }
+
+        @Override
+        public ChatRequestParameters defaultRequestParameters() {
+            return DefaultChatRequestParameters.EMPTY;
+        }
+
+        @Override
+        public ModelProvider provider() {
+            return ModelProvider.OTHER;
+        }
+
+        @Override
+        public List<ChatModelListener> listeners() {
+            return List.of();
+        }
+
+        @Override
+        public Set<Capability> supportedCapabilities() {
+            return Set.of();
+        }
+    }
+
+    /**
+     * When every route persistently fails and a non-failover strategy is used, the
+     * router must surface the underlying failure instead of recursing unboundedly and
+     * crashing with a {@link StackOverflowError}.
+     */
+    @Test
+    void propagatesFailureInsteadOfRecursingUnboundedly() {
+        ModelRouter router = ModelRouter.builder()
+                .addRoutes(new AlwaysThrowingChatModel())
+                .routingStrategy(new LowestTokenUsageRoutingStrategy())
+                .build();
+
+        Exception thrown = assertThrows(IllegalStateException.class, () -> router.chat(REQUEST));
+        assertEquals("permanent delegate failure", thrown.getMessage());
+    }
+
+    /**
+     * With a {@link FailoverStrategy}, a failing route is skipped and the request is
+     * routed to the next healthy model within a bounded number of attempts.
+     */
+    @Test
+    void failsOverToHealthyModel() {
+        ModelRouter router = ModelRouter.builder()
+                .addRoutes(new AlwaysThrowingChatModel(), new NoOpChatModel("healthy"))
+                .routingStrategy(new FailoverStrategy())
+                .build();
+
+        ChatResponse response = router.chat(REQUEST);
+        assertEquals("healthy", response.aiMessage().text());
+    }
+
+    /**
+     * After the bounded failover attempts are exhausted, the last model's failure
+     * surfaces instead of the router recursing forever.
+     */
+    @Test
+    void boundedAttemptsWhenStrategyKeepsSelectingSameFailingModel() {
+        // A throttling/usage strategy that does not mark models failed will keep
+        // selecting the (single) failing route; the router must still terminate.
+        AtomicInteger attempts = new AtomicInteger();
+        ChatModel flaky = new ChatModel() {
+
+            @Override
+            public ChatResponse doChat(ChatRequest chatRequest) {
+                attempts.incrementAndGet();
+                throw new IllegalStateException("flaky");
+            }
+
+            @Override
+            public ChatRequestParameters defaultRequestParameters() {
+                return DefaultChatRequestParameters.EMPTY;
+            }
+
+            @Override
+            public ModelProvider provider() {
+                return ModelProvider.OTHER;
+            }
+
+            @Override
+            public List<ChatModelListener> listeners() {
+                return List.of();
+            }
+
+            @Override
+            public Set<Capability> supportedCapabilities() {
+                return Set.of();
+            }
+        };
+        ModelRouter router = ModelRouter.builder()
+                .addRoutes(flaky)
+                .routingStrategy(new LowestTokenUsageRoutingStrategy())
+                .build();
+
+        IllegalStateException thrown = assertThrows(IllegalStateException.class, () -> router.chat(REQUEST));
+        assertEquals("flaky", thrown.getMessage());
+        // With a single route, the router attempts it once before propagating.
+        assertEquals(1, attempts.get());
+    }
+
+    /**
+     * A successful synchronous call is routed and returned unchanged.
+     */
+    @Test
+    void successfulCallDelegatesToRoute() {
+        ModelRouter router = ModelRouter.builder()
+                .addRoutes(new NoOpChatModel("ok"))
+                .routingStrategy(new LowestTokenUsageRoutingStrategy())
+                .build();
+
+        ChatResponse response = router.chat(REQUEST);
+        assertEquals("ok", response.aiMessage().text());
+    }
+}


### PR DESCRIPTION
## Issue

Fixes #751

## Change

`ModelRouter.doChat(...)` and its streaming overload recursed into themselves **without a bound** every time a delegate `ChatModel` threw. For a permanently-failing route combined with a routing strategy that does not mark the model as failed (e.g. `LowestTokenUsageRoutingStrategy`, or any strategy with a single route), this recursion never terminates and crashes the JVM with a `StackOverflowError` instead of surfacing the underlying failure.

This change bounds the failover retry to the number of configured routes: each route is given a single attempt before the last exception propagates. Both the synchronous and the streaming `doChat` paths are fixed identically. The intended failover behaviour (skip failed models, try the next healthy route) is preserved.

## General checklist
- [x] There are no breaking changes (API, behaviour) — the public `doChat` signatures are unchanged; on success and with a healthy failover the result is identical, only the unbounded failure path is now bounded.
- [x] I have added unit and/or integration tests for my change (`ModelRouterTest`)
- [x] The tests cover both positive and negative cases
- [x] I have manually run all unit tests in the changed module and they pass

## How to test

```shell
./mvnw -pl models/langchain4j-community-model-router test
```

`ModelRouterTest` includes:
- `propagatesFailureInsteadOfRecursingUnboundedly` — a permanently-failing model now surfaces `IllegalStateException` (previously `StackOverflowError`).
- `failsOverToHealthyModel` — a failing route followed by a healthy one routes to the healthy model within the bound.
- `boundedAttemptsWhenStrategyKeepsSelectingSameFailingModel` — with a single route it terminates after one attempt and propagates the failure.
- `successfulCallDelegatesToRoute` — happy path unchanged.
