### PR TITLE
Release workflow: fail fast if the version is already on Maven Central, and surface the failure reason

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,12 +23,38 @@ jobs:
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg-passphrase: GPG_PASSPHRASE
 
+      - name: Check that the version is not on Maven Central yet
+        run: |
+          VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          POM="https://repo1.maven.org/maven2/dev/langchain4j/langchain4j-community-core/$VERSION/langchain4j-community-core-$VERSION.pom"
+          if curl -sfI "$POM" > /dev/null; then
+            echo "::error::$VERSION is already on Maven Central. Maven Central is immutable, so it cannot be released again. Bump the version instead of re-running this workflow."
+            exit 1
+          fi
+          echo "$VERSION is not on Maven Central yet, proceeding"
+
       - name: release
         run: |
+          set -o pipefail
           mvn -B -U --fail-at-end \
             -DskipTests -DskipITs -Psign \
-            clean deploy
+            clean deploy 2>&1 | tee release.log
         env:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+
+      - name: Show why the release failed
+        if: failure()
+        run: |
+          {
+            echo '## Release failed'
+            echo '```'
+            # Sonatype Central reports rejected components a few hundred lines before the end of the build
+            if grep -q 'Deployment .* failed' release.log; then
+              sed -n '/Deployment .* failed/,$p' release.log | head -n 200
+            else
+              tail -n 100 release.log
+            fi
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Issue

Follow-up to #750 (release of `1.19.0-beta29`).

That release was reported as failed although it had actually succeeded. Two things made this hard to see:

1. The first attempt uploaded the bundle to Sonatype Central successfully, but `central-publishing-maven-plugin` gave up waiting for the deployment to reach the `published` state and failed the build after 60 minutes:

   ```
   [ERROR] Failed to execute goal org.sonatype.central:central-publishing-maven-plugin:0.10.0:publish
   (injected-central-publishing) on project langchain4j-community-arcadedb: ...
   Polling for 8823cd89-7b8d-435e-9537-208ac0ed7965 timed out before the deployment completed.
   ```

   Central published all 80 components anyway (verified on `repo1.maven.org`).

2. Every re-run after that was doomed. Maven Central is immutable, so re-uploading the same version is rejected with `Component with package url: '...' already exists` for all 80 components. Those runs still spent ~8 minutes building before failing in the last ~30 seconds, and the GitHub annotation truncates the error mid-word, so the actual reason sits several hundred lines deep in a 27k-line log.

## Change

Two changes to `.github/workflows/release.yaml`:

1. **Fail fast when the version is already released.** Before building, check whether `langchain4j-community-core` for the current project version is already on Maven Central, and stop immediately with an explicit message if it is. This turns a doomed 8-minute build into a 2-second failure that says what to do (bump the version rather than re-run the workflow).

2. **Show why the release failed.** The Maven output is teed to `release.log` (with `set -o pipefail`, so the step still fails when Maven fails), and on failure the Sonatype Central deployment report — or the tail of the build — is written to the GitHub step summary. The reason is then visible on the run page without opening the raw log.

The summary step was tested against the real logs of the failed `1.19.0-beta29` runs and renders both failure modes correctly: the per-component `already exists` report, and the polling timeout.

### Notes and limitations

- The pre-flight check queries `repo1.maven.org`, which lags Sonatype Central. It is a fast-fail heuristic, not a guarantee — Central's own validation remains the authority.
- This PR does not fix the root cause, i.e. the release job waiting up to an hour for Central to finish publishing. That is configured in `langchain4j-parent` (`<waitUntil>published</waitUntil>` with `<waitMaxTime>3600</waitMaxTime>`) and therefore affects `langchain4j/langchain4j` as well, so it is better handled in a separate PR.

## General checklist

- [X] There are no breaking changes
- [X] I have added unit and integration tests for my change — N/A, this is a CI workflow change with no production code
- [X] I have manually run all the unit tests in _all_ modules, and they are all green — N/A, see above
- [X] I have manually run all integration tests in the module I have added/changed, and they are all green — N/A, see above
- [X] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs) — N/A
- [X] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features) — N/A
- [X] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable) — N/A
