### PR TITLE
fix: adapt model-router to the new reactive StreamingChatModel API

### DIFF
--- a/models/langchain4j-community-model-router/revapi.json
+++ b/models/langchain4j-community-model-router/revapi.json
@@ -1,0 +1,94 @@
+[
+  {
+    "extension": "revapi.differences",
+    "configuration": {
+      "ignore": true,
+      "differences": [
+        {
+          "code": "java.method.removed",
+          "old": "method void dev.langchain4j.model.router.ChatModelWrapper::<init>(dev.langchain4j.model.chat.StreamingChatModel)",
+          "justification": "Adaptation to the reactive StreamingChatModel API from langchain4j/langchain4j#5527: ChatModel and StreamingChatModel now declare conflicting chat(...)/doChat(...) signatures, so streaming models are wrapped by the new StreamingChatModelWrapper instead. The module is @Experimental; see issue #775."
+        },
+        {
+          "code": "java.method.removed",
+          "old": "method void dev.langchain4j.model.router.ChatModelWrapper::doChat(dev.langchain4j.model.chat.request.ChatRequest, dev.langchain4j.model.chat.response.StreamingChatResponseHandler)",
+          "justification": "Adaptation to the reactive StreamingChatModel API from langchain4j/langchain4j#5527: streaming support moved to the new StreamingChatModelWrapper. The module is @Experimental; see issue #775."
+        },
+        {
+          "code": "java.method.removed",
+          "old": "method boolean dev.langchain4j.model.router.ChatModelWrapper::isStreaming()",
+          "justification": "Adaptation to the reactive StreamingChatModel API from langchain4j/langchain4j#5527: wrappers now wrap exactly one kind of model, so the streaming flag is obsolete. The module is @Experimental; see issue #775."
+        },
+        {
+          "code": "java.class.nonFinalClassInheritsFromNewClass",
+          "old": "class dev.langchain4j.model.router.ChatModelWrapper",
+          "new": "class dev.langchain4j.model.router.ChatModelWrapper",
+          "justification": "ChatModelWrapper now extends the new ModelWrapper base class, which only extracts members that already existed on ChatModelWrapper (routing metadata and wrapper listeners). Part of the adaptation to langchain4j/langchain4j#5527; see issue #775."
+        },
+        {
+          "code": "java.method.removed",
+          "old": "method dev.langchain4j.model.router.ModelRouter.Builder dev.langchain4j.model.router.ModelRouter.Builder::addRoutes(dev.langchain4j.model.chat.StreamingChatModel[])",
+          "justification": "Adaptation to the reactive StreamingChatModel API from langchain4j/langchain4j#5527: streaming routes are now added via the new StreamingModelRouter.Builder instead. The module is @Experimental; see issue #775."
+        },
+        {
+          "code": "java.method.removed",
+          "old": "method dev.langchain4j.model.router.ModelRouter.Builder dev.langchain4j.model.router.ModelRouter.Builder::defaultRoute(dev.langchain4j.model.chat.StreamingChatModel)",
+          "justification": "Adaptation to the reactive StreamingChatModel API from langchain4j/langchain4j#5527: the streaming default route is now configured via the new StreamingModelRouter.Builder instead. The module is @Experimental; see issue #775."
+        },
+        {
+          "code": "java.method.removed",
+          "old": "method void dev.langchain4j.model.router.ModelRouter::doChat(dev.langchain4j.model.chat.request.ChatRequest, dev.langchain4j.model.chat.response.StreamingChatResponseHandler)",
+          "justification": "Adaptation to the reactive StreamingChatModel API from langchain4j/langchain4j#5527: streaming routing moved to the new StreamingModelRouter. The module is @Experimental; see issue #775."
+        },
+        {
+          "code": "java.method.parameterTypeParameterChanged",
+          "old": "parameter dev.langchain4j.model.router.ChatModelWrapper dev.langchain4j.model.router.DelegatingModelRoutingStrategy::delegateRoute(===java.util.List<dev.langchain4j.model.router.ChatModelWrapper>===, dev.langchain4j.model.chat.request.ChatRequest)",
+          "new": "parameter dev.langchain4j.model.router.ModelWrapper dev.langchain4j.model.router.DelegatingModelRoutingStrategy::delegateRoute(===java.util.List<? extends dev.langchain4j.model.router.ModelWrapper>===, dev.langchain4j.model.chat.request.ChatRequest)",
+          "justification": "Routing strategies were generalized from List<ChatModelWrapper> to List<? extends ModelWrapper> so the same strategy can be used with both ModelRouter and the new StreamingModelRouter. Part of the adaptation to langchain4j/langchain4j#5527; see issue #775."
+        },
+        {
+          "code": "java.method.parameterTypeParameterChanged",
+          "old": "parameter dev.langchain4j.model.router.ChatModelWrapper dev.langchain4j.model.router.FailoverStrategy::route(===java.util.List<dev.langchain4j.model.router.ChatModelWrapper>===, dev.langchain4j.model.chat.request.ChatRequest)",
+          "new": "parameter dev.langchain4j.model.router.ModelWrapper dev.langchain4j.model.router.FailoverStrategy::route(===java.util.List<? extends dev.langchain4j.model.router.ModelWrapper>===, dev.langchain4j.model.chat.request.ChatRequest)",
+          "justification": "Routing strategies were generalized from List<ChatModelWrapper> to List<? extends ModelWrapper> so the same strategy can be used with both ModelRouter and the new StreamingModelRouter. Part of the adaptation to langchain4j/langchain4j#5527; see issue #775."
+        },
+        {
+          "code": "java.method.parameterTypeParameterChanged",
+          "old": "parameter dev.langchain4j.model.router.ChatModelWrapper dev.langchain4j.model.router.LowestTokenUsageRoutingStrategy::route(===java.util.List<dev.langchain4j.model.router.ChatModelWrapper>===, dev.langchain4j.model.chat.request.ChatRequest)",
+          "new": "parameter dev.langchain4j.model.router.ModelWrapper dev.langchain4j.model.router.LowestTokenUsageRoutingStrategy::route(===java.util.List<? extends dev.langchain4j.model.router.ModelWrapper>===, dev.langchain4j.model.chat.request.ChatRequest)",
+          "justification": "Routing strategies were generalized from List<ChatModelWrapper> to List<? extends ModelWrapper> so the same strategy can be used with both ModelRouter and the new StreamingModelRouter. Part of the adaptation to langchain4j/langchain4j#5527; see issue #775."
+        },
+        {
+          "code": "java.method.parameterTypeParameterChanged",
+          "old": "parameter dev.langchain4j.model.router.ChatModelWrapper dev.langchain4j.model.router.ModelRoutingStrategy::route(===java.util.List<dev.langchain4j.model.router.ChatModelWrapper>===, dev.langchain4j.model.chat.request.ChatRequest)",
+          "new": "parameter dev.langchain4j.model.router.ModelWrapper dev.langchain4j.model.router.ModelRoutingStrategy::route(===java.util.List<? extends dev.langchain4j.model.router.ModelWrapper>===, dev.langchain4j.model.chat.request.ChatRequest)",
+          "justification": "Routing strategies were generalized from List<ChatModelWrapper> to List<? extends ModelWrapper> so the same strategy can be used with both ModelRouter and the new StreamingModelRouter. Part of the adaptation to langchain4j/langchain4j#5527; see issue #775."
+        },
+        {
+          "code": "java.method.returnTypeChanged",
+          "old": "method dev.langchain4j.model.router.ChatModelWrapper dev.langchain4j.model.router.DelegatingModelRoutingStrategy::delegateRoute(java.util.List<dev.langchain4j.model.router.ChatModelWrapper>, dev.langchain4j.model.chat.request.ChatRequest)",
+          "new": "method dev.langchain4j.model.router.ModelWrapper dev.langchain4j.model.router.DelegatingModelRoutingStrategy::delegateRoute(java.util.List<? extends dev.langchain4j.model.router.ModelWrapper>, dev.langchain4j.model.chat.request.ChatRequest)",
+          "justification": "Routing strategies were generalized to return ModelWrapper instead of ChatModelWrapper so the same strategy can be used with both ModelRouter and the new StreamingModelRouter. Part of the adaptation to langchain4j/langchain4j#5527; see issue #775."
+        },
+        {
+          "code": "java.method.returnTypeChanged",
+          "old": "method dev.langchain4j.model.router.ChatModelWrapper dev.langchain4j.model.router.FailoverStrategy::route(java.util.List<dev.langchain4j.model.router.ChatModelWrapper>, dev.langchain4j.model.chat.request.ChatRequest)",
+          "new": "method dev.langchain4j.model.router.ModelWrapper dev.langchain4j.model.router.FailoverStrategy::route(java.util.List<? extends dev.langchain4j.model.router.ModelWrapper>, dev.langchain4j.model.chat.request.ChatRequest)",
+          "justification": "Routing strategies were generalized to return ModelWrapper instead of ChatModelWrapper so the same strategy can be used with both ModelRouter and the new StreamingModelRouter. Part of the adaptation to langchain4j/langchain4j#5527; see issue #775."
+        },
+        {
+          "code": "java.method.returnTypeChanged",
+          "old": "method dev.langchain4j.model.router.ChatModelWrapper dev.langchain4j.model.router.LowestTokenUsageRoutingStrategy::route(java.util.List<dev.langchain4j.model.router.ChatModelWrapper>, dev.langchain4j.model.chat.request.ChatRequest)",
+          "new": "method dev.langchain4j.model.router.ModelWrapper dev.langchain4j.model.router.LowestTokenUsageRoutingStrategy::route(java.util.List<? extends dev.langchain4j.model.router.ModelWrapper>, dev.langchain4j.model.chat.request.ChatRequest)",
+          "justification": "Routing strategies were generalized to return ModelWrapper instead of ChatModelWrapper so the same strategy can be used with both ModelRouter and the new StreamingModelRouter. Part of the adaptation to langchain4j/langchain4j#5527; see issue #775."
+        },
+        {
+          "code": "java.method.returnTypeChanged",
+          "old": "method dev.langchain4j.model.router.ChatModelWrapper dev.langchain4j.model.router.ModelRoutingStrategy::route(java.util.List<dev.langchain4j.model.router.ChatModelWrapper>, dev.langchain4j.model.chat.request.ChatRequest)",
+          "new": "method dev.langchain4j.model.router.ModelWrapper dev.langchain4j.model.router.ModelRoutingStrategy::route(java.util.List<? extends dev.langchain4j.model.router.ModelWrapper>, dev.langchain4j.model.chat.request.ChatRequest)",
+          "justification": "Routing strategies were generalized to return ModelWrapper instead of ChatModelWrapper so the same strategy can be used with both ModelRouter and the new StreamingModelRouter. Part of the adaptation to langchain4j/langchain4j#5527; see issue #775."
+        }
+      ]
+    }
+  }
+]

