### PR TITLE
fix(dashscope): allow dimension for text-embedding-v1/v2

### DIFF
--- a/models/langchain4j-community-dashscope/src/main/java/dev/langchain4j/community/model/dashscope/QwenEmbeddingModel.java
+++ b/models/langchain4j-community-dashscope/src/main/java/dev/langchain4j/community/model/dashscope/QwenEmbeddingModel.java
@@ -2,8 +2,6 @@ package dev.langchain4j.community.model.dashscope;
 
 import static com.alibaba.dashscope.embeddings.TextEmbeddingParam.TextType.DOCUMENT;
 import static com.alibaba.dashscope.embeddings.TextEmbeddingParam.TextType.QUERY;
-import static dev.langchain4j.community.model.dashscope.QwenModelName.TEXT_EMBEDDING_V1;
-import static dev.langchain4j.community.model.dashscope.QwenModelName.TEXT_EMBEDDING_V2;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 import static dev.langchain4j.spi.ServiceHelper.loadFactories;
 import static java.util.Collections.singletonList;
@@ -52,7 +50,7 @@ public class QwenEmbeddingModel extends DimensionAwareEmbeddingModel {
         }
         this.modelName = Utils.isNullOrBlank(modelName) ? QwenModelName.TEXT_EMBEDDING_V3 : modelName;
         this.apiKey = apiKey;
-        this.dimension = ensureDimension(this.modelName, dimension);
+        this.dimension = dimension;
         this.embedding = Utils.isNullOrBlank(baseUrl) ? new TextEmbedding() : new TextEmbedding(baseUrl);
     }
 
