### PR TITLE
Add Amazon DynamoDB embedding store

### DIFF
--- a/embedding-stores/langchain4j-community-dynamodb/pom.xml
+++ b/embedding-stores/langchain4j-community-dynamodb/pom.xml
@@ -1,0 +1,189 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>dev.langchain4j</groupId>
+        <artifactId>langchain4j-community</artifactId>
+        <version>1.19.0-beta29-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>langchain4j-community-dynamodb</artifactId>
+    <name>LangChain4j :: Community :: Integration :: Amazon DynamoDB</name>
+
+    <properties>
+        <!--
+            Override parent's AWS SDK version.
+            DynamoDB native vector search (the SearchVectors operation and vector
+            indexes) was introduced in AWS SDK for Java v2 2.51.0 (August 2026).
+        -->
+        <aws.sdk.version>2.51.0</aws.sdk.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>bom</artifactId>
+                <version>${aws.sdk.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-core</artifactId>
+            <version>${langchain4j.core.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>dynamodb</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>auth</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <!-- test dependencies -->
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-core</artifactId>
+            <version>${langchain4j.core.version}</version>
+            <classifier>tests</classifier>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-embeddings-all-minilm-l6-v2-q</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.revapi</groupId>
+                <artifactId>revapi-maven-plugin</artifactId>
+                <configuration>
+                    <analysisConfiguration>
+                        <revapi.differences>
+                            <differences>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.class.externalClassExposedInAPI</code>
+                                    <new>missing-class dev.langchain4j.data.embedding.Embedding</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.missing.newClass</code>
+                                    <new>missing-class dev.langchain4j.data.embedding.Embedding</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.class.externalClassExposedInAPI</code>
+                                    <new>missing-class dev.langchain4j.data.segment.TextSegment</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.missing.newClass</code>
+                                    <new>missing-class dev.langchain4j.data.segment.TextSegment</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.class.externalClassExposedInAPI</code>
+                                    <new>missing-class dev.langchain4j.store.embedding.EmbeddingSearchRequest</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.missing.newClass</code>
+                                    <new>missing-class dev.langchain4j.store.embedding.EmbeddingSearchRequest</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.class.externalClassExposedInAPI</code>
+                                    <new>missing-class dev.langchain4j.store.embedding.EmbeddingSearchResult</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.missing.newClass</code>
+                                    <new>missing-class dev.langchain4j.store.embedding.EmbeddingSearchResult</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.class.externalClassExposedInAPI</code>
+                                    <new>missing-class dev.langchain4j.store.embedding.filter.Filter</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.missing.newClass</code>
+                                    <new>missing-class dev.langchain4j.store.embedding.filter.Filter</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.class.externalClassExposedInAPI</code>
+                                    <new>missing-class software.amazon.awssdk.auth.credentials.AwsCredentialsProvider</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.missing.newClass</code>
+                                    <new>missing-class software.amazon.awssdk.auth.credentials.AwsCredentialsProvider</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.class.externalClassExposedInAPI</code>
+                                    <new>missing-class software.amazon.awssdk.services.dynamodb.DynamoDbClient</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.missing.newClass</code>
+                                    <new>missing-class software.amazon.awssdk.services.dynamodb.DynamoDbClient</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.class.externalClassExposedInAPI</code>
+                                    <new>missing-class software.amazon.awssdk.services.dynamodb.model.VectorDistanceFunction</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.missing.newClass</code>
+                                    <new>missing-class software.amazon.awssdk.services.dynamodb.model.VectorDistanceFunction</new>
+                                </item>
+                            </differences>
+                        </revapi.differences>
+                    </analysisConfiguration>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/embedding-stores/langchain4j-community-dynamodb/src/main/java/dev/langchain4j/community/store/embedding/dynamodb/DynamoDbAttributeCodec.java
+++ b/embedding-stores/langchain4j-community-dynamodb/src/main/java/dev/langchain4j/community/store/embedding/dynamodb/DynamoDbAttributeCodec.java
@@ -1,0 +1,95 @@
+package dev.langchain4j.community.store.embedding.dynamodb;
+
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+/**
+ * Encodes langchain4j metadata values to DynamoDB {@link AttributeValue}s and back.
+ *
+ * <p>Integer and long values map to native DynamoDB numbers ({@code N}). Float and double values are
+ * stored as tagged strings instead, because DynamoDB's Number type cannot represent subnormal
+ * magnitudes (smaller than roughly {@code 1E-130}) and would reject values such as
+ * {@link Double#MIN_VALUE}. Encoding them as strings preserves the exact value and Java type on
+ * read-back. Plain string values that happen to begin with one of the tags are escaped so they never
+ * collide with an encoded number.
+ *
+ * <p>This single codec is used both when writing metadata and when building filter expressions, so a
+ * filter on a float/double attribute compares against the same tagged-string representation that was
+ * persisted.
+ */
+final class DynamoDbAttributeCodec {
+
+    static final String FLOAT_PREFIX = " F#";
+    static final String DOUBLE_PREFIX = " D#";
+    static final String STRING_PREFIX = " S#";
+
+    private DynamoDbAttributeCodec() {
+        // utility class
+    }
+
+    /** Encodes a metadata value for storage or for a filter comparison. */
+    static AttributeValue encode(Object value) {
+        if (value instanceof String string) {
+            return AttributeValue.fromS(encodeString(string));
+        } else if (value instanceof Boolean b) {
+            return AttributeValue.fromBool(b);
+        } else if (value instanceof Float f) {
+            return AttributeValue.fromS(FLOAT_PREFIX + f);
+        } else if (value instanceof Double d) {
+            return AttributeValue.fromS(DOUBLE_PREFIX + d);
+        } else if (value instanceof Number number) {
+            // Integer and Long fit DynamoDB's Number range exactly.
+            return AttributeValue.fromN(number.toString());
+        } else {
+            return AttributeValue.fromS(encodeString(String.valueOf(value)));
+        }
+    }
+
+    /** Decodes a stored {@link AttributeValue} back to a metadata value, or {@code null} if unsupported. */
+    static Object decode(AttributeValue value) {
+        if (value.s() != null) {
+            return decodeString(value.s());
+        } else if (value.n() != null) {
+            return parseNumber(value.n());
+        } else if (value.bool() != null) {
+            return value.bool();
+        }
+        return null;
+    }
+
+    /** Escapes a plain string that would otherwise be mistaken for a tagged number. */
+    private static String encodeString(String value) {
+        if (value.startsWith(FLOAT_PREFIX) || value.startsWith(DOUBLE_PREFIX) || value.startsWith(STRING_PREFIX)) {
+            return STRING_PREFIX + value;
+        }
+        return value;
+    }
+
+    private static Object decodeString(String value) {
+        if (value.startsWith(FLOAT_PREFIX)) {
+            return Float.parseFloat(value.substring(FLOAT_PREFIX.length()));
+        }
+        if (value.startsWith(DOUBLE_PREFIX)) {
+            return Double.parseDouble(value.substring(DOUBLE_PREFIX.length()));
+        }
+        if (value.startsWith(STRING_PREFIX)) {
+            return value.substring(STRING_PREFIX.length());
+        }
+        return value;
+    }
+
+    private static Object parseNumber(String number) {
+        // Metadata numbers in langchain4j are Integer/Long/Float/Double; preserve integrality.
+        if (number.contains(".") || number.contains("e") || number.contains("E")) {
+            return Double.parseDouble(number);
+        }
+        try {
+            long value = Long.parseLong(number);
+            if (value >= Integer.MIN_VALUE && value <= Integer.MAX_VALUE) {
+                return (int) value;
+            }
+            return value;
+        } catch (NumberFormatException e) {
+            return Double.parseDouble(number);
+        }
+    }
+}

--- a/embedding-stores/langchain4j-community-dynamodb/src/main/java/dev/langchain4j/community/store/embedding/dynamodb/DynamoDbEmbeddingStore.java
+++ b/embedding-stores/langchain4j-community-dynamodb/src/main/java/dev/langchain4j/community/store/embedding/dynamodb/DynamoDbEmbeddingStore.java
@@ -1,0 +1,675 @@
+package dev.langchain4j.community.store.embedding.dynamodb;
+
+import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.Utils.randomUUID;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotEmpty;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+import static dev.langchain4j.internal.ValidationUtils.ensureTrue;
+import static java.util.Objects.isNull;
+import static java.util.stream.Collectors.toList;
+
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.store.embedding.EmbeddingMatch;
+import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
+import dev.langchain4j.store.embedding.EmbeddingSearchResult;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import dev.langchain4j.store.embedding.RelevanceScore;
+import dev.langchain4j.store.embedding.filter.Filter;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeDefinition;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.BatchWriteItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.BillingMode;
+import software.amazon.awssdk.services.dynamodb.model.CreateTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.DeleteRequest;
+import software.amazon.awssdk.services.dynamodb.model.DescribeTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.DescribeTableResponse;
+import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
+import software.amazon.awssdk.services.dynamodb.model.KeyType;
+import software.amazon.awssdk.services.dynamodb.model.Projection;
+import software.amazon.awssdk.services.dynamodb.model.ProjectionType;
+import software.amazon.awssdk.services.dynamodb.model.PutRequest;
+import software.amazon.awssdk.services.dynamodb.model.ResourceNotFoundException;
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
+import software.amazon.awssdk.services.dynamodb.model.SearchResultItem;
+import software.amazon.awssdk.services.dynamodb.model.SearchSchemaElement;
+import software.amazon.awssdk.services.dynamodb.model.SearchSchemaElementType;
+import software.amazon.awssdk.services.dynamodb.model.SearchVectorsRequest;
+import software.amazon.awssdk.services.dynamodb.model.SearchVectorsResponse;
+import software.amazon.awssdk.services.dynamodb.model.TableStatus;
+import software.amazon.awssdk.services.dynamodb.model.VectorAttributeDefinition;
+import software.amazon.awssdk.services.dynamodb.model.VectorDistanceFunction;
+import software.amazon.awssdk.services.dynamodb.model.VectorIndex;
+import software.amazon.awssdk.services.dynamodb.model.WriteRequest;
+
+/**
+ * An {@link EmbeddingStore} backed by Amazon DynamoDB's native vector search.
+ *
+ * <p>Each embedding is stored as a single DynamoDB item whose partition key is the embedding id.
+ * The embedding vector is stored as a list of numbers under a configurable attribute, over which a
+ * DynamoDB <em>vector index</em> performs the similarity search. The associated {@link TextSegment}
+ * text is stored under {@link #DEFAULT_TEXT_METADATA_KEY} (configurable) and each metadata entry is
+ * stored as its own top-level attribute.
+ *
+ * <p>DynamoDB vector search supports the {@code COSINE}, {@code EUCLIDEAN} and {@code DOT_PRODUCT}
+ * distance functions and vectors up to 4096 dimensions. A single search returns at most 100 results
+ * (the {@code TopK} limit), so {@code maxResults} is capped at 100.
+ *
+ * <h2>Metadata numbers</h2>
+ *
+ * <p>Integer and long metadata values are stored as native DynamoDB numbers. Float and double values
+ * are stored as strings instead, because DynamoDB's Number type cannot represent subnormal magnitudes
+ * (smaller than roughly {@code 1E-130}) and would reject values such as {@link Double#MIN_VALUE}. This
+ * preserves the exact value and Java type on read-back. Equality filters on float and double metadata
+ * work because filter values are encoded with the same scheme (see {@link DynamoDbAttributeCodec}).
+ *
+ * <p>Metadata keys must not collide with the configured key, vector, or text attribute names
+ * (by default {@code id}, {@code embedding} and {@code _page_content}); such a collision throws
+ * {@link IllegalArgumentException} on write.
+ *
+ * <h2>Filtering</h2>
+ *
+ * <p>DynamoDB vector search can filter results only on attributes declared in the vector index
+ * search schema — the {@code HASH} key and {@code INLINE_FILTER} attributes — and only with equality.
+ * Those attributes are fixed when the index is created, so to use metadata filters you must declare
+ * them up front with {@link Builder#inlineFilterAttributes(List)}. Only {@link dev.langchain4j.store.embedding.filter.comparison.IsEqualTo}
+ * filters (optionally combined with {@code AND}) are supported.
+ *
+ * @see <a href="https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/">Amazon DynamoDB Documentation</a>
+ */
+public class DynamoDbEmbeddingStore implements EmbeddingStore<TextSegment>, AutoCloseable {
+
+    private static final Logger log = LoggerFactory.getLogger(DynamoDbEmbeddingStore.class);
+
+    /** Default metadata key under which the {@link TextSegment} text is stored. */
+    public static final String DEFAULT_TEXT_METADATA_KEY = "_page_content";
+
+    /** Default name of the item attribute holding the embedding vector. */
+    public static final String DEFAULT_VECTOR_ATTRIBUTE = "embedding";
+
+    /** Default name of the partition key attribute holding the embedding id. */
+    public static final String DEFAULT_KEY_ATTRIBUTE = "id";
+
+    private static final Region DEFAULT_REGION = Region.US_EAST_1;
+    private static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(30);
+    private static final int SECONDS_TO_WAIT_FOR_TABLE = 60;
+
+    /** DynamoDB BatchWriteItem accepts at most 25 write requests per call. */
+    private static final int MAX_BATCH_WRITE_SIZE = 25;
+
+    /** Maximum number of BatchWriteItem calls per chunk before giving up on unprocessed items. */
+    private static final int MAX_BATCH_WRITE_ATTEMPTS = 10;
+
+    private static final long BATCH_WRITE_BASE_BACKOFF_MILLIS = 100;
+    private static final long MAX_BACKOFF_MILLIS = 5_000;
+
+    /** DynamoDB SearchVectors limits TopK to the range 1..100. */
+    private static final int MAX_TOP_K = 100;
+
+    private final DynamoDbClient dynamoDbClient;
+
+    /** True only when this store created the client itself and is therefore responsible for closing it. */
+    private final boolean ownsClient;
+
+    private final String tableName;
+    private final String indexName;
+    private final String keyAttribute;
+    private final String vectorAttribute;
+    private final String textMetadataKey;
+    private final VectorDistanceFunction distanceFunction;
+    private final boolean createTableIfNotExists;
+    private final List<String> inlineFilterAttributes;
+
+    public DynamoDbEmbeddingStore(Builder builder) {
+        this.tableName = ensureNotNull(builder.tableName, "tableName");
+        this.indexName = ensureNotNull(builder.indexName, "indexName");
+        this.keyAttribute = getOrDefault(builder.keyAttribute, DEFAULT_KEY_ATTRIBUTE);
+        this.vectorAttribute = getOrDefault(builder.vectorAttribute, DEFAULT_VECTOR_ATTRIBUTE);
+        this.textMetadataKey = getOrDefault(builder.textMetadataKey, DEFAULT_TEXT_METADATA_KEY);
+        this.distanceFunction = getOrDefault(builder.distanceFunction, VectorDistanceFunction.COSINE);
+        this.createTableIfNotExists = getOrDefault(builder.createTableIfNotExists, true);
+        this.inlineFilterAttributes =
+                builder.inlineFilterAttributes == null ? List.of() : List.copyOf(builder.inlineFilterAttributes);
+        this.ownsClient = isNull(builder.dynamoDbClient);
+        this.dynamoDbClient = ownsClient ? createClient(builder) : builder.dynamoDbClient;
+    }
+
+    private DynamoDbClient createClient(Builder builder) {
+        Region region = isNull(builder.region) ? DEFAULT_REGION : Region.of(builder.region);
+
+        AwsCredentialsProvider credentialsProvider =
+                getOrDefault(builder.credentialsProvider, DefaultCredentialsProvider.create());
+
+        Duration timeout = getOrDefault(builder.timeout, DEFAULT_TIMEOUT);
+
+        return DynamoDbClient.builder()
+                .region(region)
+                .credentialsProvider(credentialsProvider)
+                .overrideConfiguration(config -> config.apiCallTimeout(timeout))
+                .build();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder for {@link DynamoDbEmbeddingStore}.
+     *
+     * <p>Example usage:
+     * <pre>{@code
+     * DynamoDbEmbeddingStore store = DynamoDbEmbeddingStore.builder()
+     *     .tableName("my-embeddings")
+     *     .indexName("my-vector-index")
+     *     .region("us-east-1")
+     *     .build();
+     * }</pre>
+     */
+    public static class Builder {
+
+        public Builder() {}
+
+        private DynamoDbClient dynamoDbClient;
+        private String tableName;
+        private String indexName;
+        private String keyAttribute;
+        private String vectorAttribute;
+        private String textMetadataKey;
+        private String region;
+        private AwsCredentialsProvider credentialsProvider;
+        private Duration timeout;
+        private VectorDistanceFunction distanceFunction;
+        private Boolean createTableIfNotExists;
+        private List<String> inlineFilterAttributes;
+
+        /**
+         * Sets a pre-configured {@link DynamoDbClient}. If not set, one is created from the region,
+         * credentials provider and timeout.
+         */
+        public Builder dynamoDbClient(DynamoDbClient dynamoDbClient) {
+            this.dynamoDbClient = dynamoDbClient;
+            return this;
+        }
+
+        /** Sets the DynamoDB table name. Required. */
+        public Builder tableName(String tableName) {
+            this.tableName = tableName;
+            return this;
+        }
+
+        /** Sets the vector index name within the table. Required. */
+        public Builder indexName(String indexName) {
+            this.indexName = indexName;
+            return this;
+        }
+
+        /** Sets the partition key attribute name. Defaults to {@value #DEFAULT_KEY_ATTRIBUTE}. */
+        public Builder keyAttribute(String keyAttribute) {
+            this.keyAttribute = keyAttribute;
+            return this;
+        }
+
+        /** Sets the attribute name that holds the embedding vector. Defaults to {@value #DEFAULT_VECTOR_ATTRIBUTE}. */
+        public Builder vectorAttribute(String vectorAttribute) {
+            this.vectorAttribute = vectorAttribute;
+            return this;
+        }
+
+        /** Sets the metadata key for the text content. Defaults to {@value #DEFAULT_TEXT_METADATA_KEY}. */
+        public Builder textMetadataKey(String textMetadataKey) {
+            this.textMetadataKey = textMetadataKey;
+            return this;
+        }
+
+        /** Sets the AWS region. Defaults to us-east-1. */
+        public Builder region(String region) {
+            this.region = region;
+            return this;
+        }
+
+        /** Sets the AWS credentials provider. Defaults to {@link DefaultCredentialsProvider}. */
+        public Builder credentialsProvider(AwsCredentialsProvider credentialsProvider) {
+            this.credentialsProvider = credentialsProvider;
+            return this;
+        }
+
+        /** Sets the API call timeout. Defaults to 30 seconds. */
+        public Builder timeout(Duration timeout) {
+            this.timeout = timeout;
+            return this;
+        }
+
+        /** Sets the distance function for similarity search. Defaults to COSINE. */
+        public Builder distanceFunction(VectorDistanceFunction distanceFunction) {
+            this.distanceFunction = distanceFunction;
+            return this;
+        }
+
+        /** Sets whether to create the table and vector index if they do not exist. Defaults to true. */
+        public Builder createTableIfNotExists(Boolean createTableIfNotExists) {
+            this.createTableIfNotExists = createTableIfNotExists;
+            return this;
+        }
+
+        /**
+         * Declares the metadata attributes that can be used in filters. These become
+         * {@code INLINE_FILTER} elements of the vector index search schema and can therefore only be
+         * set when the index is created. Defaults to none (no metadata filtering).
+         */
+        public Builder inlineFilterAttributes(List<String> inlineFilterAttributes) {
+            this.inlineFilterAttributes = inlineFilterAttributes;
+            return this;
+        }
+
+        public DynamoDbEmbeddingStore build() {
+            return new DynamoDbEmbeddingStore(this);
+        }
+    }
+
+    @Override
+    public String add(Embedding embedding) {
+        String id = randomUUID();
+        add(id, embedding);
+        return id;
+    }
+
+    @Override
+    public void add(String id, Embedding embedding) {
+        addInternal(id, embedding, null);
+    }
+
+    @Override
+    public String add(Embedding embedding, TextSegment textSegment) {
+        String id = randomUUID();
+        addInternal(id, embedding, textSegment);
+        return id;
+    }
+
+    @Override
+    public List<String> addAll(List<Embedding> embeddings) {
+        List<String> ids = embeddings.stream().map(ignored -> randomUUID()).collect(toList());
+        addAll(ids, embeddings, null);
+        return ids;
+    }
+
+    @Override
+    public List<String> addAll(List<Embedding> embeddings, List<TextSegment> textSegments) {
+        List<String> ids = embeddings.stream().map(ignored -> randomUUID()).collect(toList());
+        addAll(ids, embeddings, textSegments);
+        return ids;
+    }
+
+    @Override
+    public void addAll(List<String> ids, List<Embedding> embeddings, List<TextSegment> textSegments) {
+        ensureNotEmpty(ids, "ids");
+        ensureNotEmpty(embeddings, "embeddings");
+        ensureTrue(ids.size() == embeddings.size(), "ids and embeddings must have the same size");
+        ensureTrue(
+                textSegments == null || textSegments.size() == embeddings.size(),
+                "textSegments and embeddings must have the same size");
+
+        if (createTableIfNotExists && !tableExists()) {
+            createTable(embeddings.get(0).dimension());
+        }
+
+        List<WriteRequest> writeRequests = new ArrayList<>(embeddings.size());
+        for (int i = 0; i < embeddings.size(); i++) {
+            String id = ids.get(i);
+            Embedding embedding = embeddings.get(i);
+            TextSegment textSegment = textSegments != null ? textSegments.get(i) : null;
+
+            Map<String, AttributeValue> item = buildItem(id, embedding, textSegment);
+            writeRequests.add(WriteRequest.builder()
+                    .putRequest(PutRequest.builder().item(item).build())
+                    .build());
+        }
+
+        batchWrite(writeRequests);
+    }
+
+    private void addInternal(String id, Embedding embedding, TextSegment textSegment) {
+        addAll(
+                Collections.singletonList(id),
+                Collections.singletonList(embedding),
+                textSegment == null ? null : Collections.singletonList(textSegment));
+    }
+
+    private void batchWrite(List<WriteRequest> writeRequests) {
+        for (int start = 0; start < writeRequests.size(); start += MAX_BATCH_WRITE_SIZE) {
+            int end = Math.min(start + MAX_BATCH_WRITE_SIZE, writeRequests.size());
+            List<WriteRequest> chunk = writeRequests.subList(start, end);
+
+            Map<String, List<WriteRequest>> requestItems = new HashMap<>();
+            requestItems.put(tableName, new ArrayList<>(chunk));
+
+            // BatchWriteItem may return unprocessed items under load; retry them with exponential
+            // backoff, giving up after MAX_BATCH_WRITE_ATTEMPTS so persistent throttling cannot spin
+            // forever.
+            Map<String, List<WriteRequest>> unprocessed = requestItems;
+            for (int attempt = 1; !unprocessed.isEmpty(); attempt++) {
+                BatchWriteItemRequest request = BatchWriteItemRequest.builder()
+                        .requestItems(unprocessed)
+                        .build();
+                unprocessed = dynamoDbClient.batchWriteItem(request).unprocessedItems();
+                if (unprocessed.isEmpty()) {
+                    break;
+                }
+                if (attempt >= MAX_BATCH_WRITE_ATTEMPTS) {
+                    throw new IllegalStateException("DynamoDB BatchWriteItem still had unprocessed items after "
+                            + MAX_BATCH_WRITE_ATTEMPTS + " attempts; giving up (likely sustained throttling)");
+                }
+                sleep(backoffMillis(attempt));
+            }
+        }
+    }
+
+    /** Exponential backoff (100ms, 200ms, 400ms, ...) capped at 5 seconds. */
+    private static long backoffMillis(int attempt) {
+        return Math.min(BATCH_WRITE_BASE_BACKOFF_MILLIS << (attempt - 1), MAX_BACKOFF_MILLIS);
+    }
+
+    private static void sleep(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Interrupted while backing off before a BatchWriteItem retry", e);
+        }
+    }
+
+    @Override
+    public EmbeddingSearchResult<TextSegment> search(EmbeddingSearchRequest request) {
+        if (request.maxResults() > MAX_TOP_K) {
+            log.warn(
+                    "DynamoDB vector search limits maxResults to {}. Requested: {}. Results will be capped.",
+                    MAX_TOP_K,
+                    request.maxResults());
+        }
+        int topK = Math.max(1, Math.min(request.maxResults(), MAX_TOP_K));
+
+        SearchVectorsRequest.Builder queryBuilder = SearchVectorsRequest.builder()
+                .tableName(tableName)
+                .indexName(indexName)
+                .topK(topK)
+                .searchVector(toAttributeValues(request.queryEmbedding().vector()));
+
+        if (request.filter() != null) {
+            DynamoDbMetadataFilterMapper.SearchCondition condition = DynamoDbMetadataFilterMapper.map(request.filter());
+            queryBuilder
+                    .searchConditionExpression(condition.expression)
+                    .expressionAttributeNames(condition.expressionAttributeNames)
+                    .expressionAttributeValues(condition.expressionAttributeValues);
+        }
+
+        SearchVectorsResponse response;
+        try {
+            response = dynamoDbClient.searchVectors(queryBuilder.build());
+        } catch (ResourceNotFoundException e) {
+            // Table or index does not exist yet (created lazily on first add)
+            return new EmbeddingSearchResult<>(Collections.emptyList());
+        }
+
+        List<EmbeddingMatch<TextSegment>> matches = new ArrayList<>();
+        for (SearchResultItem result : response.searchResults()) {
+            double score = distanceToScore(result.score());
+            if (score < request.minScore()) {
+                continue;
+            }
+
+            Map<String, AttributeValue> item = result.item();
+            String id = item.containsKey(keyAttribute) ? item.get(keyAttribute).s() : null;
+            if (id == null) {
+                // The key was not projected into the result: likely a misconfigured keyAttribute or
+                // index projection. Surface it rather than silently returning a null-id match.
+                log.warn(
+                        "DynamoDB search result is missing the key attribute '{}'; returning a match with a null id. "
+                                + "Check that keyAttribute matches the table's partition key.",
+                        keyAttribute);
+            }
+            TextSegment textSegment = extractTextSegment(item);
+
+            matches.add(new EmbeddingMatch<>(score, id, null, textSegment));
+        }
+
+        return new EmbeddingSearchResult<>(matches);
+    }
+
+    @Override
+    public void removeAll(Collection<String> ids) {
+        ensureNotEmpty(ids, "ids");
+
+        List<WriteRequest> writeRequests = new ArrayList<>(ids.size());
+        for (String id : ids) {
+            Map<String, AttributeValue> key = Map.of(keyAttribute, AttributeValue.fromS(id));
+            writeRequests.add(WriteRequest.builder()
+                    .deleteRequest(DeleteRequest.builder().key(key).build())
+                    .build());
+        }
+
+        try {
+            batchWrite(writeRequests);
+        } catch (ResourceNotFoundException e) {
+            // Table does not exist yet - nothing to delete
+        }
+    }
+
+    @Override
+    public void removeAll(Filter filter) {
+        throw new UnsupportedOperationException("removeAll(Filter) is not supported by DynamoDB vector search");
+    }
+
+    @Override
+    public void removeAll() {
+        List<Map<String, AttributeValue>> keys = scanAllKeys();
+        if (keys.isEmpty()) {
+            return;
+        }
+
+        List<WriteRequest> writeRequests = new ArrayList<>(keys.size());
+        for (Map<String, AttributeValue> key : keys) {
+            writeRequests.add(WriteRequest.builder()
+                    .deleteRequest(DeleteRequest.builder().key(key).build())
+                    .build());
+        }
+        batchWrite(writeRequests);
+    }
+
+    private List<Map<String, AttributeValue>> scanAllKeys() {
+        List<Map<String, AttributeValue>> keys = new ArrayList<>();
+        Map<String, AttributeValue> lastEvaluatedKey = null;
+        try {
+            do {
+                var scanBuilder = software.amazon.awssdk.services.dynamodb.model.ScanRequest.builder()
+                        .tableName(tableName)
+                        .projectionExpression("#k")
+                        .expressionAttributeNames(Map.of("#k", keyAttribute));
+                if (lastEvaluatedKey != null && !lastEvaluatedKey.isEmpty()) {
+                    scanBuilder.exclusiveStartKey(lastEvaluatedKey);
+                }
+                var scanResponse = dynamoDbClient.scan(scanBuilder.build());
+                for (Map<String, AttributeValue> item : scanResponse.items()) {
+                    keys.add(Map.of(keyAttribute, item.get(keyAttribute)));
+                }
+                lastEvaluatedKey = scanResponse.lastEvaluatedKey();
+            } while (lastEvaluatedKey != null && !lastEvaluatedKey.isEmpty());
+        } catch (ResourceNotFoundException e) {
+            return Collections.emptyList();
+        }
+        return keys;
+    }
+
+    private boolean tableExists() {
+        try {
+            dynamoDbClient.describeTable(
+                    DescribeTableRequest.builder().tableName(tableName).build());
+            return true;
+        } catch (ResourceNotFoundException e) {
+            return false;
+        }
+    }
+
+    private void createTable(int dimension) {
+        List<SearchSchemaElement> searchSchema = new ArrayList<>();
+        for (String attribute : inlineFilterAttributes) {
+            searchSchema.add(SearchSchemaElement.builder()
+                    .attributeName(attribute)
+                    .searchSchemaElementType(SearchSchemaElementType.INLINE_FILTER)
+                    .build());
+        }
+
+        VectorIndex.Builder vectorIndexBuilder = VectorIndex.builder()
+                .indexName(indexName)
+                .vectorAttribute(VectorAttributeDefinition.builder()
+                        .attributeName(vectorAttribute)
+                        .build())
+                .dimensions((long) dimension)
+                .distanceFunction(distanceFunction)
+                .projection(
+                        Projection.builder().projectionType(ProjectionType.ALL).build());
+        if (!searchSchema.isEmpty()) {
+            vectorIndexBuilder.searchSchema(searchSchema);
+        }
+
+        CreateTableRequest request = CreateTableRequest.builder()
+                .tableName(tableName)
+                .billingMode(BillingMode.PAY_PER_REQUEST)
+                .attributeDefinitions(AttributeDefinition.builder()
+                        .attributeName(keyAttribute)
+                        .attributeType(ScalarAttributeType.S)
+                        .build())
+                .keySchema(KeySchemaElement.builder()
+                        .attributeName(keyAttribute)
+                        .keyType(KeyType.HASH)
+                        .build())
+                .vectorIndexes(vectorIndexBuilder.build())
+                .build();
+
+        dynamoDbClient.createTable(request);
+        waitForTableActive();
+    }
+
+    private void waitForTableActive() {
+        long startTime = System.nanoTime();
+        long timeoutNanos = TimeUnit.SECONDS.toNanos(SECONDS_TO_WAIT_FOR_TABLE);
+
+        while (System.nanoTime() - startTime < timeoutNanos) {
+            try {
+                DescribeTableResponse response = dynamoDbClient.describeTable(
+                        DescribeTableRequest.builder().tableName(tableName).build());
+                if (response.table().tableStatus() == TableStatus.ACTIVE) {
+                    return;
+                }
+            } catch (ResourceNotFoundException e) {
+                // table not visible yet
+            }
+            sleep(1000);
+        }
+        throw new IllegalStateException("DynamoDB table " + tableName + " and its vector index were not ACTIVE within "
+                + SECONDS_TO_WAIT_FOR_TABLE + " seconds");
+    }
+
+    private Map<String, AttributeValue> buildItem(String id, Embedding embedding, TextSegment textSegment) {
+        Map<String, AttributeValue> item = new LinkedHashMap<>();
+        item.put(keyAttribute, AttributeValue.fromS(id));
+        item.put(vectorAttribute, AttributeValue.fromL(toAttributeValues(embedding.vector())));
+
+        if (textSegment != null) {
+            item.put(textMetadataKey, AttributeValue.fromS(textSegment.text()));
+            if (textSegment.metadata() != null) {
+                textSegment.metadata().toMap().forEach((key, value) -> {
+                    if (value == null) {
+                        return;
+                    }
+                    if (key.equals(keyAttribute) || key.equals(vectorAttribute) || key.equals(textMetadataKey)) {
+                        throw new IllegalArgumentException("Metadata key '" + key
+                                + "' collides with a reserved DynamoDB attribute (id / vector / text). "
+                                + "Rename the metadata key, or configure a different keyAttribute, "
+                                + "vectorAttribute or textMetadataKey on the store.");
+                    }
+                    item.put(key, DynamoDbAttributeCodec.encode(value));
+                });
+            }
+        }
+
+        return item;
+    }
+
+    private TextSegment extractTextSegment(Map<String, AttributeValue> item) {
+        if (item == null || item.isEmpty() || !item.containsKey(textMetadataKey)) {
+            return null;
+        }
+
+        String text = item.get(textMetadataKey).s();
+        if (text == null) {
+            return null;
+        }
+
+        Map<String, Object> extractedMetadata = new HashMap<>();
+        for (Map.Entry<String, AttributeValue> entry : item.entrySet()) {
+            String key = entry.getKey();
+            if (key.equals(keyAttribute) || key.equals(vectorAttribute) || key.equals(textMetadataKey)) {
+                continue;
+            }
+            Object value = DynamoDbAttributeCodec.decode(entry.getValue());
+            if (value != null) {
+                extractedMetadata.put(key, value);
+            }
+        }
+
+        return TextSegment.from(text, extractedMetadata.isEmpty() ? new Metadata() : new Metadata(extractedMetadata));
+    }
+
+    // Manual loop avoids boxing overhead from streams
+    private List<AttributeValue> toAttributeValues(float[] array) {
+        List<AttributeValue> list = new ArrayList<>(array.length);
+        for (float f : array) {
+            list.add(AttributeValue.fromN(Float.toString(f)));
+        }
+        return list;
+    }
+
+    private double distanceToScore(Double score) {
+        if (score == null) {
+            return 0.0;
+        }
+        switch (distanceFunction) {
+            case COSINE:
+                // DynamoDB cosine score ranges from 0 (identical) to 2 (opposite): score = 1 - cosineSimilarity.
+                return RelevanceScore.fromCosineSimilarity(1.0 - score);
+            case DOT_PRODUCT:
+                // Higher is better; map into (0, 1] with a monotonic squashing function.
+                return 1.0 / (1.0 + Math.exp(-score));
+            case EUCLIDEAN:
+            default:
+                // Lower distance is better.
+                return 1.0 / (1.0 + score);
+        }
+    }
+
+    /**
+     * Closes the underlying {@link DynamoDbClient}, but only if this store created it. A client
+     * supplied via {@link Builder#dynamoDbClient(DynamoDbClient)} is owned by the caller and left open.
+     */
+    @Override
+    public void close() {
+        if (ownsClient && dynamoDbClient != null) {
+            dynamoDbClient.close();
+        }
+    }
+}

--- a/embedding-stores/langchain4j-community-dynamodb/src/main/java/dev/langchain4j/community/store/embedding/dynamodb/DynamoDbMetadataFilterMapper.java
+++ b/embedding-stores/langchain4j-community-dynamodb/src/main/java/dev/langchain4j/community/store/embedding/dynamodb/DynamoDbMetadataFilterMapper.java
@@ -1,0 +1,96 @@
+package dev.langchain4j.community.store.embedding.dynamodb;
+
+import dev.langchain4j.store.embedding.filter.Filter;
+import dev.langchain4j.store.embedding.filter.comparison.IsEqualTo;
+import dev.langchain4j.store.embedding.filter.logical.And;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+/**
+ * Maps a langchain4j {@link Filter} to a DynamoDB {@code SearchConditionExpression} for vector search.
+ *
+ * <p>DynamoDB vector search is intentionally restrictive about filtering: the search condition can
+ * reference only top-level attributes declared in the vector index search schema (the {@code HASH}
+ * key and {@code INLINE_FILTER} attributes), and those attributes support only the equality operator
+ * ({@code =}). Consequently, only {@link IsEqualTo} comparisons and {@link And} combinations of them
+ * are supported. Any other filter type results in an {@link UnsupportedOperationException}.
+ *
+ * @see <a href="https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_SearchVectors.html">SearchVectors</a>
+ */
+class DynamoDbMetadataFilterMapper {
+
+    /**
+     * The compiled DynamoDB search condition: the expression string plus the name and value
+     * substitution maps it references.
+     */
+    static final class SearchCondition {
+        final String expression;
+        final Map<String, String> expressionAttributeNames;
+        final Map<String, AttributeValue> expressionAttributeValues;
+
+        SearchCondition(
+                String expression,
+                Map<String, String> expressionAttributeNames,
+                Map<String, AttributeValue> expressionAttributeValues) {
+            this.expression = expression;
+            this.expressionAttributeNames = expressionAttributeNames;
+            this.expressionAttributeValues = expressionAttributeValues;
+        }
+    }
+
+    private DynamoDbMetadataFilterMapper() {
+        // utility class
+    }
+
+    static SearchCondition map(Filter filter) {
+        if (filter == null) {
+            return null;
+        }
+
+        Map<String, String> names = new LinkedHashMap<>();
+        Map<String, AttributeValue> values = new LinkedHashMap<>();
+        StringBuilder expression = new StringBuilder();
+
+        appendFilter(filter, expression, names, values, new int[] {0});
+
+        return new SearchCondition(expression.toString(), names, values);
+    }
+
+    private static void appendFilter(
+            Filter filter,
+            StringBuilder expression,
+            Map<String, String> names,
+            Map<String, AttributeValue> values,
+            int[] counter) {
+        if (filter instanceof IsEqualTo isEqualTo) {
+            appendEqual(isEqualTo, expression, names, values, counter);
+        } else if (filter instanceof And and) {
+            appendFilter(and.left(), expression, names, values, counter);
+            expression.append(" AND ");
+            appendFilter(and.right(), expression, names, values, counter);
+        } else {
+            throw new UnsupportedOperationException("DynamoDB vector search only supports equality (IsEqualTo) filters "
+                    + "combined with AND. Unsupported filter type: "
+                    + filter.getClass().getName());
+        }
+    }
+
+    private static void appendEqual(
+            IsEqualTo filter,
+            StringBuilder expression,
+            Map<String, String> names,
+            Map<String, AttributeValue> values,
+            int[] counter) {
+        int index = counter[0]++;
+        String namePlaceholder = "#k" + index;
+        String valuePlaceholder = ":v" + index;
+
+        names.put(namePlaceholder, filter.key());
+        // Encode filter values with the same codec the store uses when writing metadata, so a filter
+        // on a float/double (persisted as a tagged string) still matches the stored value.
+        values.put(valuePlaceholder, DynamoDbAttributeCodec.encode(filter.comparisonValue()));
+
+        expression.append(namePlaceholder).append(" = ").append(valuePlaceholder);
+    }
+}

--- a/embedding-stores/langchain4j-community-dynamodb/src/test/java/dev/langchain4j/community/store/embedding/dynamodb/DynamoDbAttributeCodecTest.java
+++ b/embedding-stores/langchain4j-community-dynamodb/src/test/java/dev/langchain4j/community/store/embedding/dynamodb/DynamoDbAttributeCodecTest.java
@@ -1,0 +1,74 @@
+package dev.langchain4j.community.store.embedding.dynamodb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+class DynamoDbAttributeCodecTest {
+
+    @Test
+    void should_round_trip_string() {
+        assertRoundTrip("hello", "hello");
+    }
+
+    @Test
+    void should_round_trip_integer_as_native_number() {
+        AttributeValue encoded = DynamoDbAttributeCodec.encode(42);
+        assertThat(encoded.n()).isEqualTo("42");
+        assertThat(DynamoDbAttributeCodec.decode(encoded)).isEqualTo(42);
+    }
+
+    @Test
+    void should_round_trip_long_as_native_number() {
+        long value = 9_000_000_000L;
+        AttributeValue encoded = DynamoDbAttributeCodec.encode(value);
+        assertThat(encoded.n()).isEqualTo("9000000000");
+        assertThat(DynamoDbAttributeCodec.decode(encoded)).isEqualTo(value);
+    }
+
+    @Test
+    void should_round_trip_boolean() {
+        AttributeValue encoded = DynamoDbAttributeCodec.encode(true);
+        assertThat(encoded.bool()).isTrue();
+        assertThat(DynamoDbAttributeCodec.decode(encoded)).isEqualTo(true);
+    }
+
+    @Test
+    void should_round_trip_float_as_tagged_string() {
+        AttributeValue encoded = DynamoDbAttributeCodec.encode(1.5f);
+        assertThat(encoded.n()).isNull();
+        assertThat(DynamoDbAttributeCodec.decode(encoded)).isEqualTo(1.5f);
+    }
+
+    @Test
+    void should_round_trip_subnormal_double_that_dynamodb_number_cannot_store() {
+        // Double.MIN_VALUE underflows DynamoDB's Number type; the tagged-string encoding preserves it.
+        AttributeValue encoded = DynamoDbAttributeCodec.encode(Double.MIN_VALUE);
+        assertThat(encoded.n()).isNull();
+        assertThat(DynamoDbAttributeCodec.decode(encoded)).isEqualTo(Double.MIN_VALUE);
+    }
+
+    @Test
+    void should_round_trip_float_min_value() {
+        AttributeValue encoded = DynamoDbAttributeCodec.encode(Float.MIN_VALUE);
+        assertThat(DynamoDbAttributeCodec.decode(encoded)).isEqualTo(Float.MIN_VALUE);
+    }
+
+    @Test
+    void should_escape_plain_string_that_collides_with_float_tag() {
+        String tricky = DynamoDbAttributeCodec.FLOAT_PREFIX + "1.5";
+        assertRoundTrip(tricky, tricky);
+    }
+
+    @Test
+    void should_escape_plain_string_that_collides_with_string_tag() {
+        String tricky = DynamoDbAttributeCodec.STRING_PREFIX + "abc";
+        assertRoundTrip(tricky, tricky);
+    }
+
+    private static void assertRoundTrip(String input, String expected) {
+        AttributeValue encoded = DynamoDbAttributeCodec.encode(input);
+        assertThat(DynamoDbAttributeCodec.decode(encoded)).isEqualTo(expected);
+    }
+}

--- a/embedding-stores/langchain4j-community-dynamodb/src/test/java/dev/langchain4j/community/store/embedding/dynamodb/DynamoDbEmbeddingStoreIT.java
+++ b/embedding-stores/langchain4j-community-dynamodb/src/test/java/dev/langchain4j/community/store/embedding/dynamodb/DynamoDbEmbeddingStoreIT.java
@@ -1,0 +1,91 @@
+package dev.langchain4j.community.store.embedding.dynamodb;
+
+import static org.assertj.core.data.Percentage.withPercentage;
+
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.embedding.onnx.allminilml6v2q.AllMiniLmL6V2QuantizedEmbeddingModel;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import dev.langchain4j.store.embedding.EmbeddingStoreIT;
+import java.util.UUID;
+import org.assertj.core.data.Percentage;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.DeleteTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.VectorDistanceFunction;
+
+@EnabledIfEnvironmentVariable(named = "AWS_INTEGRATION_TESTS", matches = "(?i)true")
+class DynamoDbEmbeddingStoreIT extends EmbeddingStoreIT {
+
+    private static final String TEST_TABLE_PREFIX = "langchain4j-test-";
+    private static final String TEST_INDEX_PREFIX = "test-index-";
+
+    private static DynamoDbEmbeddingStore embeddingStore;
+    private static DynamoDbClient dynamoDbClient;
+    private static String testTableName;
+
+    private static final EmbeddingModel embeddingModel = new AllMiniLmL6V2QuantizedEmbeddingModel();
+
+    @BeforeAll
+    static void beforeAll() {
+        testTableName = TEST_TABLE_PREFIX + UUID.randomUUID().toString().substring(0, 8);
+        String testIndexName = TEST_INDEX_PREFIX + UUID.randomUUID().toString().substring(0, 8);
+
+        String region = System.getenv("AWS_REGION");
+        if (region == null || region.isBlank()) {
+            region = "us-east-1";
+        }
+
+        dynamoDbClient = DynamoDbClient.builder().region(Region.of(region)).build();
+
+        embeddingStore = DynamoDbEmbeddingStore.builder()
+                .tableName(testTableName)
+                .indexName(testIndexName)
+                .region(region)
+                .distanceFunction(VectorDistanceFunction.COSINE)
+                .createTableIfNotExists(true)
+                .build();
+    }
+
+    @AfterAll
+    static void afterAll() {
+        if (dynamoDbClient != null) {
+            try {
+                dynamoDbClient.deleteTable(
+                        DeleteTableRequest.builder().tableName(testTableName).build());
+            } catch (Exception e) {
+                // Cleanup may fail if the table does not exist
+            }
+            dynamoDbClient.close();
+        }
+    }
+
+    @Override
+    protected EmbeddingStore<TextSegment> embeddingStore() {
+        return embeddingStore;
+    }
+
+    @Override
+    protected EmbeddingModel embeddingModel() {
+        return embeddingModel;
+    }
+
+    @Override
+    protected void clearStore() {
+        embeddingStore.removeAll();
+    }
+
+    @Override
+    protected boolean assertEmbedding() {
+        // The store does not return embedding vectors in search results.
+        return false;
+    }
+
+    @Override
+    protected Percentage percentage() {
+        return withPercentage(6);
+    }
+}

--- a/embedding-stores/langchain4j-community-dynamodb/src/test/java/dev/langchain4j/community/store/embedding/dynamodb/DynamoDbEmbeddingStoreRemovalIT.java
+++ b/embedding-stores/langchain4j-community-dynamodb/src/test/java/dev/langchain4j/community/store/embedding/dynamodb/DynamoDbEmbeddingStoreRemovalIT.java
@@ -1,0 +1,87 @@
+package dev.langchain4j.community.store.embedding.dynamodb;
+
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.embedding.onnx.allminilml6v2q.AllMiniLmL6V2QuantizedEmbeddingModel;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import dev.langchain4j.store.embedding.EmbeddingStoreWithRemovalIT;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.DeleteTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.VectorDistanceFunction;
+
+@EnabledIfEnvironmentVariable(named = "AWS_INTEGRATION_TESTS", matches = "(?i)true")
+class DynamoDbEmbeddingStoreRemovalIT extends EmbeddingStoreWithRemovalIT {
+
+    private static final String TEST_TABLE_PREFIX = "langchain4j-removal-test-";
+    private static final String TEST_INDEX_PREFIX = "removal-test-index-";
+
+    private static DynamoDbEmbeddingStore embeddingStore;
+    private static DynamoDbClient dynamoDbClient;
+    private static String testTableName;
+
+    private static final EmbeddingModel embeddingModel = new AllMiniLmL6V2QuantizedEmbeddingModel();
+
+    @BeforeAll
+    static void beforeAll() {
+        testTableName = TEST_TABLE_PREFIX + UUID.randomUUID().toString().substring(0, 8);
+        String testIndexName = TEST_INDEX_PREFIX + UUID.randomUUID().toString().substring(0, 8);
+
+        String region = System.getenv("AWS_REGION");
+        if (region == null || region.isBlank()) {
+            region = "us-east-1";
+        }
+
+        dynamoDbClient = DynamoDbClient.builder().region(Region.of(region)).build();
+
+        embeddingStore = DynamoDbEmbeddingStore.builder()
+                .tableName(testTableName)
+                .indexName(testIndexName)
+                .region(region)
+                .distanceFunction(VectorDistanceFunction.COSINE)
+                .createTableIfNotExists(true)
+                .build();
+    }
+
+    @AfterAll
+    static void afterAll() {
+        if (dynamoDbClient != null) {
+            try {
+                dynamoDbClient.deleteTable(
+                        DeleteTableRequest.builder().tableName(testTableName).build());
+            } catch (Exception e) {
+                // Cleanup may fail if the table does not exist
+            }
+            dynamoDbClient.close();
+        }
+    }
+
+    @AfterEach
+    void afterEach() {
+        embeddingStore.removeAll();
+    }
+
+    @Override
+    protected EmbeddingStore<TextSegment> embeddingStore() {
+        return embeddingStore;
+    }
+
+    @Override
+    protected EmbeddingModel embeddingModel() {
+        return embeddingModel;
+    }
+
+    /**
+     * DynamoDB vector search does not support filter-based deletion.
+     * Only deletion by specific ids is supported.
+     */
+    @Override
+    protected boolean supportsRemoveAllByFilter() {
+        return false;
+    }
+}

--- a/embedding-stores/langchain4j-community-dynamodb/src/test/java/dev/langchain4j/community/store/embedding/dynamodb/DynamoDbMetadataFilterMapperTest.java
+++ b/embedding-stores/langchain4j-community-dynamodb/src/test/java/dev/langchain4j/community/store/embedding/dynamodb/DynamoDbMetadataFilterMapperTest.java
@@ -1,0 +1,126 @@
+package dev.langchain4j.community.store.embedding.dynamodb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import dev.langchain4j.store.embedding.filter.Filter;
+import dev.langchain4j.store.embedding.filter.comparison.IsEqualTo;
+import dev.langchain4j.store.embedding.filter.comparison.IsGreaterThan;
+import dev.langchain4j.store.embedding.filter.logical.And;
+import dev.langchain4j.store.embedding.filter.logical.Or;
+import org.junit.jupiter.api.Test;
+
+class DynamoDbMetadataFilterMapperTest {
+
+    @Test
+    void should_return_null_for_null_filter() {
+        assertThat(DynamoDbMetadataFilterMapper.map(null)).isNull();
+    }
+
+    @Test
+    void should_map_equal_with_string() {
+        IsEqualTo filter = new IsEqualTo("genre", "scifi");
+
+        DynamoDbMetadataFilterMapper.SearchCondition condition = DynamoDbMetadataFilterMapper.map(filter);
+
+        assertThat(condition.expression).isEqualTo("#k0 = :v0");
+        assertThat(condition.expressionAttributeNames).containsEntry("#k0", "genre");
+        assertThat(condition.expressionAttributeValues.get(":v0").s()).isEqualTo("scifi");
+    }
+
+    @Test
+    void should_map_equal_with_number() {
+        IsEqualTo filter = new IsEqualTo("rating", 5);
+
+        DynamoDbMetadataFilterMapper.SearchCondition condition = DynamoDbMetadataFilterMapper.map(filter);
+
+        assertThat(condition.expression).isEqualTo("#k0 = :v0");
+        assertThat(condition.expressionAttributeNames).containsEntry("#k0", "rating");
+        assertThat(condition.expressionAttributeValues.get(":v0").n()).isEqualTo("5");
+    }
+
+    @Test
+    void should_map_equal_with_boolean() {
+        IsEqualTo filter = new IsEqualTo("active", true);
+
+        DynamoDbMetadataFilterMapper.SearchCondition condition = DynamoDbMetadataFilterMapper.map(filter);
+
+        assertThat(condition.expressionAttributeValues.get(":v0").bool()).isTrue();
+    }
+
+    @Test
+    void should_encode_float_filter_as_tagged_string_matching_storage() {
+        // Floats are persisted as tagged strings (DynamoDB Number underflows on subnormals), so a
+        // filter value must be encoded the same way or it would never match the stored value.
+        IsEqualTo filter = new IsEqualTo("score", 1.5f);
+
+        DynamoDbMetadataFilterMapper.SearchCondition condition = DynamoDbMetadataFilterMapper.map(filter);
+
+        assertThat(condition.expressionAttributeValues.get(":v0").n()).isNull();
+        assertThat(condition.expressionAttributeValues.get(":v0").s())
+                .isEqualTo(DynamoDbAttributeCodec.FLOAT_PREFIX + "1.5");
+    }
+
+    @Test
+    void should_encode_double_filter_as_tagged_string_matching_storage() {
+        IsEqualTo filter = new IsEqualTo("score", 1.5d);
+
+        DynamoDbMetadataFilterMapper.SearchCondition condition = DynamoDbMetadataFilterMapper.map(filter);
+
+        assertThat(condition.expressionAttributeValues.get(":v0").n()).isNull();
+        assertThat(condition.expressionAttributeValues.get(":v0").s())
+                .isEqualTo(DynamoDbAttributeCodec.DOUBLE_PREFIX + "1.5");
+    }
+
+    @Test
+    void should_map_and_of_equals() {
+        And filter = new And(new IsEqualTo("genre", "scifi"), new IsEqualTo("year", 2020));
+
+        DynamoDbMetadataFilterMapper.SearchCondition condition = DynamoDbMetadataFilterMapper.map(filter);
+
+        assertThat(condition.expression).isEqualTo("#k0 = :v0 AND #k1 = :v1");
+        assertThat(condition.expressionAttributeNames)
+                .containsEntry("#k0", "genre")
+                .containsEntry("#k1", "year");
+        assertThat(condition.expressionAttributeValues.get(":v0").s()).isEqualTo("scifi");
+        assertThat(condition.expressionAttributeValues.get(":v1").n()).isEqualTo("2020");
+    }
+
+    @Test
+    void should_map_nested_and() {
+        And filter = new And(new IsEqualTo("a", "1"), new And(new IsEqualTo("b", "2"), new IsEqualTo("c", "3")));
+
+        DynamoDbMetadataFilterMapper.SearchCondition condition = DynamoDbMetadataFilterMapper.map(filter);
+
+        assertThat(condition.expression).isEqualTo("#k0 = :v0 AND #k1 = :v1 AND #k2 = :v2");
+        assertThat(condition.expressionAttributeNames).hasSize(3);
+        assertThat(condition.expressionAttributeValues).hasSize(3);
+    }
+
+    @Test
+    void should_throw_for_greater_than() {
+        IsGreaterThan filter = new IsGreaterThan("rating", 4);
+
+        assertThatThrownBy(() -> DynamoDbMetadataFilterMapper.map(filter))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("only supports equality");
+    }
+
+    @Test
+    void should_throw_for_or() {
+        Or filter = new Or(new IsEqualTo("genre", "scifi"), new IsEqualTo("genre", "fantasy"));
+
+        assertThatThrownBy(() -> DynamoDbMetadataFilterMapper.map(filter))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("only supports equality");
+    }
+
+    @Test
+    void should_throw_for_unsupported_filter_type() {
+        Filter customFilter = object -> false;
+
+        assertThatThrownBy(() -> DynamoDbMetadataFilterMapper.map(customFilter))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("Unsupported filter type");
+    }
+}

--- a/langchain4j-community-bom/pom.xml
+++ b/langchain4j-community-bom/pom.xml
@@ -164,6 +164,12 @@
 
             <dependency>
                 <groupId>dev.langchain4j</groupId>
+                <artifactId>langchain4j-community-dynamodb</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>dev.langchain4j</groupId>
                 <artifactId>langchain4j-community-valkey</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
         <module>embedding-stores/langchain4j-community-oceanbase</module>
         <module>embedding-stores/langchain4j-community-jvector</module>
         <module>embedding-stores/langchain4j-community-s3-vectors</module>
+        <module>embedding-stores/langchain4j-community-dynamodb</module>
         <module>embedding-stores/langchain4j-community-valkey</module>
         <module>embedding-stores/langchain4j-community-lancedb</module>
 


### PR DESCRIPTION
## Change

Adds a new embedding store integration: **`langchain4j-community-dynamodb`**, an `EmbeddingStore<TextSegment>` backed by Amazon DynamoDB's **native vector search**. This is a strategic addition as it complements the already present support for Amazon S3 Vectors. While Amazon S3 Vectors is recommended for infrequent queries, Amazon DynamoDB is recommended for scenarios where single-digit millisecond latency at 99%+ recall is needed.

Highlights:

- **Native vector search.** Each embedding is stored as a single DynamoDB item whose partition key is the embedding id; the vector is stored as a list of numbers under a configurable attribute and indexed by a DynamoDB vector index. Supports the `COSINE`, `EUCLIDEAN` and `DOT_PRODUCT` distance functions and vectors up to 4096 dimensions. `maxResults` is capped at DynamoDB's `TopK` limit of 100.
- **Metadata.** Stored per-attribute. Integer/long values use the native DynamoDB `Number` type; float and double values are stored as tagged strings, because DynamoDB's `Number` type underflows on subnormal magnitudes (e.g. `Double.MIN_VALUE`). A single `DynamoDbAttributeCodec` is shared by the write path and the filter mapper so equality filters on float/double values still match the persisted representation.
- **Filtering.** DynamoDB vector search only filters on attributes declared in the index search schema (the `HASH` key and `INLINE_FILTER` attributes, fixed at index creation) and only with equality. Accordingly, `IsEqualTo` filters (optionally combined with `And`) are mapped to a `SearchConditionExpression`; other filter types throw `UnsupportedOperationException`. `removeAll(Filter)` is likewise unsupported.
- **Robustness.** Metadata keys colliding with the reserved id/vector/text attributes are rejected on write; `BatchWriteItem` retries unprocessed items with capped exponential backoff; table activation waits with a timeout; and a caller-supplied `DynamoDbClient` is not closed by the store.

Also registers the module in the root `pom.xml` and `langchain4j-community-bom/pom.xml`.

## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [X] There are no breaking changes
- [X] I have added unit and integration tests for my change
- [X] I have manually run all the unit tests in _all_ modules, and they are all green
- [X] I have manually run all integration tests in the module I have added/changed, and they are all green
<!-- Before adding [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs) and example(s) (below), please wait until the PR is reviewed and approved. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [[examples repo](https://github.com/langchain4j/langchain4j-examples)](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [[Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring)](https://github.com/langchain4j/langchain4j-spring) (if applicable)


## Checklist for adding new maven module
<!-- Please double-check the following points and mark them like this: [X] -->
- [X] I have added my new module in the root `pom.xml` and `langchain4j-community-bom/pom.xml`


## Checklist for adding new embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [X] I have added a `DynamoDbEmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [X] I have added a `DynamoDbEmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`