--- a/models/langchain4j-community-model-router/src/main/java/dev/langchain4j/model/router/DelegatingModelRoutingStrategy.java
+++ b/models/langchain4j-community-model-router/src/main/java/dev/langchain4j/model/router/DelegatingModelRoutingStrategy.java
@@ -21,7 +21,7 @@ public abstract class DelegatingModelRoutingStrategy implements ModelRoutingStra
         this.delegate = delegate;
     }
 
-    protected ChatModelWrapper delegateRoute(List<ChatModelWrapper> availableModels, ChatRequest chatRequest) {
+    protected ModelWrapper delegateRoute(List<? extends ModelWrapper> availableModels, ChatRequest chatRequest) {
         if (delegate == null) {
             return null;
         }

--- a/models/langchain4j-community-model-router/src/main/java/dev/langchain4j/model/router/FailoverStrategy.java
+++ b/models/langchain4j-community-model-router/src/main/java/dev/langchain4j/model/router/FailoverStrategy.java
@@ -54,19 +54,20 @@ public class FailoverStrategy extends DelegatingModelRoutingStrategy {
     }
 
     @Override
-    public ChatModelWrapper route(List<ChatModelWrapper> availableModels, ChatRequest chatRequest) {
+    public ModelWrapper route(List<? extends ModelWrapper> availableModels, ChatRequest chatRequest) {
+        List<ModelWrapper> models = List.copyOf(availableModels);
+
         // add FailureListener to each not already having one
-        availableModels.stream()
+        models.stream()
                 .filter(m -> m.listeners().stream().noneMatch(FailureListener.class::isInstance))
                 .forEach(m -> m.addListener(new FailureListener(m)));
 
         Instant now = Instant.now();
 
-        List<ChatModelWrapper> healthyModels = availableModels.stream()
-                .filter(entry -> !isInCooldown(entry, now))
-                .collect(Collectors.toList());
+        List<ModelWrapper> healthyModels =
+                models.stream().filter(entry -> !isInCooldown(entry, now)).collect(Collectors.toList());
         // try to delegate
-        ChatModelWrapper target = delegateRoute(healthyModels, chatRequest);
+        ModelWrapper target = delegateRoute(healthyModels, chatRequest);
         // it not, use first healthy model
         if (target == null && !healthyModels.isEmpty()) {
             target = healthyModels.iterator().next();
@@ -74,7 +75,7 @@ public class FailoverStrategy extends DelegatingModelRoutingStrategy {
         return target;
     }
 
-    private boolean isInCooldown(ChatModelWrapper model, Instant now) {
+    private boolean isInCooldown(ModelWrapper model, Instant now) {
         Object failedValue = model.getMetadata(FAILED);
         if (!(failedValue instanceof Boolean) || !((Boolean) failedValue)) {
             return false;
@@ -99,9 +100,9 @@ public class FailoverStrategy extends DelegatingModelRoutingStrategy {
      */
     class FailureListener implements ChatModelListener {
 
-        private ChatModelWrapper wrapper;
+        private ModelWrapper wrapper;
         // we need to remember the wrapper as the listener does not have access to the model
-        public FailureListener(ChatModelWrapper wrapper) {
+        public FailureListener(ModelWrapper wrapper) {
             this.wrapper = wrapper;
         }
 

--- a/models/langchain4j-community-model-router/src/main/java/dev/langchain4j/model/router/LowestTokenUsageRoutingStrategy.java
+++ b/models/langchain4j-community-model-router/src/main/java/dev/langchain4j/model/router/LowestTokenUsageRoutingStrategy.java
@@ -22,16 +22,18 @@ public class LowestTokenUsageRoutingStrategy implements ModelRoutingStrategy {
     public static final String TOTAL_TOKEN_USAGE = "TOTAL_TOKEN_USAGE";
 
     @Override
-    public ChatModelWrapper route(List<ChatModelWrapper> availableModels, ChatRequest chatRequest) {
+    public ModelWrapper route(List<? extends ModelWrapper> availableModels, ChatRequest chatRequest) {
+        List<ModelWrapper> models = List.copyOf(availableModels);
+
         // add FailureListener to each not already having one
-        availableModels.stream()
+        models.stream()
                 .filter(m -> m.listeners().stream().noneMatch(UsageTrackerListener.class::isInstance))
                 .forEach(m -> m.addListener(new UsageTrackerListener(m)));
 
-        ChatModelWrapper selectedModel = null;
+        ModelWrapper selectedModel = null;
         long selectedUsage = Long.MAX_VALUE;
 
-        for (ChatModelWrapper entry : availableModels) {
+        for (ModelWrapper entry : models) {
             long routeUsage = readUsage(entry);
             if (routeUsage < selectedUsage) {
                 selectedModel = entry;
@@ -42,7 +44,7 @@ public class LowestTokenUsageRoutingStrategy implements ModelRoutingStrategy {
         return selectedModel;
     }
 
-    private long readUsage(ChatModelWrapper wrapper) {
+    private long readUsage(ModelWrapper wrapper) {
         Object metadata = wrapper.getMetadata(TOTAL_TOKEN_USAGE);
         if (metadata instanceof Number) {
             return ((Number) metadata).longValue();
@@ -55,9 +57,9 @@ public class LowestTokenUsageRoutingStrategy implements ModelRoutingStrategy {
      */
     class UsageTrackerListener implements ChatModelListener {
 
-        private ChatModelWrapper wrapper;
+        private ModelWrapper wrapper;
         // we need to remember the wrapper as the listener does not have access to the model
-        public UsageTrackerListener(ChatModelWrapper wrapper) {
+        public UsageTrackerListener(ModelWrapper wrapper) {
             this.wrapper = wrapper;
         }
 

--- a/models/langchain4j-community-model-router/src/main/java/dev/langchain4j/model/router/ModelRouter.java
+++ b/models/langchain4j-community-model-router/src/main/java/dev/langchain4j/model/router/ModelRouter.java
@@ -1,25 +1,28 @@
 package dev.langchain4j.model.router;
 
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
 import dev.langchain4j.Experimental;
 import dev.langchain4j.model.ModelProvider;
 import dev.langchain4j.model.chat.Capability;
 import dev.langchain4j.model.chat.ChatModel;
-import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.listener.ChatModelListener;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
 import dev.langchain4j.model.chat.request.DefaultChatRequestParameters;
 import dev.langchain4j.model.chat.response.ChatResponse;
-import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 
 /**
  * A {@link ChatModel} implementation that routes requests to other chat models
  * using a provided routing strategy.
+ *
+ * <p>Streaming models are routed by {@link StreamingModelRouter} instead: since
+ * {@link ChatModel} and {@link dev.langchain4j.model.chat.StreamingChatModel} define conflicting
+ * {@code chat(...)}/{@code doChat(...)} signatures, a single router cannot implement both.
  *
  * <p>Usage example:
  * <pre>{@code
@@ -36,15 +39,15 @@ import java.util.Set;
  * </pre>
  */
 @Experimental
-public class ModelRouter implements ChatModel, StreamingChatModel {
+public class ModelRouter implements ChatModel {
 
     private final List<ChatModelWrapper> routes;
     private final ModelRoutingStrategy routingStrategy;
     private final ChatModelWrapper defaultTarget;
 
     private ModelRouter(Builder builder) {
-        this.routes = Collections.unmodifiableList(Objects.requireNonNull(builder.routes, "routes"));
-        this.routingStrategy = Objects.requireNonNull(builder.routingStrategy, "routingStrategy");
+        this.routes = Collections.unmodifiableList(ensureNotNull(builder.routes, "routes"));
+        this.routingStrategy = ensureNotNull(builder.routingStrategy, "routingStrategy");
         this.defaultTarget = builder.defaultRoute;
     }
 
@@ -53,7 +56,9 @@ public class ModelRouter implements ChatModel, StreamingChatModel {
     }
 
     protected ChatModelWrapper resolveDelegate(ChatRequest chatRequest) {
-        ChatModelWrapper target = routingStrategy.route(routes, chatRequest);
+        // safe by the ModelRoutingStrategy contract: strategies must return one of the
+        // given availableModels, which are all ChatModelWrappers for this router
+        ChatModelWrapper target = (ChatModelWrapper) routingStrategy.route(routes, chatRequest);
         if (target == null) {
             target = defaultTarget;
         }
@@ -83,25 +88,6 @@ public class ModelRouter implements ChatModel, StreamingChatModel {
                 throw e;
             }
             return doChatInternal(chatRequest, attemptsLeft - 1);
-        }
-    }
-
-    @Override
-    public void doChat(ChatRequest chatRequest, StreamingChatResponseHandler handler) {
-        doChatInternal(chatRequest, handler, this.routes.size());
-    }
-
-    private void doChatInternal(ChatRequest chatRequest, StreamingChatResponseHandler handler, int attemptsLeft) {
-        ChatModelWrapper delegate = resolveDelegate(chatRequest);
-        try {
-            delegate.chat(chatRequest, handler);
-        } catch (NoMatchingModelFoundException e) {
-            throw e;
-        } catch (Exception e) {
-            if (attemptsLeft <= 1) {
-                throw e;
-            }
-            doChatInternal(chatRequest, handler, attemptsLeft - 1);
         }
     }
 
@@ -137,19 +123,7 @@ public class ModelRouter implements ChatModel, StreamingChatModel {
             return this;
         }
 
-        public Builder addRoutes(StreamingChatModel... model) {
-            for (StreamingChatModel chatModel : model) {
-                this.routes.add(new ChatModelWrapper(chatModel));
-            }
-            return this;
-        }
-
         public Builder defaultRoute(ChatModel model) {
-            this.defaultRoute = new ChatModelWrapper(model);
-            return this;
-        }
-
-        public Builder defaultRoute(StreamingChatModel model) {
             this.defaultRoute = new ChatModelWrapper(model);
             return this;
         }
@@ -160,21 +134,6 @@ public class ModelRouter implements ChatModel, StreamingChatModel {
         }
 
         public ModelRouter build() {
-            Boolean streaming = null;
-            for (ChatModelWrapper chatModelWrapper : routes) {
-                if (chatModelWrapper.isStreaming()) {
-                    if (streaming == null) {
-                        streaming = true;
-                    } else {
-                        throw new RuntimeException("you cannot mix streaming and non streaming models");
-                    }
-                }
-            }
-            if (streaming != null) {
-                if (defaultRoute.isStreaming() && !streaming) {
-                    throw new RuntimeException("you cannot mix streaming and non streaming models");
-                }
-            }
             return new ModelRouter(this);
         }
     }

--- a/models/langchain4j-community-model-router/src/main/java/dev/langchain4j/model/router/ModelRoutingStrategy.java
+++ b/models/langchain4j-community-model-router/src/main/java/dev/langchain4j/model/router/ModelRoutingStrategy.java
@@ -12,13 +12,18 @@ import java.util.List;
 public interface ModelRoutingStrategy {
 
     /**
-     * Determines the route key to use for the given chat messages.
+     * Determines the route to use for the given chat request.
+     *
+     * <p>The same strategy can be used with both {@link ModelRouter} (whose routes are
+     * {@link ChatModelWrapper}s) and {@link StreamingModelRouter} (whose routes are
+     * {@link StreamingChatModelWrapper}s). Implementations must return one of the given
+     * {@code availableModels} (or {@code null}).
      *
      * @param availableModels
      *            all configured models, including any routing metadata
      * @param chatRequest
      *            the incoming chat request
-     * @return the key of the route to use
+     * @return the route to use, or {@code null} if no route matches
      */
-    ChatModelWrapper route(List<ChatModelWrapper> availableModels, ChatRequest chatRequest);
+    ModelWrapper route(List<? extends ModelWrapper> availableModels, ChatRequest chatRequest);
 }

--- a/models/langchain4j-community-model-router/src/main/java/dev/langchain4j/model/router/ModelWrapper.java
+++ b/models/langchain4j-community-model-router/src/main/java/dev/langchain4j/model/router/ModelWrapper.java
@@ -1,0 +1,83 @@
+package dev.langchain4j.model.router;
+
+import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
+import dev.langchain4j.Experimental;
+import dev.langchain4j.model.chat.listener.ChatModelListener;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+/**
+ * Base class for wrappers that add optional routing metadata and additional
+ * {@link ChatModelListener}s to a wrapped model.
+ *
+ * <p>Concrete subclasses wrap either a {@link dev.langchain4j.model.chat.ChatModel}
+ * ({@link ChatModelWrapper}) or a {@link dev.langchain4j.model.chat.StreamingChatModel}
+ * ({@link StreamingChatModelWrapper}). Routing strategies interact with wrappers only
+ * through this class, so the same strategy can be used for both synchronous and
+ * streaming routers.
+ */
+@Experimental
+public abstract class ModelWrapper {
+
+    private final Map<String, Serializable> metadata;
+    private final List<ChatModelListener> ownListeners = new ArrayList<>();
+
+    protected ModelWrapper(Map<String, Serializable> metadata) {
+        // the metadata map must stay mutable: routing strategies store state (e.g. failure
+        // markers) on the wrapper via setMetadata
+        this.metadata = new HashMap<>(getOrDefault(metadata, Map.of()));
+    }
+
+    public Map<String, Serializable> routingMetadata() {
+        return metadata;
+    }
+
+    public Serializable getMetadata(String key) {
+        ensureNotNull(key, "key");
+        return metadata.get(key);
+    }
+
+    public void setMetadata(String key, Serializable value) {
+        ensureNotNull(key, "key");
+        if (value == null) {
+            metadata.remove(key);
+        } else {
+            metadata.put(key, value);
+        }
+    }
+
+    public boolean addListener(ChatModelListener listener) {
+        return ownListeners.add(listener);
+    }
+
+    public boolean removeListener(ChatModelListener listener) {
+        return ownListeners.remove(listener);
+    }
+
+    /**
+     * The effective listeners of the wrapped model: the listeners of the wrapped model itself
+     * merged with the listeners added directly to this wrapper.
+     */
+    public abstract List<ChatModelListener> listeners();
+
+    /**
+     * The listeners that were added directly to this wrapper.
+     */
+    protected List<ChatModelListener> ownListeners() {
+        return ownListeners;
+    }
+
+    /**
+     * Merges the listeners of the wrapped model with the listeners added directly to this wrapper.
+     */
+    protected static List<ChatModelListener> mergedListeners(
+            List<ChatModelListener> delegateListeners, List<ChatModelListener> ownListeners) {
+        return Stream.concat(delegateListeners.stream(), ownListeners.stream()).toList();
+    }
+}

--- a/models/langchain4j-community-model-router/src/main/java/dev/langchain4j/model/router/StreamingChatModelWrapper.java
+++ b/models/langchain4j-community-model-router/src/main/java/dev/langchain4j/model/router/StreamingChatModelWrapper.java
@@ -5,44 +5,51 @@ import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 import dev.langchain4j.Experimental;
 import dev.langchain4j.model.ModelProvider;
 import dev.langchain4j.model.chat.Capability;
-import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.listener.ChatModelListener;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
-import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.ChatModelStreamingEvent;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.Flow.Publisher;
 
 /**
- * Wraps a {@link ChatModel} adding optional routing metadata.
+ * Wraps a {@link StreamingChatModel} adding optional routing metadata.
  *
- * <p>Streaming models are wrapped by {@link StreamingChatModelWrapper} instead: since
- * {@link ChatModel} and {@link dev.langchain4j.model.chat.StreamingChatModel} define conflicting
+ * <p>Synchronous models are wrapped by {@link ChatModelWrapper} instead: since
+ * {@link dev.langchain4j.model.chat.ChatModel} and {@link StreamingChatModel} define conflicting
  * {@code chat(...)}/{@code doChat(...)} signatures, a single wrapper cannot implement both.
  */
 @Experimental
-public class ChatModelWrapper extends ModelWrapper implements ChatModel {
+public class StreamingChatModelWrapper extends ModelWrapper implements StreamingChatModel {
 
-    private final ChatModel model;
+    private final StreamingChatModel model;
 
-    ChatModelWrapper(ChatModel model, Map<String, Serializable> metadata) {
+    StreamingChatModelWrapper(StreamingChatModel model, Map<String, Serializable> metadata) {
         super(metadata);
         this.model = ensureNotNull(model, "model");
     }
 
-    public ChatModelWrapper(ChatModel model) {
+    public StreamingChatModelWrapper(StreamingChatModel model) {
         this(model, new HashMap<>());
     }
 
-    public ChatModel model() {
+    public StreamingChatModel model() {
         return model;
     }
 
     @Override
-    public ChatResponse doChat(ChatRequest chatRequest) {
+    public void doChat(ChatRequest chatRequest, StreamingChatResponseHandler handler) {
+        model.chat(chatRequest, handler);
+    }
+
+    @Override
+    public Publisher<ChatModelStreamingEvent> doChat(ChatRequest chatRequest) {
         return model.chat(chatRequest);
     }
 

--- a/models/langchain4j-community-model-router/src/main/java/dev/langchain4j/model/router/StreamingModelRouter.java
+++ b/models/langchain4j-community-model-router/src/main/java/dev/langchain4j/model/router/StreamingModelRouter.java
@@ -1,0 +1,309 @@
+package dev.langchain4j.model.router;
+
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
+import dev.langchain4j.Experimental;
+import dev.langchain4j.model.ModelProvider;
+import dev.langchain4j.model.chat.Capability;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.listener.ChatModelListener;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.request.DefaultChatRequestParameters;
+import dev.langchain4j.model.chat.response.ChatModelStreamingEvent;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Flow.Publisher;
+import java.util.concurrent.Flow.Subscriber;
+import java.util.concurrent.Flow.Subscription;
+
+/**
+ * A {@link StreamingChatModel} implementation that routes requests to other streaming chat models
+ * using a provided routing strategy.
+ *
+ * <p>Synchronous models are routed by {@link ModelRouter} instead: since
+ * {@link dev.langchain4j.model.chat.ChatModel} and {@link StreamingChatModel} define conflicting
+ * {@code chat(...)}/{@code doChat(...)} signatures, a single router cannot implement both.
+ *
+ * <p>Usage example:
+ * <pre>{@code
+ * StreamingChatModel oneModel = ...;
+ * StreamingChatModel otherModel = ...;
+ *
+ * StreamingModelRouter router = StreamingModelRouter.builder()
+ *         .addRoutes(oneModel, otherModel)
+ *         .routingStrategy(new FailoverStrategy())
+ *         .build();
+ *
+ * router.chat(ChatRequest.userMessage("Explain this complex topic"), handler);
+ * }
+ * </pre>
+ */
+@Experimental
+public class StreamingModelRouter implements StreamingChatModel {
+
+    private final List<StreamingChatModelWrapper> routes;
+    private final ModelRoutingStrategy routingStrategy;
+    private final StreamingChatModelWrapper defaultTarget;
+
+    private StreamingModelRouter(Builder builder) {
+        this.routes = Collections.unmodifiableList(ensureNotNull(builder.routes, "routes"));
+        this.routingStrategy = ensureNotNull(builder.routingStrategy, "routingStrategy");
+        this.defaultTarget = builder.defaultRoute;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    protected StreamingChatModelWrapper resolveDelegate(ChatRequest chatRequest) {
+        // safe by the ModelRoutingStrategy contract: strategies must return one of the
+        // given availableModels, which are all StreamingChatModelWrappers for this router
+        StreamingChatModelWrapper target = (StreamingChatModelWrapper) routingStrategy.route(routes, chatRequest);
+        if (target == null) {
+            target = defaultTarget;
+        }
+        if (target == null) {
+            throw new IllegalStateException("No matching route for request found");
+        }
+        return target;
+    }
+
+    /**
+     * Handler-based entry point. Failover applies to exceptions thrown synchronously by the
+     * delegate invocation only; asynchronous errors are reported to the handler unchanged, as
+     * they were before the reactive API existed.
+     */
+    @Override
+    public void doChat(ChatRequest chatRequest, StreamingChatResponseHandler handler) {
+        // Bound the failover retry to the number of configured routes: each route is
+        // given a single attempt before the original failure propagates. Without this
+        // bound, a persistently-failing delegate would cause unbounded recursion and a
+        // StackOverflowError instead of surfacing the underlying failure.
+        doChatInternal(chatRequest, handler, this.routes.size());
+    }
+
+    private void doChatInternal(ChatRequest chatRequest, StreamingChatResponseHandler handler, int attemptsLeft) {
+        StreamingChatModelWrapper delegate = resolveDelegate(chatRequest);
+        try {
+            delegate.chat(chatRequest, handler);
+        } catch (NoMatchingModelFoundException e) {
+            throw e;
+        } catch (Exception e) {
+            if (attemptsLeft <= 1) {
+                throw e;
+            }
+            doChatInternal(chatRequest, handler, attemptsLeft - 1);
+        }
+    }
+
+    /**
+     * Reactive entry point. The returned {@code Publisher} subscribes to the route selected by the
+     * routing strategy. If that route fails before emitting any event, the subscription is retried
+     * on the next route selected by the strategy, up to the number of configured routes (mirroring
+     * the bounded failover of the handler-based and synchronous paths). Once an event has been
+     * emitted, a failure is propagated to the subscriber instead of being retried.
+     */
+    @Override
+    public Publisher<ChatModelStreamingEvent> doChat(ChatRequest chatRequest) {
+        return downstream -> new FailoverSubscription(chatRequest, downstream, routes.size()).start();
+    }
+
+    @Override
+    public Set<Capability> supportedCapabilities() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public ModelProvider provider() {
+        return ModelProvider.OTHER;
+    }
+
+    @Override
+    public List<ChatModelListener> listeners() {
+        return List.of();
+    }
+
+    @Override
+    public ChatRequestParameters defaultRequestParameters() {
+        return DefaultChatRequestParameters.EMPTY;
+    }
+
+    public static final class Builder {
+        private final List<StreamingChatModelWrapper> routes = new ArrayList<>();
+        private ModelRoutingStrategy routingStrategy;
+        private StreamingChatModelWrapper defaultRoute;
+
+        public Builder addRoutes(StreamingChatModel... model) {
+            for (StreamingChatModel streamingChatModel : model) {
+                this.routes.add(new StreamingChatModelWrapper(streamingChatModel));
+            }
+            return this;
+        }
+
+        public Builder defaultRoute(StreamingChatModel model) {
+            this.defaultRoute = new StreamingChatModelWrapper(model);
+            return this;
+        }
+
+        public Builder routingStrategy(ModelRoutingStrategy routingStrategy) {
+            this.routingStrategy = routingStrategy;
+            return this;
+        }
+
+        public StreamingModelRouter build() {
+            return new StreamingModelRouter(this);
+        }
+    }
+
+    /**
+     * The {@link Subscription} exposed to the subscriber of {@link #doChat(ChatRequest)}. It
+     * subscribes to one route at a time and fails over to the next selected route when the current
+     * one fails before emitting any event.
+     */
+    private final class FailoverSubscription implements Subscription {
+
+        private final ChatRequest chatRequest;
+        private final Subscriber<? super ChatModelStreamingEvent> downstream;
+        private volatile int attemptsLeft;
+        private volatile boolean emitted;
+        private volatile boolean cancelled;
+        private Subscription current; // guarded by this
+        private long totalRequested; // guarded by this
+        private long forwarded; // guarded by this
+
+        FailoverSubscription(
+                ChatRequest chatRequest, Subscriber<? super ChatModelStreamingEvent> downstream, int attempts) {
+            this.chatRequest = chatRequest;
+            this.downstream = downstream;
+            this.attemptsLeft = attempts;
+        }
+
+        void start() {
+            downstream.onSubscribe(this);
+            subscribeNextRoute();
+        }
+
+        private void subscribeNextRoute() {
+            if (cancelled) {
+                return;
+            }
+            StreamingChatModelWrapper delegate;
+            try {
+                delegate = resolveDelegate(chatRequest);
+            } catch (Throwable error) {
+                downstream.onError(error);
+                return;
+            }
+            Publisher<ChatModelStreamingEvent> publisher;
+            try {
+                publisher = delegate.chat(chatRequest);
+            } catch (Throwable error) {
+                failoverOrPropagate(error);
+                return;
+            }
+            try {
+                publisher.subscribe(new FailoverSubscriber());
+            } catch (Throwable error) {
+                failoverOrPropagate(error);
+            }
+        }
+
+        private void failoverOrPropagate(Throwable error) {
+            attemptsLeft--;
+            if (!emitted && !cancelled && attemptsLeft > 0) {
+                synchronized (this) {
+                    current = null;
+                    // no event was delivered to the downstream subscriber, so the full
+                    // outstanding demand must be granted to the next route
+                    forwarded = 0;
+                }
+                subscribeNextRoute();
+            } else {
+                downstream.onError(error);
+            }
+        }
+
+        private void register(Subscription subscription) {
+            long toForward;
+            synchronized (this) {
+                if (cancelled) {
+                    subscription.cancel();
+                    return;
+                }
+                current = subscription;
+                toForward = totalRequested - forwarded;
+                forwarded = totalRequested;
+            }
+            if (toForward > 0) {
+                subscription.request(toForward);
+            }
+        }
+
+        @Override
+        public void request(long n) {
+            if (n <= 0) {
+                throw new IllegalArgumentException("non-positive request: " + n);
+            }
+            Subscription subscription;
+            long toForward;
+            synchronized (this) {
+                totalRequested = saturatingAdd(totalRequested, n);
+                subscription = current;
+                if (subscription != null) {
+                    toForward = totalRequested - forwarded;
+                    forwarded = totalRequested;
+                } else {
+                    toForward = 0;
+                }
+            }
+            if (toForward > 0) {
+                subscription.request(toForward);
+            }
+        }
+
+        @Override
+        public void cancel() {
+            cancelled = true;
+            Subscription subscription;
+            synchronized (this) {
+                subscription = current;
+            }
+            if (subscription != null) {
+                subscription.cancel();
+            }
+        }
+
+        private final class FailoverSubscriber implements Subscriber<ChatModelStreamingEvent> {
+
+            @Override
+            public void onSubscribe(Subscription subscription) {
+                register(subscription);
+            }
+
+            @Override
+            public void onNext(ChatModelStreamingEvent event) {
+                emitted = true;
+                downstream.onNext(event);
+            }
+
+            @Override
+            public void onError(Throwable error) {
+                failoverOrPropagate(error);
+            }
+
+            @Override
+            public void onComplete() {
+                downstream.onComplete();
+            }
+        }
+    }
+
+    private static long saturatingAdd(long a, long b) {
+        long sum = a + b;
+        return sum < 0 ? Long.MAX_VALUE : sum;
+    }
+}

--- a/models/langchain4j-community-model-router/src/main/java/dev/langchain4j/model/router/package-info.java
+++ b/models/langchain4j-community-model-router/src/main/java/dev/langchain4j/model/router/package-info.java
@@ -6,6 +6,7 @@
  * <p>Key interfaces and classes:
  * <ul>
  *   <li>{@link dev.langchain4j.model.router.ModelRouter} - A ChatModel implementation which routes requests to other models</li>
+ *   <li>{@link dev.langchain4j.model.router.StreamingModelRouter} - A StreamingChatModel implementation which routes requests to other models</li>
  *   <li>{@link dev.langchain4j.model.router.ModelRoutingStrategy} - Interface for different routing strategies</li>
  * </ul>
  */

--- a/models/langchain4j-community-model-router/src/test/java/dev/langchain4j/model/router/FailoverStrategyTest.java
+++ b/models/langchain4j-community-model-router/src/test/java/dev/langchain4j/model/router/FailoverStrategyTest.java
@@ -37,7 +37,7 @@ class FailoverStrategyTest {
 
         FailoverStrategy strategy = new FailoverStrategy(Duration.ofMinutes(1));
 
-        ChatModelWrapper route = strategy.route(
+        ModelWrapper route = strategy.route(
                 routes, ChatRequest.builder().messages(new UserMessage("ping")).build());
 
         assertEquals(secondary, route);
@@ -55,7 +55,7 @@ class FailoverStrategyTest {
 
         FailoverStrategy strategy = new FailoverStrategy(Duration.ofMinutes(1));
 
-        ChatModelWrapper route = strategy.route(
+        ModelWrapper route = strategy.route(
                 routes, ChatRequest.builder().messages(new UserMessage("ping")).build());
 
         assertEquals(primary, route);
@@ -77,7 +77,7 @@ class FailoverStrategyTest {
         ModelRoutingStrategy delegate = (available, chatRequest) -> available.get(0);
         FailoverStrategy strategy = new FailoverStrategy(delegate, Duration.ofMinutes(1));
 
-        ChatModelWrapper route = strategy.route(
+        ModelWrapper route = strategy.route(
                 routes, ChatRequest.builder().messages(new UserMessage("ping")).build());
 
         assertEquals(healthy, route);
@@ -95,7 +95,7 @@ class FailoverStrategyTest {
 
         FailoverStrategy strategy = new FailoverStrategy(Duration.ofMinutes(1));
 
-        ChatModelWrapper route = strategy.route(
+        ModelWrapper route = strategy.route(
                 List.of(first, second),
                 ChatRequest.builder().messages(new UserMessage("ping")).build());
 

--- a/models/langchain4j-community-model-router/src/test/java/dev/langchain4j/model/router/LowestTokenUsageRoutingStrategyTest.java
+++ b/models/langchain4j-community-model-router/src/test/java/dev/langchain4j/model/router/LowestTokenUsageRoutingStrategyTest.java
@@ -37,7 +37,7 @@ class LowestTokenUsageRoutingStrategyTest {
 
         LowestTokenUsageRoutingStrategy strategy = new LowestTokenUsageRoutingStrategy();
 
-        ChatModelWrapper selected = strategy.route(List.of(highUsage, lowUsage), REQUEST);
+        ModelWrapper selected = strategy.route(List.of(highUsage, lowUsage), REQUEST);
 
         assertEquals(lowUsage, selected);
     }
@@ -49,8 +49,8 @@ class LowestTokenUsageRoutingStrategyTest {
 
         LowestTokenUsageRoutingStrategy strategy = new LowestTokenUsageRoutingStrategy();
 
-        ChatModelWrapper selected = strategy.route(List.of(first, second), REQUEST);
-        Set<Capability> capabilities = selected.supportedCapabilities();
+        ModelWrapper selected = strategy.route(List.of(first, second), REQUEST);
+        Set<Capability> capabilities = ((ChatModelWrapper) selected).supportedCapabilities();
 
         assertEquals(first, selected);
         assertTrue(capabilities.isEmpty());
@@ -60,7 +60,7 @@ class LowestTokenUsageRoutingStrategyTest {
     void returnsNullWhenNoRoutesAreAvailable() {
         LowestTokenUsageRoutingStrategy strategy = new LowestTokenUsageRoutingStrategy();
 
-        ChatModelWrapper selected = strategy.route(List.of(), REQUEST);
+        ModelWrapper selected = strategy.route(List.of(), REQUEST);
 
         assertNull(selected);
     }

--- a/models/langchain4j-community-model-router/src/test/java/dev/langchain4j/model/router/StreamingModelRouterTest.java
+++ b/models/langchain4j-community-model-router/src/test/java/dev/langchain4j/model/router/StreamingModelRouterTest.java
@@ -1,0 +1,363 @@
+package dev.langchain4j.model.router;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatModelStreamingEvent;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.CompleteResponse;
+import dev.langchain4j.model.chat.response.PartialResponse;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Flow.Publisher;
+import java.util.concurrent.Flow.Subscriber;
+import java.util.concurrent.Flow.Subscription;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.Test;
+
+class StreamingModelRouterTest {
+
+    private static final ChatRequest REQUEST =
+            ChatRequest.builder().messages(new UserMessage("ping")).build();
+
+    /**
+     * A {@link StreamingChatModel} whose reactive and handler-based behaviors are scripted by the
+     * tests, and which counts how many times each entry point is invoked.
+     */
+    private static class ScriptedStreamingModel implements StreamingChatModel {
+
+        private final Consumer<Subscriber<? super ChatModelStreamingEvent>> reactiveScript;
+        private final Consumer<StreamingChatResponseHandler> handlerScript;
+        private final AtomicInteger reactiveCalls = new AtomicInteger();
+        private final AtomicInteger handlerCalls = new AtomicInteger();
+
+        ScriptedStreamingModel(
+                Consumer<Subscriber<? super ChatModelStreamingEvent>> reactiveScript,
+                Consumer<StreamingChatResponseHandler> handlerScript) {
+            this.reactiveScript = reactiveScript;
+            this.handlerScript = handlerScript;
+        }
+
+        @Override
+        public Publisher<ChatModelStreamingEvent> doChat(ChatRequest chatRequest) {
+            reactiveCalls.incrementAndGet();
+            return subscriber -> {
+                subscriber.onSubscribe(noOpSubscription());
+                reactiveScript.accept(subscriber);
+            };
+        }
+
+        @Override
+        public void doChat(ChatRequest chatRequest, StreamingChatResponseHandler handler) {
+            handlerCalls.incrementAndGet();
+            if (handlerScript == null) {
+                throw new UnsupportedOperationException("handler-based calls are not scripted for this model");
+            }
+            handlerScript.accept(handler);
+        }
+
+        int reactiveCalls() {
+            return reactiveCalls.get();
+        }
+
+        int handlerCalls() {
+            return handlerCalls.get();
+        }
+    }
+
+    private static ScriptedStreamingModel successfulModel(String id) {
+        return new ScriptedStreamingModel(
+                subscriber -> {
+                    subscriber.onNext(new PartialResponse(id));
+                    subscriber.onNext(new CompleteResponse(response(id)));
+                    subscriber.onComplete();
+                },
+                handler -> handler.onCompleteResponse(response(id)));
+    }
+
+    private static ScriptedStreamingModel immediatelyFailingModel(String message) {
+        return new ScriptedStreamingModel(subscriber -> subscriber.onError(new IllegalStateException(message)), null);
+    }
+
+    private static ChatResponse response(String text) {
+        return ChatResponse.builder().aiMessage(new AiMessage(text)).build();
+    }
+
+    private static Subscription noOpSubscription() {
+        return new Subscription() {
+            @Override
+            public void request(long n) {}
+
+            @Override
+            public void cancel() {}
+        };
+    }
+
+    /**
+     * A strategy that always picks the given index, regardless of wrapper state.
+     */
+    private static ModelRoutingStrategy fixedIndexStrategy(int index) {
+        return (availableModels, chatRequest) -> availableModels.get(index);
+    }
+
+    /**
+     * A strategy that cycles through the available models on every call.
+     */
+    private static ModelRoutingStrategy roundRobinStrategy() {
+        AtomicInteger nextIndex = new AtomicInteger();
+        return (availableModels, chatRequest) ->
+                availableModels.get(nextIndex.getAndIncrement() % availableModels.size());
+    }
+
+    private static final class EventCollector implements Subscriber<ChatModelStreamingEvent> {
+
+        private final List<ChatModelStreamingEvent> events = new CopyOnWriteArrayList<>();
+        private final AtomicReference<Throwable> error = new AtomicReference<>();
+        private final CountDownLatch terminal = new CountDownLatch(1);
+
+        @Override
+        public void onSubscribe(Subscription subscription) {
+            subscription.request(Long.MAX_VALUE);
+        }
+
+        @Override
+        public void onNext(ChatModelStreamingEvent event) {
+            events.add(event);
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+            error.set(throwable);
+            terminal.countDown();
+        }
+
+        @Override
+        public void onComplete() {
+            terminal.countDown();
+        }
+
+        void awaitTerminal() throws InterruptedException {
+            assertTrue(terminal.await(10, TimeUnit.SECONDS), "the stream did not terminate in time");
+        }
+    }
+
+    private static final class HandlerCollector implements StreamingChatResponseHandler {
+
+        private final AtomicReference<ChatResponse> completeResponse = new AtomicReference<>();
+        private final AtomicReference<Throwable> error = new AtomicReference<>();
+        private final CountDownLatch terminal = new CountDownLatch(1);
+
+        @Override
+        public void onCompleteResponse(ChatResponse response) {
+            completeResponse.set(response);
+            terminal.countDown();
+        }
+
+        @Override
+        public void onError(Throwable error) {
+            this.error.set(error);
+            terminal.countDown();
+        }
+
+        void awaitTerminal() throws InterruptedException {
+            assertTrue(terminal.await(10, TimeUnit.SECONDS), "the stream did not terminate in time");
+        }
+    }
+
+    /**
+     * A successful reactive call is routed to the selected delegate and its events are passed
+     * through unchanged.
+     */
+    @Test
+    void successfulReactiveCallDelegatesToRoute() throws InterruptedException {
+        ScriptedStreamingModel model = successfulModel("ok");
+        StreamingModelRouter router = StreamingModelRouter.builder()
+                .addRoutes(model)
+                .routingStrategy(new LowestTokenUsageRoutingStrategy())
+                .build();
+
+        EventCollector collector = new EventCollector();
+        router.chat(REQUEST).subscribe(collector);
+        collector.awaitTerminal();
+
+        assertEquals(2, collector.events.size());
+        assertEquals("ok", ((PartialResponse) collector.events.get(0)).text());
+        assertInstanceOf(CompleteResponse.class, collector.events.get(1));
+        assertNull(collector.error.get());
+        assertEquals(1, model.reactiveCalls());
+    }
+
+    /**
+     * With a {@link FailoverStrategy}, a route failing before emitting any event is skipped and
+     * the subscription is retried on the next healthy route.
+     */
+    @Test
+    void reactiveCallFailsOverToHealthyRoute() throws InterruptedException {
+        ScriptedStreamingModel failing = immediatelyFailingModel("boom");
+        ScriptedStreamingModel healthy = successfulModel("healthy");
+        StreamingModelRouter router = StreamingModelRouter.builder()
+                .addRoutes(failing, healthy)
+                .routingStrategy(new FailoverStrategy())
+                .build();
+
+        EventCollector collector = new EventCollector();
+        router.chat(REQUEST).subscribe(collector);
+        collector.awaitTerminal();
+
+        assertNull(collector.error.get());
+        assertEquals("healthy", ((PartialResponse) collector.events.get(0)).text());
+        assertEquals(1, failing.reactiveCalls());
+        assertEquals(1, healthy.reactiveCalls());
+    }
+
+    /**
+     * Once events have been emitted downstream, a failure is propagated instead of being retried,
+     * because retrying would duplicate or lose already-delivered events.
+     */
+    @Test
+    void reactiveCallDoesNotRetryAfterEventsWereEmitted() throws InterruptedException {
+        ScriptedStreamingModel partialThenFailing = new ScriptedStreamingModel(
+                subscriber -> {
+                    subscriber.onNext(new PartialResponse("partial"));
+                    subscriber.onError(new IllegalStateException("mid-stream failure"));
+                },
+                null);
+        ScriptedStreamingModel healthy = successfulModel("healthy");
+        StreamingModelRouter router = StreamingModelRouter.builder()
+                .addRoutes(partialThenFailing, healthy)
+                .routingStrategy(new LowestTokenUsageRoutingStrategy())
+                .build();
+
+        EventCollector collector = new EventCollector();
+        router.chat(REQUEST).subscribe(collector);
+        collector.awaitTerminal();
+
+        assertEquals(1, collector.events.size());
+        assertEquals("partial", ((PartialResponse) collector.events.get(0)).text());
+        Throwable error = collector.error.get();
+        assertInstanceOf(IllegalStateException.class, error);
+        assertEquals("mid-stream failure", error.getMessage());
+        assertEquals(0, healthy.reactiveCalls());
+    }
+
+    /**
+     * When the strategy keeps selecting the same failing route, the number of attempts is bounded
+     * by the number of configured routes and the last failure surfaces.
+     */
+    @Test
+    void reactiveCallBoundedByRouteCountWhenStrategyKeepsSelectingSameFailingModel() throws InterruptedException {
+        ScriptedStreamingModel failing = immediatelyFailingModel("flaky");
+        ScriptedStreamingModel unused = successfulModel("unused");
+        StreamingModelRouter router = StreamingModelRouter.builder()
+                .addRoutes(failing, unused)
+                .routingStrategy(fixedIndexStrategy(0))
+                .build();
+
+        EventCollector collector = new EventCollector();
+        router.chat(REQUEST).subscribe(collector);
+        collector.awaitTerminal();
+
+        Throwable error = collector.error.get();
+        assertInstanceOf(IllegalStateException.class, error);
+        assertEquals("flaky", error.getMessage());
+        assertEquals(2, failing.reactiveCalls());
+        assertEquals(0, unused.reactiveCalls());
+    }
+
+    /**
+     * A single failing route surfaces its error directly without retrying.
+     */
+    @Test
+    void reactiveCallPropagatesFailureOfSingleRoute() throws InterruptedException {
+        ScriptedStreamingModel failing = immediatelyFailingModel("permanent delegate failure");
+        StreamingModelRouter router = StreamingModelRouter.builder()
+                .addRoutes(failing)
+                .routingStrategy(new LowestTokenUsageRoutingStrategy())
+                .build();
+
+        EventCollector collector = new EventCollector();
+        router.chat(REQUEST).subscribe(collector);
+        collector.awaitTerminal();
+
+        Throwable error = collector.error.get();
+        assertInstanceOf(IllegalStateException.class, error);
+        assertEquals("permanent delegate failure", error.getMessage());
+        assertEquals(1, failing.reactiveCalls());
+    }
+
+    /**
+     * When no route matches and a default route is configured, reactive calls are delegated to it.
+     */
+    @Test
+    void reactiveCallFallsBackToDefaultRoute() throws InterruptedException {
+        ScriptedStreamingModel defaultModel = successfulModel("default");
+        StreamingModelRouter router = StreamingModelRouter.builder()
+                .addRoutes(immediatelyFailingModel("ignored"))
+                .defaultRoute(defaultModel)
+                .routingStrategy((availableModels, chatRequest) -> null)
+                .build();
+
+        EventCollector collector = new EventCollector();
+        router.chat(REQUEST).subscribe(collector);
+        collector.awaitTerminal();
+
+        assertNull(collector.error.get());
+        assertEquals("default", ((PartialResponse) collector.events.get(0)).text());
+        assertEquals(1, defaultModel.reactiveCalls());
+    }
+
+    /**
+     * When no route matches and no default route is configured, the subscriber receives an error.
+     */
+    @Test
+    void reactiveCallFailsWhenNoRouteMatches() throws InterruptedException {
+        StreamingModelRouter router = StreamingModelRouter.builder()
+                .addRoutes(successfulModel("unused"))
+                .routingStrategy((availableModels, chatRequest) -> null)
+                .build();
+
+        EventCollector collector = new EventCollector();
+        router.chat(REQUEST).subscribe(collector);
+        collector.awaitTerminal();
+
+        Throwable error = collector.error.get();
+        assertInstanceOf(IllegalStateException.class, error);
+        assertEquals("No matching route for request found", error.getMessage());
+    }
+
+    /**
+     * The handler-based entry point fails over when a delegate throws synchronously, mirroring the
+     * synchronous router behavior.
+     */
+    @Test
+    void handlerBasedCallFailsOverOnSynchronousFailure() throws InterruptedException {
+        ScriptedStreamingModel throwing = new ScriptedStreamingModel(null, handler -> {
+            throw new IllegalStateException("sync failure");
+        });
+        ScriptedStreamingModel healthy = successfulModel("healthy");
+        StreamingModelRouter router = StreamingModelRouter.builder()
+                .addRoutes(throwing, healthy)
+                .routingStrategy(roundRobinStrategy())
+                .build();
+
+        HandlerCollector collector = new HandlerCollector();
+        router.chat(REQUEST, collector);
+        collector.awaitTerminal();
+
+        assertNull(collector.error.get());
+        assertEquals("healthy", collector.completeResponse.get().aiMessage().text());
+        assertEquals(1, throwing.handlerCalls());
+        assertEquals(1, healthy.handlerCalls());
+    }
+}


### PR DESCRIPTION
## Issue
Part of #775

The nightly builds (all JDKs) have been failing since September 3 because [langchain4j/langchain4j#5527](https://github.com/langchain4j/langchain4j/pull/5527) ("Non-blocking / reactive support") changed `StreamingChatModel`: it now declares `doChat(ChatRequest)` returning `Flow.Publisher<ChatModelStreamingEvent>` and reactive `chat(...)` overloads, which conflict with `ChatModel.doChat(ChatRequest)` returning `ChatResponse`. A class can therefore no longer implement both interfaces, and `ModelRouter`/`ChatModelWrapper` implemented both. Example failed run: https://github.com/langchain4j/langchain4j-community/actions/runs/33835812542

## Change
Adapts the `langchain4j-community-model-router` module to the new API, mirroring the upstream split of sync and streaming models:

- `ChatModelWrapper` now implements `ChatModel` only; a new `StreamingChatModelWrapper` implements `StreamingChatModel`
- New `ModelWrapper` base class carries routing metadata and wrapper listeners, so routing strategies (`FailoverStrategy`, `LowestTokenUsageRoutingStrategy`) work unchanged for both router types; `ModelRoutingStrategy.route(...)` now accepts `List<? extends ModelWrapper>`
- `ModelRouter` implements `ChatModel` only; a new `StreamingModelRouter` implements `StreamingChatModel`, including bounded failover for the new reactive entry point (retries the next route only while no event has been emitted yet, bounded by the number of routes — same semantics as the synchronous path)
- New `StreamingModelRouterTest` (reactive routing, failover, bounded attempts, no-retry-after-emit, handler-based path); existing tests updated for the new signatures

Note: this is technically a breaking change for the `@Experimental` model-router API (e.g. `ModelRouter.builder().addRoutes(StreamingChatModel...)` moves to `StreamingModelRouter`), but it is unavoidable: the module no longer compiles against `1.20.0-SNAPSHOT` as-is, and implementing both interfaces is impossible with the new core API. The rest of the repository compiles unchanged against the new snapshots (verified with a full `test-compile` of all 81 modules).

## General checklist
- [ ] There are no breaking changes
- [X] I have added unit and integration tests for my change
- [ ] I have manually run all the unit tests in _all_ modules, and they are all green
- [X] I have manually run all integration tests in the module I have added/changed, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

Notes on the checklist:
- "no breaking changes" is left unchecked on purpose, see the note above — the change only affects the `@Experimental` model-router module.
- All unit tests of the changed module are green (21 run, 2 skipped: the Azure-backed ITs gated by environment variables, as usual in CI). A full `test-compile` of all modules passes locally; the CI run on this PR executes the full test suite.
- Documentation/examples are intentionally not included yet, per the template (waiting for review/approval).

## Checklist for adding new maven module
Not applicable — no new module is added.

## Checklist for adding new embedding store integration
Not applicable.

## Checklist for changing existing embedding store integration
Not applicable.