@@ -162,16 +160,6 @@ public class QwenEmbeddingModel extends DimensionAwareEmbeddingModel {
     public void setTextEmbeddingParamCustomizer(
             Consumer<TextEmbeddingParam.TextEmbeddingParamBuilder<?, ?>> textEmbeddingParamCustomizer) {
         this.textEmbeddingParamCustomizer = ensureNotNull(textEmbeddingParamCustomizer, "textEmbeddingParamCustomizer");
-    }
-
-    private static Integer ensureDimension(String modelName, Integer dimension) {
-        if (dimension == null) {
-            return null;
-        }
-        if (TEXT_EMBEDDING_V1.equals(modelName) || TEXT_EMBEDDING_V2.equals(modelName)) {
-            throw new IllegalArgumentException("dimension '" + dimension + "' is not supported by " + modelName);
-        }
-        return dimension;
     }
 
     public static QwenEmbeddingModelBuilder builder() {

--- a/models/langchain4j-community-dashscope/src/test/java/dev/langchain4j/community/model/dashscope/QwenEmbeddingModelDimensionTest.java
+++ b/models/langchain4j-community-dashscope/src/test/java/dev/langchain4j/community/model/dashscope/QwenEmbeddingModelDimensionTest.java
@@ -5,16 +5,14 @@ import static dev.langchain4j.community.model.dashscope.QwenModelName.TEXT_EMBED
 import static dev.langchain4j.community.model.dashscope.QwenModelName.TEXT_EMBEDDING_V3;
 import static dev.langchain4j.community.model.dashscope.QwenModelName.TEXT_EMBEDDING_V4;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.stream.Stream;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Unit tests for QwenEmbeddingModel dimension validation.
- * These tests verify that ensureDimension correctly handles different model-dimension combinations.
+ * These tests verify that custom dimensions are accepted for all embedding model versions (API validates).
  */
 class QwenEmbeddingModelDimensionTest {
 
@@ -28,30 +26,24 @@ class QwenEmbeddingModelDimensionTest {
                 .build();
     }
 
-    // --- V1 and V2: always reject custom dimension ---
+    // --- V1 and V2: accept dimensions (API validates) ---
 
-    @Test
-    void should_reject_dimension_for_v1() {
-        assertThatThrownBy(() -> buildModel(TEXT_EMBEDDING_V1, 512))
-                .isExactlyInstanceOf(IllegalArgumentException.class);
+    static Stream<Integer> supportedDimensionsV1AndV2() {
+        return Stream.of(512, 768, 1024, 1536, 2048);
     }
 
-    @Test
-    void should_reject_dimension_for_v2() {
-        assertThatThrownBy(() -> buildModel(TEXT_EMBEDDING_V2, 512))
-                .isExactlyInstanceOf(IllegalArgumentException.class);
+    @ParameterizedTest
+    @MethodSource("supportedDimensionsV1AndV2")
+    void should_accept_dimension_for_v1(Integer dimension) {
+        QwenEmbeddingModel model = buildModel(TEXT_EMBEDDING_V1, dimension);
+        assertThat(model.dimension()).isEqualTo(dimension);
     }
 
-    @Test
-    void should_reject_2048_dimension_for_v1() {
-        assertThatThrownBy(() -> buildModel(TEXT_EMBEDDING_V1, 2048))
-                .isExactlyInstanceOf(IllegalArgumentException.class);
-    }
-
-    @Test
-    void should_reject_2048_dimension_for_v2() {
-        assertThatThrownBy(() -> buildModel(TEXT_EMBEDDING_V2, 2048))
-                .isExactlyInstanceOf(IllegalArgumentException.class);
+    @ParameterizedTest
+    @MethodSource("supportedDimensionsV1AndV2")
+    void should_accept_dimension_for_v2(Integer dimension) {
+        QwenEmbeddingModel model = buildModel(TEXT_EMBEDDING_V2, dimension);
+        assertThat(model.dimension()).isEqualTo(dimension);
     }
 
     // --- V3: accept all dimensions (API validates) ---

--- a/models/langchain4j-community-dashscope/src/test/java/dev/langchain4j/community/model/dashscope/QwenEmbeddingModelIT.java
+++ b/models/langchain4j-community-dashscope/src/test/java/dev/langchain4j/community/model/dashscope/QwenEmbeddingModelIT.java
@@ -10,8 +10,6 @@ import static dev.langchain4j.community.model.dashscope.QwenTestHelper.apiKey;
 import static dev.langchain4j.data.segment.TextSegment.textSegment;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 import dev.langchain4j.data.document.Metadata;
 import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.model.embedding.EmbeddingModel;
@@ -144,14 +142,13 @@ class QwenEmbeddingModelIT {
 
     @Test
     void should_embed_one_text_by_customized_dimension() {
-        assertThatThrownBy(() -> getModel(TEXT_EMBEDDING_V1, 512)).isExactlyInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> getModel(TEXT_EMBEDDING_V2, 512)).isExactlyInstanceOf(IllegalArgumentException.class);
+        for (String modelName : List.of(TEXT_EMBEDDING_V1, TEXT_EMBEDDING_V2, TEXT_EMBEDDING_V3)) {
+            QwenEmbeddingModel model = getModel(modelName, 512);
+            assertThat(model.dimension()).isEqualTo(512);
 
-        QwenEmbeddingModel model = getModel(TEXT_EMBEDDING_V3, 512);
-        assertThat(model.dimension()).isEqualTo(512);
-
-        Embedding embedding = model.embed("hello").content();
-        assertThat(embedding.dimension()).isEqualTo(512);
+            Embedding embedding = model.embed("hello").content();
+            assertThat(embedding.dimension()).isEqualTo(512);
+        }
     }
 
     @Test


### PR DESCRIPTION
## Issue
Fixes #731

## Change
PR #723 removed the hardcoded `SUPPORTED_DIMENSIONS` list and delegated invalid dimensions to the DashScope API, but `ensureDimension()` still rejected **any** custom `dimension` for `text-embedding-v1` and `text-embedding-v2`. That made those models unusable when a dimension was configured (e.g. Spring Boot properties), even though Alibaba Cloud supports the parameter.

This change removes the leftover v1/v2 client-side rejection and assigns `dimension` directly in the constructor, consistent with v3/v4 behavior after #723.

## General checklist
- [X] There are no breaking changes
- [X] I have added unit and integration tests for my change
- [ ] I have manually run all the unit tests in _all_ modules, and they are all green
- [ ] I have manually run all integration tests in the module I have added/changed, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

## Checklist for adding new maven module
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-community-bom/pom.xml`

## Checklist for adding new embedding store integration
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j

## Test plan
- [X] `./mvnw -pl models/langchain4j-community-dashscope -am test -Dtest=QwenEmbeddingModelDimensionTest` (Java 21)