### PR TITLE
feat(tools): add Live Tennis API tool integration

### DIFF
--- a/langchain4j-community-bom/pom.xml
+++ b/langchain4j-community-bom/pom.xml
@@ -280,6 +280,12 @@
 
             <dependency>
                 <groupId>dev.langchain4j</groupId>
+                <artifactId>langchain4j-community-tool-live-tennis</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>dev.langchain4j</groupId>
                 <artifactId>langchain4j-community-tool-xquik</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,7 @@
         <module>tools/langchain4j-community-tool-xquik</module>
         <module>tools/langchain4j-community-tool-web-scraper</module>
         <module>tools/langchain4j-community-tool-browser-use</module>
+        <module>tools/langchain4j-community-tool-live-tennis</module>
 
         <!-- Spring Boot Starters -->
         <module>spring-boot-starters</module>

--- a/tools/langchain4j-community-tool-live-tennis/pom.xml
+++ b/tools/langchain4j-community-tool-live-tennis/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>dev.langchain4j</groupId>
+        <artifactId>langchain4j-community</artifactId>
+        <version>1.21.0-beta31-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>langchain4j-community-tool-live-tennis</artifactId>
+    <packaging>jar</packaging>
+    <name>LangChain4j :: Community :: Tool :: Live Tennis</name>
+    <description>Read-only live tennis scores, fixtures, rankings and head-to-head tools backed by the Live Tennis API.</description>
+
+    <licenses>
+        <license>
+            <name>Apache-2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+            <comments>A business-friendly OSS license</comments>
+        </license>
+    </licenses>
+
+    <dependencies>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-core</artifactId>
+            <version>${langchain4j.core.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-http-client</artifactId>
+            <version>${langchain4j.core.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-http-client-jdk</artifactId>
+            <version>${langchain4j.http-client-jdk.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j</artifactId>
+            <version>${langchain4j.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-open-ai</artifactId>
+            <version>${langchain4j.open-ai.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/tools/langchain4j-community-tool-live-tennis/src/main/java/dev/langchain4j/community/tool/livetennis/LiveTennisClient.java
+++ b/tools/langchain4j-community-tool-live-tennis/src/main/java/dev/langchain4j/community/tool/livetennis/LiveTennisClient.java
@@ -1,0 +1,318 @@
+package dev.langchain4j.community.tool.livetennis;
+
+import static dev.langchain4j.http.client.HttpMethod.GET;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.langchain4j.exception.HttpException;
+import dev.langchain4j.http.client.HttpClient;
+import dev.langchain4j.http.client.HttpClientBuilder;
+import dev.langchain4j.http.client.HttpClientBuilderLoader;
+import dev.langchain4j.http.client.HttpRequest;
+import dev.langchain4j.http.client.SuccessfulHttpResponse;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/**
+ * Low-level client for the read-only endpoints of the Live Tennis API.
+ *
+ * <p>The API key is supplied through the builder and sent as the {@code X-API-Key} request header.
+ * It is never written to a log or included in an exception message by this class.
+ */
+final class LiveTennisClient {
+
+    static final int DEFAULT_LIMIT = 10;
+    static final int MAX_LIMIT = 200;
+
+    /** Ranking systems that the rank-ordered listing mode of {@code GET /rankings} can serve. */
+    static final Set<String> RANKING_SYSTEMS =
+            Set.of("atp", "wta", "atp_doubles", "wta_doubles", "itf_jt", "itf_mt", "itf_wt");
+
+    private static final String DEFAULT_BASE_URL = "https://api.livetennisapi.com/api/public/v1";
+    private static final int MAX_RESPONSE_BYTES = 5 * 1024 * 1024;
+    private static final int MIN_PLAYER_NAME_LENGTH = 3;
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final Set<String> TOURS = Set.of("atp", "wta", "challenger", "itf", "juniors");
+    private static final Set<String> DRAWS = Set.of("singles", "doubles");
+    private static final Pattern DATE = Pattern.compile("\\d{4}-\\d{2}-\\d{2}");
+
+    private final HttpClient httpClient;
+    private final String baseUrl;
+    private final String apiKey;
+
+    private LiveTennisClient(Builder builder) {
+        this.baseUrl = normalizeBaseUrl(builder.baseUrl);
+        this.apiKey = ensureNotBlank(builder.apiKey, "apiKey");
+        Duration timeout = Objects.requireNonNull(builder.timeout, "timeout must not be null");
+        HttpClientBuilder httpClientBuilder = HttpClientBuilderLoader.loadHttpClientBuilder()
+                .connectTimeout(timeout)
+                .readTimeout(timeout);
+        this.httpClient = httpClientBuilder.build();
+    }
+
+    /**
+     * Creates a new Live Tennis API client builder.
+     *
+     * @return a new builder
+     */
+    static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Lists the matches currently in play.
+     *
+     * @param tour tour filter, or {@code null} for all tours
+     * @param draw {@code singles}, {@code doubles}, or {@code null} for both
+     * @param limit result limit from 1 through 200, or {@code null} for 10
+     * @return Live Tennis API response JSON
+     */
+    JsonNode listLiveMatches(String tour, String draw, Integer limit) {
+        StringBuilder path = new StringBuilder("/matches?status=live&limit=").append(normalizeLimit(limit));
+        appendOptional(path, "tour", normalizeEnum(tour, TOURS, "tour"));
+        appendOptional(path, "draw", normalizeEnum(draw, DRAWS, "draw"));
+        return get(path.toString());
+    }
+
+    /**
+     * Reads the full detail of one match.
+     *
+     * @param matchId the match id
+     * @return Live Tennis API response JSON
+     */
+    JsonNode getMatch(long matchId) {
+        return get("/matches/" + normalizeMatchId(matchId));
+    }
+
+    /**
+     * Lists upcoming scheduled fixtures, earliest first.
+     *
+     * @param tour tour filter, or {@code null} for all tours
+     * @param draw {@code singles}, {@code doubles}, or {@code null} for both
+     * @param limit result limit from 1 through 200, or {@code null} for 10
+     * @return Live Tennis API response JSON
+     */
+    JsonNode listFixtures(String tour, String draw, Integer limit) {
+        StringBuilder path = new StringBuilder("/fixtures?limit=").append(normalizeLimit(limit));
+        appendOptional(path, "tour", normalizeEnum(tour, TOURS, "tour"));
+        appendOptional(path, "draw", normalizeEnum(draw, DRAWS, "draw"));
+        return get(path.toString());
+    }
+
+    /**
+     * Reads one published ranking table in rank order.
+     *
+     * @param system ranking system, one of {@link #RANKING_SYSTEMS}
+     * @param asOf {@code YYYY-MM-DD} publication date, or {@code null} for the latest table
+     * @param limit result limit from 1 through 200, or {@code null} for 10
+     * @return Live Tennis API response JSON
+     */
+    JsonNode listRankings(String system, String asOf, Integer limit) {
+        StringBuilder path = new StringBuilder("/rankings?system=")
+                .append(normalizeEnum(ensureNotBlank(system, "system"), RANKING_SYSTEMS, "system"))
+                .append("&limit=")
+                .append(normalizeLimit(limit));
+        appendOptional(path, "as_of", normalizeDate(asOf));
+        return get(path.toString());
+    }
+
+    /**
+     * Reads the head-to-head record between two players.
+     *
+     * @param player1 first player name, at least three characters
+     * @param player2 second player name, at least three characters
+     * @return Live Tennis API response JSON
+     */
+    JsonNode getHeadToHead(String player1, String player2) {
+        String path = "/h2h?p1=" + encode(normalizePlayerName(player1, "player1")) + "&p2="
+                + encode(normalizePlayerName(player2, "player2"));
+        return get(path);
+    }
+
+    private JsonNode get(String path) {
+        HttpRequest request = HttpRequest.builder()
+                .url(baseUrl + path)
+                .method(GET)
+                .addHeader("Accept", "application/json")
+                .addHeader("User-Agent", "langchain4j-community-tool-live-tennis")
+                .addHeader("X-API-Key", apiKey)
+                .build();
+        return send(request);
+    }
+
+    private JsonNode send(HttpRequest request) {
+        try {
+            SuccessfulHttpResponse response = httpClient.execute(request);
+            String body = response.body();
+            if (body == null || body.isBlank()) {
+                throw new LiveTennisClientException("The Live Tennis API returned an empty response.");
+            }
+            if (body.getBytes(StandardCharsets.UTF_8).length > MAX_RESPONSE_BYTES) {
+                throw new LiveTennisClientException("The Live Tennis API response exceeds the 5 MiB safety limit.");
+            }
+            return OBJECT_MAPPER.readTree(body);
+        } catch (HttpException e) {
+            throw new LiveTennisClientException(e.statusCode(), httpErrorMessage(e.statusCode()), e);
+        } catch (JsonProcessingException e) {
+            throw new LiveTennisClientException("The Live Tennis API returned invalid JSON.", e);
+        } catch (LiveTennisClientException e) {
+            throw e;
+        } catch (RuntimeException e) {
+            throw new LiveTennisClientException("The Live Tennis API request failed.", e);
+        }
+    }
+
+    private static void appendOptional(StringBuilder path, String name, String value) {
+        if (value != null) {
+            path.append('&').append(name).append('=').append(encode(value));
+        }
+    }
+
+    private static String httpErrorMessage(int statusCode) {
+        String guidance =
+                switch (statusCode) {
+                    case 400 -> "Invalid request. Check the tool arguments.";
+                    case 401 -> "Authentication failed. Check the API key.";
+                    case 403 -> "The API key's plan does not include this endpoint.";
+                    case 404 -> "Requested tennis resource not found.";
+                    case 410 -> "That match id was merged into another match record.";
+                    case 429 -> "Rate limit or daily quota exceeded. Retry later.";
+                    default -> "Request could not be completed.";
+                };
+        return "Live Tennis API request failed: HTTP " + statusCode + ". " + guidance;
+    }
+
+    private static int normalizeLimit(Integer limit) {
+        int value = limit == null ? DEFAULT_LIMIT : limit;
+        if (value < 1 || value > MAX_LIMIT) {
+            throw new IllegalArgumentException("limit must be between 1 and " + MAX_LIMIT);
+        }
+        return value;
+    }
+
+    private static long normalizeMatchId(long matchId) {
+        if (matchId < 1) {
+            throw new IllegalArgumentException("matchId must be a positive match id");
+        }
+        return matchId;
+    }
+
+    private static String normalizeEnum(String value, Set<String> allowed, String name) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        String normalized = value.trim().toLowerCase(Locale.ROOT);
+        if (!allowed.contains(normalized)) {
+            throw new IllegalArgumentException(
+                    name + " must be one of " + allowed.stream().sorted().toList());
+        }
+        return normalized;
+    }
+
+    private static String normalizeDate(String date) {
+        if (date == null || date.isBlank()) {
+            return null;
+        }
+        String normalized = date.trim();
+        if (!DATE.matcher(normalized).matches()) {
+            throw new IllegalArgumentException("as_of must be a YYYY-MM-DD date");
+        }
+        return normalized;
+    }
+
+    private static String normalizePlayerName(String name, String parameter) {
+        String normalized = ensureNotBlank(name, parameter).trim();
+        if (normalized.length() < MIN_PLAYER_NAME_LENGTH) {
+            throw new IllegalArgumentException(parameter + " must be at least " + MIN_PLAYER_NAME_LENGTH
+                    + " characters, so it can identify one player");
+        }
+        return normalized;
+    }
+
+    private static String encode(String value) {
+        return URLEncoder.encode(value, StandardCharsets.UTF_8);
+    }
+
+    private static String normalizeBaseUrl(String baseUrl) {
+        String value = baseUrl == null || baseUrl.isBlank() ? DEFAULT_BASE_URL : baseUrl.trim();
+        while (value.endsWith("/")) {
+            value = value.substring(0, value.length() - 1);
+        }
+        URI uri;
+        try {
+            uri = URI.create(value);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("baseUrl is not a valid URL", e);
+        }
+        String scheme = uri.getScheme();
+        if (scheme == null || !("http".equalsIgnoreCase(scheme) || "https".equalsIgnoreCase(scheme))) {
+            throw new IllegalArgumentException("baseUrl must use HTTP or HTTPS");
+        }
+        if (uri.getHost() == null) {
+            throw new IllegalArgumentException("baseUrl must include a host");
+        }
+        return value;
+    }
+
+    /**
+     * Builder for {@link LiveTennisClient}.
+     */
+    static final class Builder {
+
+        private String apiKey;
+        private String baseUrl = DEFAULT_BASE_URL;
+        private Duration timeout = Duration.ofSeconds(30);
+
+        private Builder() {}
+
+        /**
+         * Sets the Live Tennis API key.
+         *
+         * @param apiKey Live Tennis API key
+         * @return this builder
+         */
+        Builder apiKey(String apiKey) {
+            this.apiKey = apiKey;
+            return this;
+        }
+
+        /**
+         * Sets the API base URL. Defaults to {@code https://api.livetennisapi.com/api/public/v1}.
+         *
+         * @param baseUrl API base URL
+         * @return this builder
+         */
+        Builder baseUrl(String baseUrl) {
+            this.baseUrl = baseUrl;
+            return this;
+        }
+
+        /**
+         * Sets connection and read timeouts.
+         *
+         * @param timeout connection and read timeout
+         * @return this builder
+         */
+        Builder timeout(Duration timeout) {
+            this.timeout = Objects.requireNonNull(timeout, "timeout must not be null");
+            return this;
+        }
+
+        /**
+         * Builds the client.
+         *
+         * @return configured Live Tennis API client
+         */
+        LiveTennisClient build() {
+            return new LiveTennisClient(this);
+        }
+    }
+}

--- a/tools/langchain4j-community-tool-live-tennis/src/main/java/dev/langchain4j/community/tool/livetennis/LiveTennisClientException.java
+++ b/tools/langchain4j-community-tool-live-tennis/src/main/java/dev/langchain4j/community/tool/livetennis/LiveTennisClientException.java
@@ -1,0 +1,32 @@
+package dev.langchain4j.community.tool.livetennis;
+
+/**
+ * Raised when a Live Tennis API request fails.
+ */
+final class LiveTennisClientException extends RuntimeException {
+
+    /** HTTP status, or -1 when the request received no HTTP response. */
+    private final int statusCode;
+
+    LiveTennisClientException(String message) {
+        this(-1, message, null);
+    }
+
+    LiveTennisClientException(String message, Throwable cause) {
+        this(-1, message, cause);
+    }
+
+    LiveTennisClientException(int statusCode, String message, Throwable cause) {
+        super(message, cause);
+        this.statusCode = statusCode;
+    }
+
+    /**
+     * Returns the HTTP status, or {@code -1} when no response was received.
+     *
+     * @return HTTP status or -1
+     */
+    int statusCode() {
+        return statusCode;
+    }
+}

--- a/tools/langchain4j-community-tool-live-tennis/src/main/java/dev/langchain4j/community/tool/livetennis/LiveTennisTool.java
+++ b/tools/langchain4j-community-tool-live-tennis/src/main/java/dev/langchain4j/community/tool/livetennis/LiveTennisTool.java
@@ -1,0 +1,540 @@
+package dev.langchain4j.community.tool.livetennis;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import dev.langchain4j.agent.tool.P;
+import dev.langchain4j.agent.tool.Tool;
+import java.time.Duration;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Agent tools for read-only tennis data from the Live Tennis API: live scores, match detail,
+ * upcoming fixtures, published ranking tables and head-to-head records.
+ *
+ * <p>Endpoint access is plan-tiered. Live matches, match detail and fixtures are on the free plan
+ * (30 requests/minute, 100/day); head-to-head requires a paid history plan and the ranking table
+ * requires the next plan above it. A call above the key's plan is reported back to the model as an
+ * error rather than an empty result.
+ *
+ * <pre>{@code
+ * LiveTennisTool tool = LiveTennisTool.builder()
+ *         .apiKey(System.getenv("LIVE_TENNIS_API_KEY"))
+ *         .build();
+ * }</pre>
+ */
+public final class LiveTennisTool {
+
+    private static final String UNKNOWN_CELL = "?";
+    private static final int MAX_TEXT_LENGTH = 120;
+    private static final int MAX_MEETINGS = 10;
+    private static final int MAX_SETS = 5;
+
+    private final LiveTennisClient client;
+
+    LiveTennisTool(LiveTennisClient client) {
+        this.client = Objects.requireNonNull(client, "client must not be null");
+    }
+
+    /**
+     * Creates a new Live Tennis tool builder.
+     *
+     * @return a new builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Lists the tennis matches currently in play, with their live scores.
+     *
+     * @param tour tour filter
+     * @param draw singles or doubles
+     * @param limit number of matches
+     * @return agent-friendly live match summaries
+     */
+    @Tool("List the tennis matches currently in play, with live scores.")
+    public String getLiveMatches(
+            @P(value = "Tour: atp, wta, challenger, itf or juniors. Defaults to all tours", required = false)
+                    String tour,
+            @P(value = "Draw: singles or doubles. Defaults to both", required = false) String draw,
+            @P(value = "Number of matches from 1 through 200. Defaults to 10", required = false) Integer limit) {
+        try {
+            return formatMatchList(client.listLiveMatches(tour, draw, limit), "No matches are in play right now.");
+        } catch (RuntimeException e) {
+            return formatError(e);
+        }
+    }
+
+    /**
+     * Reads the full detail of one match, including its current score.
+     *
+     * @param matchId the match id
+     * @return agent-friendly match detail
+     */
+    @Tool("Get full detail and the current score of one tennis match by its numeric match id.")
+    public String getMatch(@P("Numeric match id, as returned by the live match or fixture tools") long matchId) {
+        try {
+            return formatMatchDetail(client.getMatch(matchId));
+        } catch (RuntimeException e) {
+            return formatError(e);
+        }
+    }
+
+    /**
+     * Lists upcoming scheduled fixtures, earliest first.
+     *
+     * @param tour tour filter
+     * @param draw singles or doubles
+     * @param limit number of fixtures
+     * @return agent-friendly fixture summaries
+     */
+    @Tool("List upcoming scheduled tennis fixtures, earliest first.")
+    public String getUpcomingFixtures(
+            @P(value = "Tour: atp, wta, challenger, itf or juniors. Defaults to all tours", required = false)
+                    String tour,
+            @P(value = "Draw: singles or doubles. Defaults to both", required = false) String draw,
+            @P(value = "Number of fixtures from 1 through 200. Defaults to 10", required = false) Integer limit) {
+        try {
+            return formatFixtures(client.listFixtures(tour, draw, limit));
+        } catch (RuntimeException e) {
+            return formatError(e);
+        }
+    }
+
+    /**
+     * Reads one published ranking table in rank order.
+     *
+     * @param system ranking system
+     * @param asOf publication date
+     * @param limit number of ranked players
+     * @return agent-friendly ranking table
+     */
+    @Tool("Get a published tennis ranking table in rank order (ATP, WTA, their doubles tables, or ITF circuits).")
+    public String getRankings(
+            @P("Ranking system: atp, wta, atp_doubles, wta_doubles, itf_jt, itf_mt or itf_wt") String system,
+            @P(value = "Table date as YYYY-MM-DD. Defaults to the latest table", required = false) String asOf,
+            @P(value = "Number of ranked players from 1 through 200. Defaults to 10", required = false) Integer limit) {
+        try {
+            return formatRankings(client.listRankings(system, asOf, limit), system);
+        } catch (RuntimeException e) {
+            return formatError(e);
+        }
+    }
+
+    /**
+     * Reads the head-to-head record between two players.
+     *
+     * @param player1 first player name
+     * @param player2 second player name
+     * @return agent-friendly head-to-head record
+     */
+    @Tool("Get the head-to-head record between two tennis players, by name, back to 1968.")
+    public String getHeadToHead(
+            @P("First player's name or surname, at least 3 characters") String player1,
+            @P("Second player's name or surname, at least 3 characters") String player2) {
+        try {
+            return formatHeadToHead(client.getHeadToHead(player1, player2), player1, player2);
+        } catch (RuntimeException e) {
+            return formatError(e);
+        }
+    }
+
+    private static String formatMatchList(JsonNode response, String emptyMessage) {
+        JsonNode matches = response.path("data");
+        if (!matches.isArray() || matches.isEmpty()) {
+            return emptyMessage;
+        }
+
+        StringBuilder result = new StringBuilder();
+        for (JsonNode match : matches) {
+            if (!result.isEmpty()) {
+                result.append(System.lineSeparator());
+            }
+            result.append("- [")
+                    .append(match.path("id").asLong())
+                    .append("] ")
+                    .append(matchContext(match))
+                    .append(": ")
+                    .append(playerName(match, "p1"))
+                    .append(" vs ")
+                    .append(playerName(match, "p2"))
+                    .append(" — ")
+                    .append(formatScore(match.path("score")));
+        }
+        return result.append(System.lineSeparator())
+                .append(paginationNote(response.path("meta")))
+                .toString();
+    }
+
+    private static String formatMatchDetail(JsonNode match) {
+        StringBuilder result = new StringBuilder("Match ")
+                .append(match.path("id").asLong())
+                .append(": ")
+                .append(playerName(match, "p1"))
+                .append(" vs ")
+                .append(playerName(match, "p2"))
+                .append(System.lineSeparator())
+                .append(matchContext(match))
+                .append(System.lineSeparator())
+                .append("Status: ")
+                .append(text(match, "status", "unknown"));
+
+        appendIfPresent(result, "Ended as", text(match, "event_status", ""));
+        appendIfPresent(result, "Outcome", text(match, "outcome", ""));
+        appendIfPresent(result, "Scheduled", text(match, "scheduled_time", ""));
+        result.append(System.lineSeparator()).append("Score: ").append(formatScore(match.path("score")));
+
+        JsonNode winner = match.path("winner");
+        if (winner.isInt()) {
+            result.append(System.lineSeparator())
+                    .append("Winner: ")
+                    .append(playerName(match, winner.asInt() == 2 ? "p2" : "p1"));
+        }
+        return result.toString();
+    }
+
+    private static String formatFixtures(JsonNode response) {
+        JsonNode fixtures = response.path("data");
+        if (!fixtures.isArray() || fixtures.isEmpty()) {
+            return "No upcoming fixtures found.";
+        }
+
+        StringBuilder result = new StringBuilder();
+        for (JsonNode fixture : fixtures) {
+            String start = text(fixture, "start_time", text(fixture, "event_date", "time to be confirmed"));
+            if (!result.isEmpty()) {
+                result.append(System.lineSeparator());
+            }
+            result.append("- [")
+                    .append(fixture.path("id").asLong())
+                    .append("] ")
+                    .append(start)
+                    .append(" ")
+                    .append(truncate(text(fixture, "tournament", "unknown tournament")))
+                    .append(roundSuffix(fixture))
+                    .append(surfaceSuffix(fixture))
+                    .append(": ")
+                    .append(truncate(text(fixture, "player1_name", "unknown")))
+                    .append(" vs ")
+                    .append(truncate(text(fixture, "player2_name", "unknown")));
+        }
+        return result.append(System.lineSeparator())
+                .append(paginationNote(response.path("meta")))
+                .toString();
+    }
+
+    private static String formatRankings(JsonNode response, String requestedSystem) {
+        JsonNode records = response.path("data");
+        if (!records.isArray() || records.isEmpty()) {
+            return "No ranking records found.";
+        }
+
+        String effectiveDate =
+                text(response.path("meta").path("coverage"), "effective_date", "an unstated publication week");
+        StringBuilder result = new StringBuilder(requestedSystem.trim().toLowerCase(Locale.ROOT))
+                .append(" ranking table, published ")
+                .append(effectiveDate)
+                .append(":");
+        for (JsonNode record : records) {
+            result.append(System.lineSeparator()).append("- ");
+            JsonNode rank = record.path("rank");
+            result.append(rank.isInt() ? rank.asInt() + "." : "unranked.")
+                    .append(" ")
+                    .append(truncate(text(record, "player_name", "unknown player")));
+            JsonNode points = record.path("points");
+            if (points.isInt()) {
+                result.append(" — ").append(points.asInt()).append(" points");
+            }
+            JsonNode rating = record.path("rating");
+            if (rating.isNumber()) {
+                result.append(" — rating ").append(rating.asDouble());
+            }
+        }
+        return result.append(System.lineSeparator())
+                .append(paginationNote(response.path("meta")))
+                .toString();
+    }
+
+    private static String formatHeadToHead(JsonNode response, String requested1, String requested2) {
+        JsonNode players = response.path("players");
+        if (!players.isObject()) {
+            return "No head-to-head record found for " + truncate(requested1) + " and " + truncate(requested2) + ".";
+        }
+        String name1 = truncate(text(players.path("p1"), "name", requested1));
+        String name2 = truncate(text(players.path("p2"), "name", requested2));
+
+        JsonNode totals = response.path("totals");
+        StringBuilder result = new StringBuilder("Head-to-head: ")
+                .append(name1)
+                .append(" vs ")
+                .append(name2)
+                .append(System.lineSeparator())
+                .append("Record: ")
+                .append(totals.path("p1_wins").asInt(0))
+                .append("-")
+                .append(totals.path("p2_wins").asInt(0))
+                .append(" over ")
+                .append(totals.path("meetings").asInt(0))
+                .append(" decided meetings");
+        int undecided = totals.path("undecided").asInt(0);
+        if (undecided > 0) {
+            result.append(" (").append(undecided).append(" with no derivable winner)");
+        }
+
+        JsonNode bySurface = response.path("by_surface");
+        if (bySurface.isObject() && !bySurface.isEmpty()) {
+            result.append(System.lineSeparator()).append("By surface:");
+            for (Map.Entry<String, JsonNode> surface : bySurface.properties()) {
+                result.append(" ")
+                        .append(surface.getKey())
+                        .append(" ")
+                        .append(surface.getValue().path("p1").asInt(0))
+                        .append("-")
+                        .append(surface.getValue().path("p2").asInt(0));
+            }
+        }
+
+        JsonNode meetings = response.path("meetings");
+        if (meetings.isArray() && !meetings.isEmpty()) {
+            result.append(System.lineSeparator()).append("Recent meetings, newest first:");
+            int shown = 0;
+            for (JsonNode meeting : meetings) {
+                if (shown++ == MAX_MEETINGS) {
+                    result.append(System.lineSeparator())
+                            .append("(")
+                            .append(meetings.size() - MAX_MEETINGS)
+                            .append(" older meetings not shown)");
+                    break;
+                }
+                JsonNode winner = meeting.path("winner");
+                String verdict = winner.isInt() ? (winner.asInt() == 2 ? name2 : name1) + " won" : "no winner recorded";
+                result.append(System.lineSeparator())
+                        .append("- ")
+                        .append(text(meeting, "date", "undated"))
+                        .append(" ")
+                        .append(truncate(text(meeting, "tournament", "unknown tournament")))
+                        .append(roundSuffix(meeting))
+                        .append(surfaceSuffix(meeting))
+                        .append(": ")
+                        .append(verdict)
+                        .append(scoreSuffix(meeting));
+            }
+        }
+        return result.toString();
+    }
+
+    private static String matchContext(JsonNode match) {
+        StringBuilder context =
+                new StringBuilder(truncate(text(match, "tournament", "unknown tournament"))).append(" (");
+        context.append(text(match, "tour", "tour unstated"));
+        appendCommaSeparated(context, text(match, "surface", ""));
+        appendCommaSeparated(context, text(match, "draw", ""));
+        appendCommaSeparated(context, match.path("indoor").asBoolean(false) ? "indoor" : "");
+        return context.append(")").append(roundSuffix(match)).toString();
+    }
+
+    private static void appendCommaSeparated(StringBuilder builder, String value) {
+        if (!value.isBlank()) {
+            builder.append(", ").append(value);
+        }
+    }
+
+    private static void appendIfPresent(StringBuilder builder, String label, String value) {
+        if (!value.isBlank()) {
+            builder.append(System.lineSeparator()).append(label).append(": ").append(value);
+        }
+    }
+
+    private static String roundSuffix(JsonNode node) {
+        String round = text(node, "round", text(node, "round_code", ""));
+        return round.isBlank() ? "" : " " + truncate(round);
+    }
+
+    private static String surfaceSuffix(JsonNode node) {
+        String surface = text(node, "surface", "");
+        return surface.isBlank() ? "" : " [" + surface + "]";
+    }
+
+    private static String scoreSuffix(JsonNode meeting) {
+        String score = text(meeting, "score", "");
+        String outcome = text(meeting, "outcome", "");
+        StringBuilder suffix = new StringBuilder();
+        if (!score.isBlank()) {
+            suffix.append(" ").append(truncate(score));
+        }
+        if (!outcome.isBlank() && !"completed".equals(outcome)) {
+            suffix.append(" (").append(outcome).append(")");
+        }
+        return suffix.toString();
+    }
+
+    private static String formatScore(JsonNode score) {
+        if (!score.isObject()) {
+            return "no score yet";
+        }
+
+        StringBuilder result = new StringBuilder();
+        String sets = sidePair(score.path("sets"));
+        if (!sets.isBlank()) {
+            result.append("sets ").append(sets);
+        }
+        String games = formatGames(score.path("games"));
+        if (!games.isBlank()) {
+            appendSegment(result, "games " + games);
+        }
+        String points = sidePair(score.path("points"));
+        if (!points.isBlank()) {
+            appendSegment(result, (score.path("is_tiebreak").asBoolean(false) ? "tiebreak " : "points ") + points);
+        }
+        JsonNode server = score.path("server");
+        if (server.isInt()) {
+            appendSegment(result, "player " + server.asInt() + " serving");
+        }
+        return result.isEmpty() ? "no score yet" : result.toString();
+    }
+
+    private static void appendSegment(StringBuilder result, String segment) {
+        if (!result.isEmpty()) {
+            result.append("; ");
+        }
+        result.append(segment);
+    }
+
+    /**
+     * Formats the player-major {@code games} array as per-set pairs: {@code [[6,3],[4,4]]} reads
+     * {@code 6-4 3-4}.
+     */
+    private static String formatGames(JsonNode games) {
+        if (!games.isArray() || games.size() < 2) {
+            return "";
+        }
+        JsonNode p1 = games.get(0);
+        JsonNode p2 = games.get(1);
+        if (!p1.isArray() || !p2.isArray()) {
+            return "";
+        }
+        int setCount = Math.min(MAX_SETS, Math.max(p1.size(), p2.size()));
+        StringBuilder result = new StringBuilder();
+        for (int set = 0; set < setCount; set++) {
+            if (!result.isEmpty()) {
+                result.append(" ");
+            }
+            result.append(cell(p1.path(set))).append("-").append(cell(p2.path(set)));
+        }
+        return result.toString();
+    }
+
+    /** Formats a two-entry player-major array, such as {@code sets} or {@code points}. */
+    private static String sidePair(JsonNode pair) {
+        if (!pair.isArray() || pair.size() < 2) {
+            return "";
+        }
+        String p1 = cell(pair.get(0));
+        String p2 = cell(pair.get(1));
+        return UNKNOWN_CELL.equals(p1) && UNKNOWN_CELL.equals(p2) ? "" : p1 + "-" + p2;
+    }
+
+    /** Renders one score cell, or {@code ?} where the API reports a null the score shape allows. */
+    private static String cell(JsonNode value) {
+        return value.isNumber() || value.isTextual() ? value.asText() : UNKNOWN_CELL;
+    }
+
+    private static String playerName(JsonNode match, String side) {
+        JsonNode player = match.path("players").path(side);
+        String name = truncate(text(player, "name", "unknown"));
+        JsonNode ranking = player.path("ranking");
+        return ranking.isInt() ? name + " (#" + ranking.asInt() + ")" : name;
+    }
+
+    private static String paginationNote(JsonNode meta) {
+        int count = meta.path("count").asInt(0);
+        StringBuilder note = new StringBuilder("Showing ").append(count);
+        JsonNode total = meta.path("total");
+        if (total.isInt()) {
+            note.append(" of ").append(total.asInt());
+        }
+        if (meta.path("has_more").asBoolean(false)) {
+            note.append("; more available, raise the limit to see them");
+        }
+        return note.append(".").toString();
+    }
+
+    private static String text(JsonNode node, String field, String fallback) {
+        JsonNode value = node.path(field);
+        return value.isTextual() && !value.asText().isBlank() ? value.asText() : fallback;
+    }
+
+    private static String truncate(String text) {
+        if (text.length() <= MAX_TEXT_LENGTH) {
+            return text;
+        }
+        return text.substring(0, MAX_TEXT_LENGTH - 3) + "...";
+    }
+
+    private static String formatError(RuntimeException error) {
+        String message = error.getMessage();
+        return message == null || message.isBlank()
+                ? "Error: the Live Tennis API request failed."
+                : "Error: " + message;
+    }
+
+    /**
+     * Builder for {@link LiveTennisTool}.
+     */
+    public static final class Builder {
+
+        private String apiKey;
+        private String baseUrl;
+        private Duration timeout = Duration.ofSeconds(30);
+
+        private Builder() {}
+
+        /**
+         * Sets the Live Tennis API key, sent as the {@code X-API-Key} header.
+         *
+         * @param apiKey Live Tennis API key
+         * @return this builder
+         */
+        public Builder apiKey(String apiKey) {
+            this.apiKey = apiKey;
+            return this;
+        }
+
+        /**
+         * Sets the API base URL. Defaults to {@code https://api.livetennisapi.com/api/public/v1}.
+         *
+         * @param baseUrl API base URL
+         * @return this builder
+         */
+        public Builder baseUrl(String baseUrl) {
+            this.baseUrl = baseUrl;
+            return this;
+        }
+
+        /**
+         * Sets connection and read timeouts.
+         *
+         * @param timeout connection and read timeout
+         * @return this builder
+         */
+        public Builder timeout(Duration timeout) {
+            this.timeout = Objects.requireNonNull(timeout, "timeout must not be null");
+            return this;
+        }
+
+        /**
+         * Builds the tool.
+         *
+         * @return configured Live Tennis tool
+         */
+        public LiveTennisTool build() {
+            LiveTennisClient.Builder clientBuilder =
+                    LiveTennisClient.builder().apiKey(apiKey).timeout(timeout);
+            if (baseUrl != null) {
+                clientBuilder.baseUrl(baseUrl);
+            }
+            return new LiveTennisTool(clientBuilder.build());
+        }
+    }
+}

--- a/tools/langchain4j-community-tool-live-tennis/src/test/java/dev/langchain4j/community/tool/livetennis/LiveTennisClientTest.java
+++ b/tools/langchain4j-community-tool-live-tennis/src/test/java/dev/langchain4j/community/tool/livetennis/LiveTennisClientTest.java
@@ -1,0 +1,284 @@
+package dev.langchain4j.community.tool.livetennis;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+
+class LiveTennisClientTest {
+
+    @Test
+    void listLiveMatches_sendsApiKeyHeaderAndFilters() throws Exception {
+        AtomicReference<RecordedRequest> recorded = new AtomicReference<>();
+        try (TestServer server = startServer(200, "{\"data\":[],\"meta\":{\"count\":0}}", recorded)) {
+            LiveTennisClient client = client(server);
+
+            JsonNode response = client.listLiveMatches("ATP", "Singles", 25);
+
+            assertThat(response.path("data").isArray()).isTrue();
+            RecordedRequest request = recorded.get();
+            assertThat(request.method).isEqualTo("GET");
+            assertThat(request.pathAndQuery).isEqualTo("/matches?status=live&limit=25&tour=atp&draw=singles");
+            assertThat(request.apiKey).isEqualTo("test-key");
+            assertThat(request.accept).isEqualTo("application/json");
+            assertThat(request.userAgent).isEqualTo("langchain4j-community-tool-live-tennis");
+        }
+    }
+
+    @Test
+    void listLiveMatches_omitsUnsetFiltersAndDefaultsTheLimit() throws Exception {
+        AtomicReference<RecordedRequest> recorded = new AtomicReference<>();
+        try (TestServer server = startServer(200, "{\"data\":[]}", recorded)) {
+            LiveTennisClient client = client(server);
+
+            client.listLiveMatches(null, "  ", null);
+
+            assertThat(recorded.get().pathAndQuery).isEqualTo("/matches?status=live&limit=10");
+        }
+    }
+
+    @Test
+    void getMatch_readsOneMatchById() throws Exception {
+        AtomicReference<RecordedRequest> recorded = new AtomicReference<>();
+        try (TestServer server = startServer(200, "{\"id\":187701}", recorded)) {
+            LiveTennisClient client = client(server);
+
+            assertThat(client.getMatch(187701).path("id").asLong()).isEqualTo(187701L);
+            assertThat(recorded.get().pathAndQuery).isEqualTo("/matches/187701");
+        }
+    }
+
+    @Test
+    void listFixtures_pagesWithTourAndDrawFilters() throws Exception {
+        AtomicReference<RecordedRequest> recorded = new AtomicReference<>();
+        try (TestServer server = startServer(200, "{\"data\":[]}", recorded)) {
+            LiveTennisClient client = client(server);
+
+            client.listFixtures("challenger", "doubles", 5);
+
+            assertThat(recorded.get().pathAndQuery).isEqualTo("/fixtures?limit=5&tour=challenger&draw=doubles");
+        }
+    }
+
+    @Test
+    void listRankings_requiresASystemAndAcceptsAnAsOfDate() throws Exception {
+        AtomicReference<RecordedRequest> recorded = new AtomicReference<>();
+        try (TestServer server = startServer(200, "{\"data\":[]}", recorded)) {
+            LiveTennisClient client = client(server);
+
+            client.listRankings("wta", "2026-09-08", 50);
+
+            assertThat(recorded.get().pathAndQuery).isEqualTo("/rankings?system=wta&limit=50&as_of=2026-09-08");
+        }
+    }
+
+    @Test
+    void getHeadToHead_encodesBothPlayerNames() throws Exception {
+        AtomicReference<RecordedRequest> recorded = new AtomicReference<>();
+        try (TestServer server = startServer(200, "{\"players\":null}", recorded)) {
+            LiveTennisClient client = client(server);
+
+            client.getHeadToHead("Iga Swiatek", "Aryna Sabalenka");
+
+            assertThat(recorded.get().pathAndQuery).isEqualTo("/h2h?p1=Iga+Swiatek&p2=Aryna+Sabalenka");
+        }
+    }
+
+    @Test
+    void preservesTheBaseUrlPathPrefix() throws Exception {
+        AtomicReference<RecordedRequest> recorded = new AtomicReference<>();
+        try (TestServer server = startServer(200, "{\"data\":[]}", recorded)) {
+            LiveTennisClient client = LiveTennisClient.builder()
+                    .apiKey("test-key")
+                    .baseUrl(server.baseUrl() + "/api/public/v1/")
+                    .timeout(Duration.ofSeconds(5))
+                    .build();
+
+            client.listLiveMatches(null, null, null);
+
+            assertThat(recorded.get().pathAndQuery).isEqualTo("/api/public/v1/matches?status=live&limit=10");
+        }
+    }
+
+    @Test
+    void rejectsArgumentsTheApiWouldRefuse() {
+        LiveTennisClient client = LiveTennisClient.builder()
+                .apiKey("test-key")
+                .baseUrl("http://localhost")
+                .build();
+
+        assertThatThrownBy(() -> client.listLiveMatches(null, null, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("limit must be between 1 and 200");
+        assertThatThrownBy(() -> client.listFixtures(null, null, 201))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("limit must be between 1 and 200");
+        assertThatThrownBy(() -> client.listLiveMatches("premier", null, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("tour must be one of [atp, challenger, itf, juniors, wta]");
+        assertThatThrownBy(() -> client.listLiveMatches(null, "mixed", null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("draw must be one of [doubles, singles]");
+        assertThatThrownBy(() -> client.getMatch(0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("matchId must be a positive match id");
+        assertThatThrownBy(() -> client.listRankings("utr", null, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("system must be one of [atp, atp_doubles, itf_jt, itf_mt, itf_wt, wta, wta_doubles]");
+        assertThatThrownBy(() -> client.listRankings("atp", "last week", null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("as_of must be a YYYY-MM-DD date");
+        assertThatThrownBy(() -> client.getHeadToHead("Li", "Sabalenka"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("player1 must be at least 3 characters, so it can identify one player");
+    }
+
+    @Test
+    void requiresApiKeyAndValidBaseUrl() {
+        assertThatThrownBy(() -> LiveTennisClient.builder().build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("apiKey cannot be null or blank");
+        assertThatThrownBy(() -> LiveTennisClient.builder()
+                        .apiKey("test-key")
+                        .baseUrl("file:///tmp/tennis")
+                        .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("baseUrl must use HTTP or HTTPS");
+        assertThatThrownBy(() -> LiveTennisClient.builder()
+                        .apiKey("test-key")
+                        .baseUrl("https:///api/public/v1")
+                        .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("baseUrl must include a host");
+        assertThatThrownBy(() -> LiveTennisClient.builder()
+                        .apiKey("test-key")
+                        .baseUrl("not a url")
+                        .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("baseUrl is not a valid URL");
+    }
+
+    @Test
+    void mapsHttpStatusesToRecoveryGuidanceWithoutExposingTheResponseBody() throws Exception {
+        assertHttpError(400, "Invalid request. Check the tool arguments.");
+        assertHttpError(401, "Authentication failed. Check the API key.");
+        assertHttpError(403, "The API key's plan does not include this endpoint.");
+        assertHttpError(404, "Requested tennis resource not found.");
+        assertHttpError(410, "That match id was merged into another match record.");
+        assertHttpError(429, "Rate limit or daily quota exceeded. Retry later.");
+        assertHttpError(500, "Request could not be completed.");
+    }
+
+    @Test
+    void carriesTheHttpStatusOnTheException() throws Exception {
+        AtomicReference<RecordedRequest> recorded = new AtomicReference<>();
+        try (TestServer server = startServer(429, "{\"error\":\"rate_limited\",\"scope\":\"day\"}", recorded)) {
+            LiveTennisClient client = client(server);
+
+            assertThatThrownBy(() -> client.listLiveMatches(null, null, null))
+                    .isInstanceOf(LiveTennisClientException.class)
+                    .extracting("statusCode")
+                    .isEqualTo(429);
+        }
+    }
+
+    @Test
+    void rejectsEmptyAndOversizedResponses() throws Exception {
+        AtomicReference<RecordedRequest> emptyRecorded = new AtomicReference<>();
+        try (TestServer server = startServer(200, "", emptyRecorded)) {
+            assertThatThrownBy(() -> client(server).listLiveMatches(null, null, null))
+                    .isInstanceOf(LiveTennisClientException.class)
+                    .hasMessage("The Live Tennis API returned an empty response.");
+        }
+
+        AtomicReference<RecordedRequest> largeRecorded = new AtomicReference<>();
+        String largeResponse = "\"" + "x".repeat(5 * 1024 * 1024) + "\"";
+        try (TestServer server = startServer(200, largeResponse, largeRecorded)) {
+            assertThatThrownBy(() -> client(server).listLiveMatches(null, null, null))
+                    .isInstanceOf(LiveTennisClientException.class)
+                    .hasMessage("The Live Tennis API response exceeds the 5 MiB safety limit.");
+        }
+    }
+
+    @Test
+    void rejectsInvalidJson() throws Exception {
+        AtomicReference<RecordedRequest> recorded = new AtomicReference<>();
+        try (TestServer server = startServer(200, "<html>maintenance</html>", recorded)) {
+            assertThatThrownBy(() -> client(server).listLiveMatches(null, null, null))
+                    .isInstanceOf(LiveTennisClientException.class)
+                    .hasMessage("The Live Tennis API returned invalid JSON.");
+        }
+    }
+
+    private static void assertHttpError(int statusCode, String guidance) throws Exception {
+        AtomicReference<RecordedRequest> recorded = new AtomicReference<>();
+        try (TestServer server = startServer(statusCode, "{\"detail\":\"not exposed\"}", recorded)) {
+            assertThatThrownBy(() -> client(server).listLiveMatches(null, null, null))
+                    .isInstanceOf(LiveTennisClientException.class)
+                    .hasMessage("Live Tennis API request failed: HTTP " + statusCode + ". " + guidance);
+        }
+    }
+
+    private static LiveTennisClient client(TestServer server) {
+        return LiveTennisClient.builder()
+                .apiKey("test-key")
+                .baseUrl(server.baseUrl())
+                .timeout(Duration.ofSeconds(5))
+                .build();
+    }
+
+    private static TestServer startServer(
+            int statusCode, String responseBody, AtomicReference<RecordedRequest> recorded) throws IOException {
+        HttpServer server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        server.setExecutor(executor);
+        server.createContext("/", exchange -> {
+            RecordedRequest request = new RecordedRequest();
+            request.method = exchange.getRequestMethod();
+            request.pathAndQuery = exchange.getRequestURI().toASCIIString();
+            request.apiKey = exchange.getRequestHeaders().getFirst("X-API-Key");
+            request.accept = exchange.getRequestHeaders().getFirst("Accept");
+            request.userAgent = exchange.getRequestHeaders().getFirst("User-Agent");
+            recorded.set(request);
+            byte[] responseBytes = responseBody.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(statusCode, responseBytes.length);
+            try (OutputStream outputStream = exchange.getResponseBody()) {
+                outputStream.write(responseBytes);
+            }
+        });
+        server.start();
+        return new TestServer(server, executor);
+    }
+
+    private record TestServer(HttpServer server, ExecutorService executor) implements AutoCloseable {
+
+        private String baseUrl() {
+            return "http://localhost:" + server.getAddress().getPort();
+        }
+
+        @Override
+        public void close() {
+            server.stop(0);
+            executor.shutdownNow();
+        }
+    }
+
+    private static final class RecordedRequest {
+        private String method;
+        private String pathAndQuery;
+        private String apiKey;
+        private String accept;
+        private String userAgent;
+    }
+}

--- a/tools/langchain4j-community-tool-live-tennis/src/test/java/dev/langchain4j/community/tool/livetennis/LiveTennisToolIT.java
+++ b/tools/langchain4j-community-tool-live-tennis/src/test/java/dev/langchain4j/community/tool/livetennis/LiveTennisToolIT.java
@@ -1,0 +1,68 @@
+package dev.langchain4j.community.tool.livetennis;
+
+import static dev.langchain4j.model.openai.OpenAiChatModelName.GPT_4_O_MINI;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.model.openai.OpenAiChatModel;
+import dev.langchain4j.service.AiServices;
+import dev.langchain4j.service.Result;
+import dev.langchain4j.service.tool.ToolExecution;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+@EnabledIfEnvironmentVariable(named = "LIVE_TENNIS_API_KEY", matches = ".+")
+class LiveTennisToolIT {
+
+    interface Assistant {
+        Result<String> chat(String userMessage);
+    }
+
+    @Test
+    void shouldReadTheLiveSlateFromTheRealApi() {
+        LiveTennisTool tool = LiveTennisTool.builder()
+                .apiKey(System.getenv("LIVE_TENNIS_API_KEY"))
+                .build();
+
+        String result = tool.getLiveMatches(null, "singles", 3);
+
+        assertThat(result).isNotBlank().doesNotStartWith("Error:");
+    }
+
+    @Test
+    void shouldListUpcomingFixturesFromTheRealApi() {
+        LiveTennisTool tool = LiveTennisTool.builder()
+                .apiKey(System.getenv("LIVE_TENNIS_API_KEY"))
+                .build();
+
+        String result = tool.getUpcomingFixtures("atp", "singles", 3);
+
+        assertThat(result).isNotBlank().doesNotStartWith("Error:");
+    }
+
+    @Test
+    @EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
+    void shouldAnswerALiveTennisQuestionThroughTheTool() {
+        OpenAiChatModel model = OpenAiChatModel.builder()
+                .baseUrl(System.getenv("OPENAI_BASE_URL"))
+                .apiKey(System.getenv("OPENAI_API_KEY"))
+                .organizationId(System.getenv("OPENAI_ORGANIZATION_ID"))
+                .modelName(GPT_4_O_MINI)
+                .temperature(0.0)
+                .strictTools(true)
+                .build();
+        LiveTennisTool tool = LiveTennisTool.builder()
+                .apiKey(System.getenv("LIVE_TENNIS_API_KEY"))
+                .build();
+        Assistant assistant =
+                AiServices.builder(Assistant.class).chatModel(model).tools(tool).build();
+
+        Result<String> result =
+                assistant.chat("Use the live tennis tool to list up to 3 tennis matches in play now, then summarize.");
+
+        assertThat(result.toolExecutions()).isNotEmpty();
+        ToolExecution execution = result.toolExecutions().get(0);
+        assertThat(execution.request().name()).isEqualTo("getLiveMatches");
+        assertThat(execution.result()).isNotBlank();
+        assertThat(result.content()).isNotBlank();
+    }
+}

--- a/tools/langchain4j-community-tool-live-tennis/src/test/java/dev/langchain4j/community/tool/livetennis/LiveTennisToolTest.java
+++ b/tools/langchain4j-community-tool-live-tennis/src/test/java/dev/langchain4j/community/tool/livetennis/LiveTennisToolTest.java
@@ -1,0 +1,331 @@
+package dev.langchain4j.community.tool.livetennis;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.Test;
+
+class LiveTennisToolTest {
+
+    private static final String LIVE_MATCH_RESPONSE = """
+            {
+              "data": [{
+                "id": 187701,
+                "tournament": "Wimbledon",
+                "tour": "atp",
+                "surface": "grass",
+                "indoor": false,
+                "round": "Round of 16",
+                "round_code": "R16",
+                "status": "live",
+                "draw": "singles",
+                "players": {
+                  "p1": {"id": 11, "name": "Carlos Alcaraz", "ranking": 2},
+                  "p2": {"id": 22, "name": "Jannik Sinner", "ranking": 1}
+                },
+                "score": {
+                  "sets": [1, 0],
+                  "games": [[6, 3], [4, 4]],
+                  "points": ["30", "15"],
+                  "server": 1,
+                  "is_tiebreak": false
+                }
+              }],
+              "meta": {"limit": 10, "offset": 0, "count": 1, "total": 3, "has_more": true}
+            }
+            """;
+
+    @Test
+    void getLiveMatches_formatsThePlayerMajorScore() throws Exception {
+        try (TestServer server = startServer(200, LIVE_MATCH_RESPONSE)) {
+            LiveTennisTool tool = tool(server);
+
+            String result = tool.getLiveMatches("atp", "singles", 10);
+
+            assertThat(result)
+                    .startsWith("- [187701] Wimbledon (atp, grass, singles) Round of 16: "
+                            + "Carlos Alcaraz (#2) vs Jannik Sinner (#1) — ")
+                    .contains("sets 1-0; games 6-4 3-4; points 30-15; player 1 serving")
+                    .endsWith("Showing 1 of 3; more available, raise the limit to see them.");
+        }
+    }
+
+    @Test
+    void getLiveMatches_saysSoWhenNothingIsInPlay() throws Exception {
+        try (TestServer server = startServer(200, "{\"data\":[],\"meta\":{\"count\":0,\"has_more\":false}}")) {
+            LiveTennisTool tool = tool(server);
+
+            assertThat(tool.getLiveMatches(null, null, null)).isEqualTo("No matches are in play right now.");
+        }
+    }
+
+    @Test
+    void getLiveMatches_readsATiebreakAsATiebreak() throws Exception {
+        String response = """
+                {"data":[{
+                  "id": 5,
+                  "tournament": "US Open",
+                  "tour": "wta",
+                  "players": {"p1": {"name": "A"}, "p2": {"name": "B"}},
+                  "score": {"sets":[1,1],"games":[[6,6],[4,6]],"points":["5","3"],"server":2,"is_tiebreak":true}
+                }],"meta":{"count":1,"has_more":false}}
+                """;
+        try (TestServer server = startServer(200, response)) {
+            LiveTennisTool tool = tool(server);
+
+            assertThat(tool.getLiveMatches(null, null, null)).contains("tiebreak 5-3; player 2 serving");
+        }
+    }
+
+    @Test
+    void getLiveMatches_toleratesTheNullScoreShapesTheApiDocuments() throws Exception {
+        String response = """
+                {"data":[
+                  {"id":1,"tournament":"T","tour":"itf","players":{"p1":{"name":"A"},"p2":{"name":"B"}},
+                   "score":{"sets":[2,0],"games":[[],[]],"points":[null,null],"server":null,"is_tiebreak":false}},
+                  {"id":2,"tournament":"T","tour":"itf","players":{"p1":{"name":"C"},"p2":{"name":"D"}},
+                   "score":null}
+                ],"meta":{"count":2,"has_more":false}}
+                """;
+        try (TestServer server = startServer(200, response)) {
+            LiveTennisTool tool = tool(server);
+
+            String result = tool.getLiveMatches(null, null, null);
+
+            assertThat(result).contains("A vs B — sets 2-0").contains("C vs D — no score yet");
+        }
+    }
+
+    @Test
+    void getMatch_reportsTheSettlementFields() throws Exception {
+        String response = """
+                {
+                  "id": 187701,
+                  "tournament": "Roland Garros",
+                  "tour": "atp",
+                  "surface": "clay",
+                  "indoor": false,
+                  "round": "QF",
+                  "status": "completed",
+                  "event_status": "Retired",
+                  "outcome": "retired",
+                  "draw": "singles",
+                  "scheduled_time": "2026-06-02T11:00:00Z",
+                  "players": {"p1": {"name": "Alice Smith"}, "p2": {"name": "Bob Jones"}},
+                  "score": {"sets":[2,0],"games":[[6,6],[3,4]],"points":[null,null],"server":null},
+                  "winner": 1
+                }
+                """;
+        try (TestServer server = startServer(200, response)) {
+            LiveTennisTool tool = tool(server);
+
+            String result = tool.getMatch(187701);
+
+            assertThat(result)
+                    .contains("Match 187701: Alice Smith vs Bob Jones")
+                    .contains("Roland Garros (atp, clay, singles) QF")
+                    .contains("Status: completed")
+                    .contains("Ended as: Retired")
+                    .contains("Outcome: retired")
+                    .contains("Scheduled: 2026-06-02T11:00:00Z")
+                    .contains("Score: sets 2-0; games 6-3 6-4")
+                    .contains("Winner: Alice Smith");
+        }
+    }
+
+    @Test
+    void getUpcomingFixtures_usesStartTimeAndFallsBackToTheDate() throws Exception {
+        String response = """
+                {"data":[
+                  {"id":190001,"start_time":"2026-09-15T11:00:00Z","event_date":"2026-09-15",
+                   "tournament":"US Open","round":"QF","surface":"hard",
+                   "player1_name":"Coco Gauff","player2_name":"Elena Rybakina"},
+                  {"id":190002,"start_time":null,"event_date":"2026-09-16",
+                   "tournament":"US Open","round":"SF","surface":"hard",
+                   "player1_name":"Iga Swiatek","player2_name":null}
+                ],"meta":{"count":2,"total":2,"has_more":false}}
+                """;
+        try (TestServer server = startServer(200, response)) {
+            LiveTennisTool tool = tool(server);
+
+            String result = tool.getUpcomingFixtures("wta", "singles", 2);
+
+            assertThat(result)
+                    .contains("- [190001] 2026-09-15T11:00:00Z US Open QF [hard]: Coco Gauff vs Elena Rybakina")
+                    .contains("- [190002] 2026-09-16 US Open SF [hard]: Iga Swiatek vs unknown")
+                    .endsWith("Showing 2 of 2.");
+        }
+    }
+
+    @Test
+    void getUpcomingFixtures_saysSoWhenThereAreNone() throws Exception {
+        try (TestServer server = startServer(200, "{\"data\":[],\"meta\":{\"count\":0}}")) {
+            assertThat(tool(server).getUpcomingFixtures(null, null, null)).isEqualTo("No upcoming fixtures found.");
+        }
+    }
+
+    @Test
+    void getRankings_printsTheTableWithItsPublicationWeek() throws Exception {
+        String response = """
+                {"data":[
+                  {"player_id":11,"player_name":"Jannik Sinner","system":"atp","rank":1,"points":11500},
+                  {"player_id":null,"player_name":"Carlos Alcaraz","system":"atp","rank":2,"points":9900}
+                ],"meta":{"count":2,"total":100,"has_more":true,
+                  "coverage":{"as_of":"2026-09-08","effective_date":"2026-09-08"}}}
+                """;
+        try (TestServer server = startServer(200, response)) {
+            LiveTennisTool tool = tool(server);
+
+            String result = tool.getRankings("ATP", "2026-09-08", 2);
+
+            assertThat(result)
+                    .startsWith("atp ranking table, published 2026-09-08:")
+                    .contains("- 1. Jannik Sinner — 11500 points")
+                    .contains("- 2. Carlos Alcaraz — 9900 points")
+                    .endsWith("Showing 2 of 100; more available, raise the limit to see them.");
+        }
+    }
+
+    @Test
+    void getHeadToHead_summarisesTheRecordAndRecentMeetings() throws Exception {
+        String response = """
+                {
+                  "players": {"p1": {"name": "Novak Djokovic"}, "p2": {"name": "Rafael Nadal"}},
+                  "totals": {"p1_wins": 31, "p2_wins": 29, "meetings": 60, "undecided": 1},
+                  "by_surface": {"hard": {"p1": 20, "p2": 7}, "clay": {"p1": 9, "p2": 20}},
+                  "meetings": [{
+                    "era": "archive", "date": "2022-05-31", "tournament": "Roland Garros",
+                    "round": "QF", "surface": "clay", "score": "6-2 4-6 6-2 7-6(4)",
+                    "outcome": "completed", "winner": 2
+                  }, {
+                    "era": "current", "date": "2023-06-09", "tournament": "Roland Garros",
+                    "round": "SF", "surface": "clay", "score": null,
+                    "outcome": "walkover", "winner": null
+                  }]
+                }
+                """;
+        try (TestServer server = startServer(200, response)) {
+            LiveTennisTool tool = tool(server);
+
+            String result = tool.getHeadToHead("Djokovic", "Nadal");
+
+            assertThat(result)
+                    .startsWith("Head-to-head: Novak Djokovic vs Rafael Nadal")
+                    .contains("Record: 31-29 over 60 decided meetings (1 with no derivable winner)")
+                    .contains("By surface: hard 20-7 clay 9-20")
+                    .contains("- 2022-05-31 Roland Garros QF [clay]: Rafael Nadal won 6-2 4-6 6-2 7-6(4)")
+                    .contains("- 2023-06-09 Roland Garros SF [clay]: no winner recorded (walkover)");
+        }
+    }
+
+    @Test
+    void getHeadToHead_reportsAnUnmatchedPairHonestly() throws Exception {
+        try (TestServer server = startServer(200, "{\"players\":null,\"totals\":{}}")) {
+            assertThat(tool(server).getHeadToHead("Nobody", "Nemo"))
+                    .isEqualTo("No head-to-head record found for Nobody and Nemo.");
+        }
+    }
+
+    @Test
+    void everyToolTurnsAPlanRefusalIntoAnActionableMessage() throws Exception {
+        try (TestServer server = startServer(403, "{\"error\":\"upgrade_required\"}")) {
+            LiveTennisTool tool = tool(server);
+            String expected = "Error: Live Tennis API request failed: HTTP 403. "
+                    + "The API key's plan does not include this endpoint.";
+
+            assertThat(tool.getLiveMatches(null, null, null)).isEqualTo(expected);
+            assertThat(tool.getMatch(187701)).isEqualTo(expected);
+            assertThat(tool.getUpcomingFixtures(null, null, null)).isEqualTo(expected);
+            assertThat(tool.getRankings("atp", null, null)).isEqualTo(expected);
+            assertThat(tool.getHeadToHead("Djokovic", "Nadal")).isEqualTo(expected);
+        }
+    }
+
+    @Test
+    void reportsTheDailyQuotaCeilingRatherThanThrowing() throws Exception {
+        try (TestServer server = startServer(429, "{\"error\":\"rate_limited\",\"scope\":\"day\"}")) {
+            assertThat(tool(server).getLiveMatches(null, null, null))
+                    .isEqualTo("Error: Live Tennis API request failed: HTTP 429. "
+                            + "Rate limit or daily quota exceeded. Retry later.");
+        }
+    }
+
+    @Test
+    void returnsValidationErrorsAsToolOutput() throws Exception {
+        try (TestServer server = startServer(200, "{\"data\":[]}")) {
+            LiveTennisTool tool = tool(server);
+
+            assertThat(tool.getLiveMatches("premier", null, null))
+                    .isEqualTo("Error: tour must be one of [atp, challenger, itf, juniors, wta]");
+            assertThat(tool.getUpcomingFixtures(null, null, 500)).isEqualTo("Error: limit must be between 1 and 200");
+            assertThat(tool.getRankings("elo", null, null))
+                    .isEqualTo("Error: system must be one of "
+                            + "[atp, atp_doubles, itf_jt, itf_mt, itf_wt, wta, wta_doubles]");
+            assertThat(tool.getHeadToHead("Li", "Nadal"))
+                    .isEqualTo("Error: player1 must be at least 3 characters, so it can identify one player");
+        }
+    }
+
+    @Test
+    void boundsTheTextItHandsBackToTheModel() throws Exception {
+        String response =
+                "{\"data\":[{\"id\":1,\"tournament\":\"%s\",\"tour\":\"itf\",\"players\":{\"p1\":{\"name\":\"A\"},\"p2\":{\"name\":\"B\"}}}],\"meta\":{\"count\":1}}"
+                        .formatted("T".repeat(400));
+        try (TestServer server = startServer(200, response)) {
+            String result = tool(server).getLiveMatches(null, null, null);
+
+            assertThat(result).contains("T".repeat(117) + "...").hasSizeLessThan(300);
+        }
+    }
+
+    @Test
+    void buildsWithTheDefaultBaseUrlWithoutCallingTheApi() {
+        LiveTennisTool tool = LiveTennisTool.builder().apiKey("test-key").build();
+
+        assertThat(tool).isNotNull();
+    }
+
+    private static LiveTennisTool tool(TestServer server) {
+        return LiveTennisTool.builder()
+                .apiKey("test-key")
+                .baseUrl(server.baseUrl())
+                .timeout(Duration.ofSeconds(5))
+                .build();
+    }
+
+    private static TestServer startServer(int statusCode, String responseBody) throws IOException {
+        HttpServer server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        server.setExecutor(executor);
+        server.createContext("/", exchange -> {
+            byte[] responseBytes = responseBody.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(statusCode, responseBytes.length);
+            try (OutputStream outputStream = exchange.getResponseBody()) {
+                outputStream.write(responseBytes);
+            }
+        });
+        server.start();
+        return new TestServer(server, executor);
+    }
+
+    private record TestServer(HttpServer server, ExecutorService executor) implements AutoCloseable {
+
+        private String baseUrl() {
+            return "http://localhost:" + server.getAddress().getPort();
+        }
+
+        @Override
+        public void close() {
+            server.stop(0);
+            executor.shutdownNow();
+        }
+    }
+}


### PR DESCRIPTION
**Affiliation disclosure:** I work on the Live Tennis API, the commercial service this module integrates. I am contributing the integration and will maintain it. Happy to take any changes you would prefer, including declining it if a vendor-authored tool is not wanted here. AI tooling was used while writing it; the code and the checks below are mine.

Opened as a draft per the contributing guide.

## Issue

Closes #781

## Change

Adds `tools/langchain4j-community-tool-live-tennis`, read-only agent tools over the Live Tennis API covering ATP, WTA, Challenger and ITF:

| `@Tool` method | Endpoint |
|---|---|
| `getLiveMatches` | `GET /matches?status=live` |
| `getMatch` | `GET /matches/{matchId}` |
| `getUpcomingFixtures` | `GET /fixtures` |
| `getRankings` | `GET /rankings?system=` |
| `getHeadToHead` | `GET /h2h` |

```java
LiveTennisTool tool = LiveTennisTool.builder()
        .apiKey(System.getenv("LIVE_TENNIS_API_KEY"))
        .build();
```

Every path and field name came from our published OpenAPI document at `https://docs.livetennisapi.com/openapi.yaml`. A free key needs no card, so the tools are testable without a subscription.

### Design notes

- There is no Java SDK for this API, so the client is `langchain4j-http-client` plus Jackson, following `langchain4j-community-tool-xquik` as the closest existing model. Java 17, no Lombok, and no new third-party dependency.
- Only `LiveTennisTool` is public. The client and its exception are package-private, so the module adds one class to the published API surface.
- The key is builder-injected, validated with `ensureNotBlank`, and sent as `X-API-Key`. The module contains no logger and never puts the key in a message. `HttpRequestLogger` already masks that header name if a user turns request logging on.
- Arguments the API would reject are validated locally, so a tool call does not spend a request to learn it was malformed. Errors reach the model as one short line with recovery guidance, and the upstream response body is never echoed back.
- Output is bounded and formatted for a model rather than passed through as raw JSON. The score formatter respects the API's player-major arrays and its documented nullable points and empty games arrays, which is the shape a non-nullable type would throw on.
- Endpoint access is plan-tiered. Live matches, match detail and fixtures are free; head-to-head and the ranking table are paid. A call above the key's plan returns a clear message naming the plan rather than an empty list.

### Registration

A `<module>` line in the root pom's tool-integrations block, and a `<dependency>` in the BOM under tools. Parent version `1.21.0-beta31-SNAPSHOT`, matching the root pom and the existing tool modules. I checked that specifically, because a stale parent resolves locally from the reactor and then fails a clean CI checkout, which is the bug you fixed by hand on another module recently.

## General checklist

- [x] There are no breaking changes
- [x] I have added unit and integration tests for my change
- [x] I have manually run all the unit tests in _all_ modules, and they are all green
- [ ] I have manually run all integration tests in the module I have added/changed, and they are all green
- [ ] I have added/updated the documentation
- [ ] I have added an example in the examples repo
- [ ] I have added/updated Spring Boot starter(s)

On the fourth box, plainly: **I cannot tick it.** The three integration tests are gated on an environment variable and skip without a key, and there is no key on the machine I built this on, so they have never executed. Every response shape in the unit tests is a fixture built from our own schema. Field names and nullability are verified against the specification, not against an observed response. If you would like them run for real, I can supply a key privately.

The last three boxes are the post-approval items your guide asks contributors to wait on.

## Test evidence

```
mvn -Pspotless validate      BUILD SUCCESS
mvn verify (this module)     Tests run: 28, Failures: 0, Errors: 0, Skipped: 0
                             LiveTennisToolIT: Skipped: 3 (no key)
                             revapi: API checks completed without failures
mvn test (all modules)       BUILD SUCCESS, 22:20 min, every module green
```

Verified on JDK 21 with the project's Maven wrapper. The JDK 17 and 25 matrix rows and the compliance job I have left to CI.

One small thing I noticed while following the guide: `CONTRIBUTING.md` asks contributors to run `make lint` and `make format`, but there is no `Makefile` in the repository. I used the underlying spotless goals instead.
